### PR TITLE
Document note-tolerant roster punch parsing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,27 @@ Rules:
 - Never silently mutate the roster log.
 - Rejected updates stay as tracker-only context.
 
+## Note-Tolerant Roster Parsing
+
+Roster users may write human notes directly in punch cells when operational reality demands it. Scripts must treat this as valid input, not corruption.
+
+Examples of valid note-bearing punch values:
+
+```text
+9:28:00 AM / Client support
+9:28 AM - off-project coverage
+17:30 / inventory follow-up
+```
+
+Parsing requirements:
+
+- Extract the time portion for hour calculations.
+- Preserve the note portion for internal context and exception review.
+- Do not allow the note portion to break admin artifact generation.
+- If a note implies a project classification different from the resolved worked project, create an exception or proposed override.
+- Do not silently reclassify admin output from a raw note alone unless an approved override or resolved worked-project rule supports it.
+- Do not expose raw private notes in admin-facing outputs unless explicitly requested.
+
 ## Priority Order
 
 1. Roster Log to Admin Sheet

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent Instructions
+
+## Billing Pipeline Directional Contract
+
+This repository supports Web Excel-safe repair and triage workflows for roster, billing, admin-sheet, and task-tracker artifacts.
+
+Agents must identify the requested workflow direction before generating scripts, workbook patches, summaries, or corrections.
+
+## Supported Directions
+
+### 1. Roster Log to Admin Sheet
+
+High-priority submission workflow.
+
+Use the roster log to generate a clean admin-facing Project Team sheet for Friday billing/submission review. This is a one-shot output path.
+
+Rules:
+
+- Produce admin-facing output only.
+- Default workbook scope is Project Team tab only unless explicitly requested.
+- Use resolved worked-project logic, including assignments and overrides.
+- Do not expose internal exception machinery.
+- Do not expose confidence fields.
+- Do not expose private notes.
+- Do not leak task-tracker context into the admin artifact.
+
+### 2. Roster Log to Task Tracker
+
+Medium-priority contextualization workflow.
+
+Use the roster log to contextualize hours inside the task tracker. This path explains what the hours supported: configuration, deployment, logistics, project coordination, exceptions, and documented contributions.
+
+Rules:
+
+- Treat this as internal context, not submission output.
+- Map staff, date, hours, project assignment, and override logic into task context.
+- Preserve useful contribution evidence.
+- Do not reshape this into an admin-facing workbook unless explicitly requested.
+
+### 3. Task Tracker to Roster Log
+
+Low-priority reviewed backfill workflow.
+
+Use the task tracker to propose roster updates based on noted contributions. This direction must be review-gated.
+
+Rules:
+
+- Propose updates only unless direct roster mutation is explicitly approved.
+- Typical proposed updates include project overrides, assignment clarifications, and notes.
+- Never silently mutate the roster log.
+- Rejected updates stay as tracker-only context.
+
+## Priority Order
+
+1. Roster Log to Admin Sheet
+2. Roster Log to Task Tracker
+3. Task Tracker to Roster Log
+
+## Recommended Script Names
+
+```text
+roster_to_admin_submission.py
+roster_to_task_context.py
+task_tracker_to_roster_backfill.py
+```
+
+## Friday Reporting Rule
+
+Friday is the reporting batch marker. Work performed Monday through Friday maps to that Friday's reporting/submission batch. Weekend work generally rolls into the next Friday reporting batch unless explicitly handled otherwise.
+
+## Core Logic Rules
+
+- Overrides beat default assignment.
+- Resolved worked-project logic beats raw assumption.
+- Raw notes that conflict with resolved logic should create exceptions.
+- Admin-facing output stays narrow and clean.
+- Internal task-tracker context may be richer, but it must not leak into admin submission artifacts.
+- Backfill into the roster log must be proposed, reviewed, and approved before mutation.

--- a/docs/BILLING_PIPELINE_DIRECTIONAL_CONTRACT.md
+++ b/docs/BILLING_PIPELINE_DIRECTIONAL_CONTRACT.md
@@ -1,0 +1,174 @@
+# Billing Pipeline Directional Contract
+
+This document defines the supported billing and task-tracking workflow directions for Web Excel repair and triage work.
+
+The central rule: direction matters. A clean admin submission export is not the same thing as internal task contextualization, and neither is the same thing as a reviewed roster backfill.
+
+## Direction Map
+
+```mermaid
+flowchart TD
+    RL["Roster Log: hours, punches, assignments, overrides"]
+    AS["Admin Sheet: one-shot Project Team submission output"]
+    TT["Task Tracker: hours context, contribution notes, project evidence"]
+
+    RL --> AS
+    RL --> TT
+    TT --> RL
+```
+
+## Priority Order
+
+1. Roster Log to Admin Sheet
+2. Roster Log to Task Tracker
+3. Task Tracker to Roster Log
+
+Agents must identify the requested direction before generating scripts, workbook patches, summaries, or corrections.
+
+---
+
+## 1. Roster Log to Admin Sheet
+
+High-priority submission workflow.
+
+```mermaid
+flowchart TD
+    A["Roster Log"] --> B["Read live month tabs"]
+    B --> C["Read assignments and overrides"]
+    C --> D["Resolve worked project"]
+    D --> E["Filter to admin submission scope"]
+    E --> F["Populate Project Team tab only"]
+    F --> G["Generate admin-facing workbook"]
+    G --> H["Friday submission"]
+```
+
+### Purpose
+
+Create a clean admin-facing workbook for Friday billing or submission review.
+
+### Rules
+
+| Rule | Requirement |
+|---|---|
+| Output scope | Admin-facing only |
+| Default workbook scope | Project Team tab only unless explicitly requested |
+| Project classification | Use resolved worked-project logic, including assignments and overrides |
+| Internal notes | Do not expose |
+| Confidence fields | Do not expose |
+| Exception machinery | Keep internal unless it blocks submission |
+| Priority | High |
+
+### Contract
+
+Roster Log to Admin Sheet is a one-shot submission export. It should produce a clean admin-facing Project Team workbook from resolved roster data. It should not expose internal logic, review scaffolding, confidence notes, private notes, or task-tracker context.
+
+---
+
+## 2. Roster Log to Task Tracker
+
+Medium-priority contextualization workflow.
+
+```mermaid
+flowchart TD
+    A["Roster Log"] --> B["Read staff, date, and hour records"]
+    B --> C["Resolve project assignment and override"]
+    C --> D["Attach hours to task-tracker context"]
+    D --> E["Map hours to work categories"]
+    E --> F["Support narratives and weekly summaries"]
+    F --> G["Task Tracker"]
+```
+
+### Purpose
+
+Explain what the hours supported.
+
+The admin sheet says who worked, when, and how much. The task tracker adds what the labor supported: configuration, deployment, logistics, project coordination, exceptions, and documented contributions.
+
+### Rules
+
+| Rule | Requirement |
+|---|---|
+| Output scope | Internal context |
+| Goal | Explain hours through task and project activity |
+| Acceptable context | Project notes, contribution notes, deployment context, configuration work, logistics, exceptions |
+| Admin-ready by default | No |
+| Priority | Medium |
+
+### Contract
+
+Roster Log to Task Tracker is for contextualizing hours. It should help explain what work the hours supported, including project activity, configuration, deployment, logistics, exceptions, and contribution narratives. It is not the admin submission artifact.
+
+---
+
+## 3. Task Tracker to Roster Log
+
+Low-priority reviewed backfill workflow.
+
+```mermaid
+flowchart TD
+    A["Task Tracker"] --> B["Identify noted contribution"]
+    B --> C["Extract staff, date, project, and work context"]
+    C --> D{"Does roster already reflect it?"}
+    D -- "Yes" --> E["No action"]
+    D -- "No" --> F["Create proposed roster update"]
+    F --> G["Review queue"]
+    G --> H{"Approved?"}
+    H -- "No" --> I["Keep as tracker-only note"]
+    H -- "Yes" --> J["Update roster override, note, or assignment"]
+```
+
+### Purpose
+
+Propose roster updates based on noted contributions.
+
+This is a backfill workflow, not the normal direction. The task tracker can suggest that the roster needs an update, but it must not silently rewrite the roster.
+
+### Rules
+
+| Rule | Requirement |
+|---|---|
+| Output scope | Proposed roster corrections |
+| Automation level | Review-gated |
+| Direct write allowed | No, unless explicitly approved |
+| Typical updates | Override, project note, assignment clarification |
+| Priority | Low |
+
+### Contract
+
+Task Tracker to Roster Log is a low-priority backfill path. It should only propose roster updates based on noted contributions. It must not silently mutate the roster log. All updates should pass through a review queue before becoming roster data.
+
+---
+
+## Agent Decision Rule
+
+```mermaid
+flowchart TD
+    A["Agent receives billing or task-tracking request"] --> B{"Which direction is requested?"}
+    B --> C["Roster Log to Admin Sheet"]
+    B --> D["Roster Log to Task Tracker"]
+    B --> E["Task Tracker to Roster Log"]
+    C --> F["Generate clean submission artifact"]
+    D --> G["Generate internal context and contribution mapping"]
+    E --> H["Generate proposed roster updates only"]
+```
+
+## Recommended Script Names
+
+```text
+roster_to_admin_submission.py
+roster_to_task_context.py
+task_tracker_to_roster_backfill.py
+```
+
+## Friday Reporting Rule
+
+Friday is the reporting batch marker. Work performed Monday through Friday maps to that Friday's reporting or submission batch. Weekend work generally rolls into the next Friday reporting batch unless explicitly handled otherwise.
+
+## Implementation Notes
+
+- Overrides beat default assignment.
+- Resolved worked-project logic beats raw assumption.
+- Raw notes that conflict with resolved logic should create exceptions.
+- Admin-facing output should remain clean and narrow.
+- Internal task-tracker context can be richer, but it must not leak into admin submission artifacts.
+- Backfill from Task Tracker into Roster Log must be proposed, reviewed, and approved before mutation.

--- a/docs/BILLING_PIPELINE_DIRECTIONAL_CONTRACT.md
+++ b/docs/BILLING_PIPELINE_DIRECTIONAL_CONTRACT.md
@@ -27,6 +27,37 @@ Agents must identify the requested direction before generating scripts, workbook
 
 ---
 
+## Note-Tolerant Roster Parsing
+
+Roster users may write human notes directly in punch cells when operational reality demands it. Scripts must treat this as valid input, not corruption.
+
+Examples of valid note-bearing punch values:
+
+```text
+9:28:00 AM / Client support
+9:28 AM - off-project coverage
+17:30 / inventory follow-up
+```
+
+### Required Behavior
+
+| Input Piece | Required Script Behavior |
+|---|---|
+| Time portion | Extract for hour calculation |
+| Note portion | Preserve for internal context and exception review |
+| Project signal in note | Compare against resolved worked-project logic |
+| Conflict between note and resolved project | Create exception or proposed override |
+| Admin-facing output | Do not expose private raw notes unless explicitly requested |
+| Artifact generation | Must not fail because a punch cell contains a note |
+
+### Classification Rule
+
+Raw notes are evidence, not final authority.
+
+If a note implies a project classification different from the resolved worked project, the script should create an exception or proposed override. It should not silently reclassify admin output from a raw note alone unless an approved override or resolved worked-project rule supports it.
+
+---
+
 ## 1. Roster Log to Admin Sheet
 
 High-priority submission workflow.
@@ -34,12 +65,13 @@ High-priority submission workflow.
 ```mermaid
 flowchart TD
     A["Roster Log"] --> B["Read live month tabs"]
-    B --> C["Read assignments and overrides"]
-    C --> D["Resolve worked project"]
-    D --> E["Filter to admin submission scope"]
-    E --> F["Populate Project Team tab only"]
-    F --> G["Generate admin-facing workbook"]
-    G --> H["Friday submission"]
+    B --> C["Parse punch times and preserve punch notes"]
+    C --> D["Read assignments and overrides"]
+    D --> E["Resolve worked project"]
+    E --> F["Filter to admin submission scope"]
+    F --> G["Populate Project Team tab only"]
+    G --> H["Generate admin-facing workbook"]
+    H --> I["Friday submission"]
 ```
 
 ### Purpose
@@ -71,11 +103,12 @@ Medium-priority contextualization workflow.
 ```mermaid
 flowchart TD
     A["Roster Log"] --> B["Read staff, date, and hour records"]
-    B --> C["Resolve project assignment and override"]
-    C --> D["Attach hours to task-tracker context"]
-    D --> E["Map hours to work categories"]
-    E --> F["Support narratives and weekly summaries"]
-    F --> G["Task Tracker"]
+    B --> C["Parse punch notes and operational context"]
+    C --> D["Resolve project assignment and override"]
+    D --> E["Attach hours to task-tracker context"]
+    E --> F["Map hours to work categories"]
+    F --> G["Support narratives and weekly summaries"]
+    G --> H["Task Tracker"]
 ```
 
 ### Purpose
@@ -172,3 +205,4 @@ Friday is the reporting batch marker. Work performed Monday through Friday maps 
 - Admin-facing output should remain clean and narrow.
 - Internal task-tracker context can be richer, but it must not leak into admin submission artifacts.
 - Backfill from Task Tracker into Roster Log must be proposed, reviewed, and approved before mutation.
+- Note-bearing punch cells are valid input and must not break artifact generation.

--- a/docs/NOTE_TOLERANT_ROSTER_PARSING_SPEC.md
+++ b/docs/NOTE_TOLERANT_ROSTER_PARSING_SPEC.md
@@ -1,0 +1,161 @@
+# Note-Tolerant Roster Parsing Spec
+
+This spec defines how scripts should parse roster punch cells that contain both time data and human notes.
+
+Users should be able to record operational notes where they work. Code should separate the time signal from the context signal without breaking artifact generation.
+
+## Accepted Input Pattern
+
+A punch cell may contain:
+
+1. a time value
+2. optional separator text
+3. optional human note
+
+Examples:
+
+```text
+9:28:00 AM / Client support
+9:28 AM - off-project coverage
+17:30 / inventory follow-up
+6:00 PM
+```
+
+## Required Output Fields
+
+A parser should return a structured result similar to this:
+
+```json
+{
+  "raw_value": "9:28:00 AM / Client support",
+  "parsed_time": "09:28:00",
+  "note": "Client support",
+  "has_note": true,
+  "parse_status": "parsed_with_note"
+}
+```
+
+## Parse Status Values
+
+| Status | Meaning |
+|---|---|
+| `parsed_time_only` | Cell contains a usable time and no note |
+| `parsed_with_note` | Cell contains a usable time and a preserved note |
+| `blank` | Cell is blank |
+| `note_only` | Cell has note text but no usable time |
+| `invalid_time` | Cell appears intended as a punch but the time cannot be parsed |
+
+## Separators
+
+Scripts should tolerate common separators between a time and a note:
+
+```text
+/
+-
+–
+—
+|
+;
+```
+
+Do not require users to use one perfect delimiter.
+
+## Classification Rules
+
+A note may contain useful project signals, but raw notes are evidence, not final authority.
+
+Rules:
+
+1. Use the time portion for hour calculations.
+2. Preserve the note portion for internal context.
+3. Compare note-derived project signals against resolved worked-project logic.
+4. If the note conflicts with the resolved project, create an exception or proposed override.
+5. Do not silently reclassify admin output from a raw note alone.
+6. Do not expose raw private notes in admin-facing outputs unless explicitly requested.
+
+## Admin Artifact Behavior
+
+Admin generation must continue when a punch cell contains a note.
+
+Valid behavior:
+
+- parse the time
+- calculate hours
+- classify using resolved rules and approved overrides
+- keep raw note out of admin-facing output
+- log an internal exception if needed
+
+Invalid behavior:
+
+- crash on note-bearing cells
+- treat the entire cell as invalid because it includes a note
+- copy private note text into admin output by default
+- change project classification from note text without review
+
+## Internal Context Behavior
+
+Internal reports may preserve note text when useful.
+
+Examples:
+
+- exception report
+- proposed override report
+- task-tracker contextualization
+- weekly review notes
+
+These outputs should clearly label notes as source context, not approved classification.
+
+## Pseudocode
+
+```python
+def parse_punch_cell(raw_value: object) -> dict:
+    if raw_value is None or str(raw_value).strip() == "":
+        return {"raw_value": raw_value, "parsed_time": None, "note": None, "has_note": False, "parse_status": "blank"}
+
+    text = str(raw_value).strip()
+    time_match = find_first_time_like_token(text)
+
+    if not time_match:
+        return {"raw_value": raw_value, "parsed_time": None, "note": text, "has_note": True, "parse_status": "note_only"}
+
+    parsed_time = normalize_time(time_match.group(0))
+    note = remove_time_and_leading_separator(text, time_match).strip()
+
+    return {
+        "raw_value": raw_value,
+        "parsed_time": parsed_time,
+        "note": note or None,
+        "has_note": bool(note),
+        "parse_status": "parsed_with_note" if note else "parsed_time_only",
+    }
+```
+
+## Test Cases
+
+| Raw value | Parsed time | Note | Status |
+|---|---|---|---|
+| `9:28:00 AM / Client support` | `09:28:00` | `Client support` | `parsed_with_note` |
+| `9:28 AM - off-project coverage` | `09:28:00` | `off-project coverage` | `parsed_with_note` |
+| `17:30 / inventory follow-up` | `17:30:00` | `inventory follow-up` | `parsed_with_note` |
+| `6:00 PM` | `18:00:00` | null | `parsed_time_only` |
+| blank | null | null | `blank` |
+| `Client support only` | null | `Client support only` | `note_only` |
+
+## Implementation Standard
+
+Parser utilities should be deterministic and side-effect free.
+
+They should not:
+
+- modify workbooks directly
+- decide final project classification alone
+- write admin output directly
+
+They should:
+
+- parse raw cells
+- return structured data
+- preserve notes safely
+- feed downstream resolver and exception logic
+
+Tiny parser. Big discipline.


### PR DESCRIPTION
## Summary

Documents that roster punch cells may contain both time values and human notes, and that scripts must handle those inputs without breaking artifact generation.

## Why this matters

Users need to write operational notes where reality happens: directly in the roster. The parser should separate time, notes, and project signals logically instead of treating note-bearing punch cells as corrupt data.

## Behavior documented

- Extract the time portion for hour calculations.
- Preserve the note portion for internal context and exception review.
- Compare project signals in notes against resolved worked-project logic.
- Create exceptions or proposed overrides when notes conflict with resolved classification.
- Do not expose raw private notes in admin-facing output unless explicitly requested.
- Do not silently reclassify admin output from raw notes alone without an approved override or resolved rule.

## Relationship to PR #9

PR #9 has been merged into main. This PR has been retargeted to main so the next feature can land cleanly after note-tolerant roster parsing is accepted.
