### PR TITLE
feat: NW PRJ dashboard v6 Web Excel contract and automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ conditional formatting, or shared-string references.
 - **MCP-first** — every triage phase is also an MCP tool, so Augment Code can
   orchestrate the full pipeline from a chat prompt.
 
+### NW PRJ dashboard v6 (Tech Roster)
+
+Contract, configs, generator, and validators for the NW PRJ Tech Roster Dashboard workflow:
+
+- Docs: `docs/NW_PRJ_DASHBOARD_V6_CONTRACT.md`
+- Configs: `configs/nw_prj_dashboard_v6_schema.json`
+- Validate: `python -m triage.nw_prj_dashboard_validator <workbook.xlsx>` (via API: `validate_nw_prj_dashboard`)
+- Generate: `python -m triage.nw_prj_dashboard_generator --admin-scratch <scratch.xlsx> [--dashboard ...] [--roster ...]`
+- Compare: `python -m triage.nw_prj_artifact_compare --admin-scratch <scratch.xlsx> [--dashboard ...]`
+
 ### Lifecycle folder rules (quick reference)
 
 This repo uses lifecycle folders so the engine can keep artifacts organized:

--- a/configs/cf_palette_v1.json
+++ b/configs/cf_palette_v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "cf_palette_v1",
+  "fills": {
+    "resolved_green": "FF92D050",
+    "skipped_gray": "FFBFBFBF",
+    "blocker_red": "FFFF6666",
+    "review_amber": "FFFFC000",
+    "rich_guard_purple": "FFB4A7D6",
+    "roster_blue": "FF9DC3E6",
+    "quiet_muted": "FFE7E6E6"
+  },
+  "tab_colors": {
+    "Start Here": "FF4472C4",
+    "Dashboard_Tool_v6_x": "FF70AD47",
+    "Active_Admin_Targets": "FFFF0000",
+    "Partial_Hours_Active": "FFFFC000",
+    "Review_Guardrails": "FF7030A0",
+    "Quiet_Queues": "FFD9D9D9",
+    "Resolved_Archive": "FF7F7F7F",
+    "Tech_Summary": "FF00B0F0",
+    "CF_Dictionary": "FF00B0F0",
+    "Definitions_Current": "FF00B0F0",
+    "Visual_System_v6_x": "FF00B0F0",
+    "Dropdown_Values": "FF00B0F0",
+    "Repo_Automation_Notes": "FF595959"
+  },
+  "tab_roles": {
+    "Start Here": "operator_entry",
+    "Dashboard_Tool_v6_x": "dashboard_hub",
+    "Active_Admin_Targets": "active_queue",
+    "Partial_Hours_Active": "review_queue",
+    "Review_Guardrails": "guardrail",
+    "Quiet_Queues": "quiet",
+    "Resolved_Archive": "archive",
+    "CF_Dictionary": "reference",
+    "Definitions_Current": "reference",
+    "Dropdown_Values": "reference",
+    "Repo_Automation_Notes": "automation"
+  },
+  "cf_priority_order": [
+    "column_a_resolved_green",
+    "column_a_skipped_gray",
+    "submission_blocker_red",
+    "partial_review_amber",
+    "rich_guard_purple",
+    "roster_later_blue",
+    "quiet_archive_muted"
+  ]
+}

--- a/configs/nw_prj_dashboard_v6_schema.json
+++ b/configs/nw_prj_dashboard_v6_schema.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "nw_prj_dashboard_v6",
+  "status": "active",
+  "output_name_pattern": "NW_PRJ_Tech_Roster_Dashboard_v6_{minor}_{descriptor}_WEBSAFE.xlsx",
+  "required_sheets": [
+    "Start Here",
+    "Dashboard_Tool_v6",
+    "Active_Admin_Targets",
+    "Partial_Hours_Active",
+    "Review_Guardrails",
+    "Quiet_Queues",
+    "Resolved_Archive",
+    "Tech_Summary",
+    "CF_Dictionary",
+    "Definitions_Current",
+    "Visual_System_v6",
+    "Dropdown_Values",
+    "Repo_Automation_Notes"
+  ],
+  "sheet_name_aliases": {
+    "Dashboard_Tool_v6": "Dashboard_Tool_v6_x",
+    "Visual_System_v6": "Visual_System_v6_x"
+  },
+  "required_active_columns": [
+    "Review Status",
+    "Work Queue Status",
+    "Target Type",
+    "Action Needed",
+    "Target Workbook",
+    "Edit Sheet",
+    "Edit Row",
+    "Edit In Cell",
+    "Proposed In",
+    "Edit Out Cell",
+    "Proposed Out",
+    "Total Cell",
+    "Expected Total",
+    "Tech",
+    "Date",
+    "Team Scope",
+    "Current Admin Value",
+    "Roster Latest In",
+    "Roster Latest Out",
+    "Roster Latest Hours",
+    "Roster Check",
+    "Roster Check Notes",
+    "Reason Code",
+    "Confidence",
+    "Submission Blocker",
+    "Manual Note / Resolution Note"
+  ],
+  "review_status_column": "Review Status",
+  "active_queue_sheets": [
+    "Active_Admin_Targets",
+    "Partial_Hours_Active",
+    "Review_Guardrails"
+  ],
+  "archive_sheet": "Resolved_Archive",
+  "cf_dictionary_sheet": "CF_Dictionary",
+  "input_hierarchy": [
+    "manual_admin_scratch",
+    "official_admin_workbook",
+    "roster_log",
+    "prior_dashboard"
+  ],
+  "layout_fingerprint_headers": [
+    "Review Status",
+    "Tech",
+    "Date"
+  ]
+}

--- a/configs/status_values_v1.json
+++ b/configs/status_values_v1.json
@@ -1,0 +1,27 @@
+{
+  "schema_version": "status_values_v1",
+  "review_status": {
+    "resolved_green": [
+      "Done",
+      "Confirmed Valid",
+      "Addressed",
+      "Resolved"
+    ],
+    "skipped_gray": [
+      "Skipped/Gray",
+      "Gray/Skip"
+    ],
+    "active_review": [
+      "Needs Review",
+      "Open",
+      ""
+    ]
+  },
+  "work_queue_status": {
+    "blocker": ["BLOCKER", "RED"],
+    "amber": ["AMBER", "PARTIAL"],
+    "purple": ["RICH_GUARD", "PURPLE"],
+    "blue": ["ROSTER", "BLUE"]
+  },
+  "column_a_wins_before_queue_cf": true
+}

--- a/configs/team_scope_values_v1.json
+++ b/configs/team_scope_values_v1.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": "team_scope_values_v1",
+  "allowed_values": [
+    "Cybernet/Neuron Active",
+    "Tracked Only",
+    "Out of Scope"
+  ],
+  "defaults_by_signal": {
+    "cybernet_neuron_assignment": "Cybernet/Neuron Active",
+    "projects_team_noise": "Out of Scope",
+    "watch_only": "Tracked Only"
+  },
+  "project_team_tab_is_authority": false
+}

--- a/configs/web_excel_stop_ship_tokens.json
+++ b/configs/web_excel_stop_ship_tokens.json
@@ -1,0 +1,23 @@
+{
+  "schema_version": "web_excel_stop_ship_tokens_v1",
+  "xml_tokens": [
+    "_xlfn.",
+    "_xludf.",
+    "_xlpm.",
+    "AGGREGATE("
+  ],
+  "error_literals": [
+    "#REF!",
+    "#VALUE!",
+    "#NAME?"
+  ],
+  "filename_markers": [
+    "repaired_",
+    "Deprecated_repaired_",
+    "web_repaired_"
+  ],
+  "cf_forbidden_patterns": [
+    "RC\\d",
+    "SEARCH\\(\"AMBER\""
+  ]
+}

--- a/docs/ARTIFACT_GENERATION_LEDGER.md
+++ b/docs/ARTIFACT_GENERATION_LEDGER.md
@@ -1,0 +1,37 @@
+# Artifact Generation Ledger — NW PRJ Dashboard
+
+Durable memory of generated workbooks and lessons. Append one row per generation run.
+
+## Ledger format
+
+| Date | Version | Descriptor | Inputs | Output | Gate result | Lessons |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-XX | v6.5 | ROSTER_CONFIRMED_REDUCED_NOISE | dashboard, roster, admin scratch | `..._WEBSAFE.xlsx` | pass | Reduced active queue; Column A override fixed yellow-done |
+| 2026-05-XX | v6.6 | FULL_ARTIFACT_COMPARISON | + optional official admin | `..._WEBSAFE.xlsx` | pass | Three-way compare; archive demotion |
+
+## Template row (copy for next run)
+
+```text
+Date:
+Generator commit:
+Descriptor:
+Dashboard input:
+Roster input:
+Admin scratch input:
+Official admin (optional):
+Output path:
+web_excel_safe:
+Failures:
+Lessons:
+```
+
+## Automation hook
+
+`nw_prj_dashboard_generator.py` appends a JSON line to `Outputs/nw_prj_generation_ledger.jsonl` when `--ledger` is passed (gitignored under `Outputs/**` except curated JSON).
+
+## Reference artifacts (local only, not in repo)
+
+- v6.5: `NW_PRJ_Tech_Roster_Dashboard_v6_5_ROSTER_CONFIRMED_REDUCED_NOISE_WEBSAFE.xlsx`
+- v6.6: `NW_PRJ_Tech_Roster_Dashboard_v6_6_FULL_ARTIFACT_COMPARISON_WEBSAFE.xlsx`
+
+Store golden copies outside git; reference paths in ledger rows above.

--- a/docs/CF_DICTIONARY_AND_VISUAL_SYSTEM.md
+++ b/docs/CF_DICTIONARY_AND_VISUAL_SYSTEM.md
@@ -1,0 +1,59 @@
+# CF Dictionary and Visual System — NW PRJ Dashboard v6
+
+## CF_Dictionary requirement
+
+Every generated dashboard MUST include a `CF_Dictionary` sheet. Validators fail workbooks missing this sheet.
+
+Each row documents one conditional-format rule:
+
+| Column | Meaning |
+| --- | --- |
+| Rule ID | Stable identifier (e.g. `CF_A_DONE`) |
+| Priority | Integer; lower runs first |
+| Applies To | Sheet and column range |
+| Condition (plain English) | Team-readable trigger |
+| Formula (audit) | Stored formula for diff/review |
+| Fill / Font | Visual outcome |
+| Overrides | What this rule must beat or yield to |
+
+## Column A override (non-negotiable)
+
+Rules that color by `Work Queue Status` or roster strings MUST NOT run before Column A review rules. Done rows that stay yellow because an AMBER queue rule fired first are a **contract violation**.
+
+## Tab color taxonomy
+
+Configured in `configs/cf_palette_v1.json`. Roles:
+
+| Tab role | Color intent | Example sheets |
+| --- | --- | --- |
+| `operator_entry` | Blue — start here | `Start Here` |
+| `dashboard_hub` | Green — primary tool | `Dashboard_Tool_v6_x` |
+| `active_queue` | Red/orange — needs action | `Active_Admin_Targets` |
+| `review_queue` | Amber — partial/review | `Partial_Hours_Active` |
+| `guardrail` | Purple — policy / Rich Guard | `Review_Guardrails` |
+| `quiet` | Light gray — watch only | `Quiet_Queues` |
+| `archive` | Dark gray — resolved/dismissed | `Resolved_Archive` |
+| `reference` | Teal — lookup | `CF_Dictionary`, `Definitions_Current`, `Dropdown_Values` |
+| `automation` | Slate — repo notes | `Repo_Automation_Notes` |
+
+## Fill palette (active rows)
+
+| Semantic | ARGB (Excel) | Use |
+| --- | --- | --- |
+| `resolved_green` | `FF92D050` | Column A done family |
+| `skipped_gray` | `FFBFBFBF` | Column A skipped/gray |
+| `blocker_red` | `FFFF6666` | Submission blocker |
+| `review_amber` | `FFFFC000` | Partial / needs review |
+| `rich_guard_purple` | `FFB4A7D6` | Rich Guard |
+| `roster_blue` | `FF9DC3E6` | Roster-later |
+| `quiet_muted` | `FFE7E6E6` | Archive / quiet |
+
+## Visual_System sheet
+
+The `Visual_System_v6_x` sheet mirrors this document for operators. Generator copies tab colors from `cf_palette_v1.json` at build time.
+
+## Anti-patterns
+
+- R1C1 references (`RC1`, `RC2`) in CF formulas
+- `SEARCH("AMBER", …)` on queue status instead of Column A
+- Missing `CF_Dictionary` while CF rules exist on data sheets

--- a/docs/NW_PRJ_DASHBOARD_V6_CONTRACT.md
+++ b/docs/NW_PRJ_DASHBOARD_V6_CONTRACT.md
@@ -1,0 +1,140 @@
+# NW PRJ Tech Roster Dashboard v6 — Web Excel Contract
+
+## Purpose
+
+Formalize the proven v6.5 / v6.6 dashboard workflow so generation is repeatable, auditable, and safe for Excel for Web. This contract supersedes tribal spreadsheet fixes.
+
+## Carryover thesis
+
+```text
+Generate fewer flags, not more.
+Respect manual resolution.
+Treat gray as quiet.
+Make Column A control visual state.
+Target the manual admin scratch copy first.
+Never trust Excel Web compatibility until the package passes structural checks.
+Never let weak roster evidence downgrade confirmed admin hours.
+```
+
+## Input hierarchy (authority order)
+
+1. **Manual admin scratch / control copy** — checkpoint surface; hours and edits here win for admin truth until leadership promotes official admin.
+2. **Official admin workbook** — leadership-facing hours/control artifact; not project-assignment authority.
+3. **Latest roster log** — punch timing and hours evidence.
+4. **Prior dashboard workbook** — manual review status, notes, and resolved rows.
+
+The generator MUST accept, at minimum:
+
+- Latest dashboard workbook
+- Latest roster log
+- Latest manual admin scratch/control copy
+- Optional official admin workbook
+
+## Output naming
+
+```text
+NW_PRJ_Tech_Roster_Dashboard_v6_x_<descriptor>_WEBSAFE.xlsx
+```
+
+If Excel for Web repairs the file or the filename contains `repaired_` / `Deprecated_repaired_`, the artifact is **failed**. Do not bless it or continue without labeling the source as repaired.
+
+## Required sheet structure
+
+| Sheet | Role |
+| --- | --- |
+| `Start Here` | Operator instructions |
+| `Dashboard_Tool_v6_x` | Summary and controls |
+| `Active_Admin_Targets` | Actionable admin edit queue |
+| `Partial_Hours_Active` | Partial-hour review (amber) |
+| `Review_Guardrails` | Rich Guard and policy rows |
+| `Quiet_Queues` | Low-noise watch list |
+| `Resolved_Archive` | Done / skipped / gray demoted rows |
+| `Tech_Summary` | Per-tech rollup |
+| `CF_Dictionary` | Human-readable CF rule catalog (**required**) |
+| `Definitions_Current` | Field definitions |
+| `Visual_System_v6_x` | Palette and tab-color matrix |
+| `Dropdown_Values` | Validated lists |
+| `Repo_Automation_Notes` | Generator version and inputs used |
+
+## Required active row fields
+
+Every actionable row MUST include:
+
+`Review Status`, `Work Queue Status`, `Target Type`, `Action Needed`, `Target Workbook`, `Edit Sheet`, `Edit Row`, `Edit In Cell`, `Proposed In`, `Edit Out Cell`, `Proposed Out`, `Total Cell`, `Expected Total`, `Tech`, `Date`, `Team Scope`, `Current Admin Value`, `Roster Latest In`, `Roster Latest Out`, `Roster Latest Hours`, `Roster Check`, `Roster Check Notes`, `Reason Code`, `Confidence`, `Submission Blocker`, `Manual Note / Resolution Note`
+
+## Column A override doctrine
+
+**Column A (`Review Status`) wins before all other conditional formatting.**
+
+| Review Status | Visual |
+| --- | --- |
+| `Done`, `Confirmed Valid`, `Addressed`, `Resolved` | Green |
+| `Skipped/Gray`, `Gray/Skip` | Gray |
+| Unresolved | May inherit queue colors (red, amber, purple, blue) |
+
+Forbidden CF patterns:
+
+- `=ISNUMBER(SEARCH("AMBER",RC2))` — queue string sniffing
+- `=RC1="Done"` — R1C1 leakage; not team-readable
+
+## CF priority order
+
+1. Column A done/resolved → green
+2. Column A skipped/gray → gray
+3. Submission blocker / admin edit → red
+4. Partial / review → amber
+5. Rich Guard → purple
+6. Roster-later → blue
+7. Quiet / archive → muted gray/green
+
+## Team scope
+
+`Team Scope` MUST be one of:
+
+- `Cybernet/Neuron Active`
+- `Tracked Only`
+- `Out of Scope`
+
+Admin `Project Team` tab is **not** project-assignment authority. Expectations come from roster defaults, assignments, worked-project tabs, explicit notes, and approved overrides.
+
+## Gray archive doctrine
+
+Gray means dismissed / false flag / not applicable / skip — **not** unresolved. Gray rows MUST be demoted to `Resolved_Archive` by default. They may return to active queues only when new roster or admin scratch evidence proves a real submission issue.
+
+## Rich Guard
+
+```text
+Preserve admin full/long-day hours unless explicit short-day evidence exists.
+```
+
+Weak roster evidence may trigger review; it MUST NOT downgrade admin full/long-day hours in the scratch copy. Afternoon clock-outs are suspect unless an exception documents a short day.
+
+## Partial hours
+
+Roster/admin hours greater than 0 and less than 8 require review before leadership submission. Valid outcomes: `Confirmed Valid`, `Addressed`, `Needs Review`, `Skipped/Gray`. Partials are amber review, not automatic red errors.
+
+## Formula edit doctrine
+
+Techs MUST:
+
+- Edit **In** and **Out** cells only
+- **Not** overwrite **Total** cell formulas
+- Check **Expected Total**
+
+The generator separates: `Edit In Cell`, `Proposed In`, `Edit Out Cell`, `Proposed Out`, `Total Cell`, `Expected Total`.
+
+## Manual status carry-forward
+
+Manual status and notes are **evidence**. They MUST be carried forward from the prior dashboard unless newer contradictory roster or admin scratch evidence exists.
+
+## Layout fingerprint
+
+Cell targets MUST be resolved from header / date / tech mapping, not hardcoded forever. If the layout fingerprint changes, generation MUST fail with a clear warning.
+
+## Related documents
+
+- [CF_DICTIONARY_AND_VISUAL_SYSTEM.md](CF_DICTIONARY_AND_VISUAL_SYSTEM.md)
+- [WEB_EXCEL_COMPATIBILITY_STOP_SHIP_RULES.md](WEB_EXCEL_COMPATIBILITY_STOP_SHIP_RULES.md)
+- [NW_PRJ_RECONCILIATION_INSIGHTS.md](NW_PRJ_RECONCILIATION_INSIGHTS.md)
+- [ARTIFACT_GENERATION_LEDGER.md](ARTIFACT_GENERATION_LEDGER.md)
+- [billing_bridge/WEB_EXCEL_VALIDATION.md](billing_bridge/WEB_EXCEL_VALIDATION.md)

--- a/docs/NW_PRJ_RECONCILIATION_INSIGHTS.md
+++ b/docs/NW_PRJ_RECONCILIATION_INSIGHTS.md
@@ -1,0 +1,55 @@
+# NW PRJ Reconciliation Insights
+
+Lessons from v6.5 (roster-confirmed, reduced noise) and v6.6 (full artifact comparison) dashboard generations.
+
+## Three-way comparison
+
+The comparison engine reconciles:
+
+1. Latest dashboard (manual review truth)
+2. Latest roster log (punch evidence)
+3. Latest manual admin scratch copy (admin hours truth)
+
+Optional: official admin workbook for leadership-facing cross-check only.
+
+## Wrong authority (corrected)
+
+The false-positive engine once treated the admin workbook `Project Team` tab as project assignment authority. **It is not.** Use roster defaults, worked-project tabs, notes, and `Team Scope` instead.
+
+## Admin scratch targeting
+
+Tell operators to update the **manual admin scratch** copy first. Do not redirect them to the official admin workbook while scratch is still the checkpoint.
+
+## Queue reduction
+
+Resolved, skipped, and gray rows MUST demote to `Resolved_Archive` so active tabs show fewer flags. v6.5 proved noise reduction is a feature, not a loss of coverage.
+
+## Rich Guard compression
+
+When roster is incomplete but admin scratch shows a full/long day, emit a purple guardrail row for review — do **not** propose lower hours. Wording:
+
+```text
+Preserve admin full/long-day hours unless explicit short-day evidence exists.
+```
+
+## Partial-hour compression
+
+Collapse duplicate partial flags per tech/date. Classify as amber `Needs Review` unless Column A already resolved.
+
+## Lingering flags
+
+After comparison, emit a summary of:
+
+- Rows still active after manual done (carry-forward bug)
+- Gray rows resurrected in active queues (archive bug)
+- Roster/admin hour mismatches with no Column A resolution
+- Repaired-filename inputs used in the run (STOP-SHIP)
+
+## Note-bearing punch cells
+
+Punch cells may contain notes; parse with note-tolerant roster doctrine. Preserve note text in `Roster Check Notes`; extract clean times for `Roster Latest In` / `Out`.
+
+## Comparator module
+
+Implementation: `triage/nw_prj_artifact_compare.py`  
+CLI entry: `python -m triage.nw_prj_artifact_compare`

--- a/docs/WEB_EXCEL_COMPATIBILITY_STOP_SHIP_RULES.md
+++ b/docs/WEB_EXCEL_COMPATIBILITY_STOP_SHIP_RULES.md
@@ -1,0 +1,60 @@
+# Web Excel Compatibility — STOP-SHIP Rules (NW PRJ Dashboard)
+
+## Failed artifact rule
+
+```text
+If Excel for Web repairs the workbook, the artifact is failed.
+Do not bless it.
+Do not continue from it without labeling it as a repaired source.
+Rebuild clean if possible.
+```
+
+## Filename STOP-SHIP
+
+Reject outputs or inputs when the basename contains:
+
+- `repaired_`
+- `Deprecated_repaired_`
+- `web_repaired_` (legacy local pattern)
+
+## Package STOP-SHIP tokens
+
+Scan all XML parts (see `configs/web_excel_stop_ship_tokens.json`):
+
+| Token / pattern | Why |
+| --- | --- |
+| `_xlfn.` | Unsupported function namespace |
+| `_xludf.` | User-defined function leakage |
+| `_xlpm.` | Lambda / PM namespace |
+| `AGGREGATE(` | Known Web hazard |
+| `#REF!` | Broken references (especially CF) |
+| `#VALUE!` | Eval errors in stored XML |
+| `#NAME?` | Unknown names |
+
+## Structural STOP-SHIP
+
+| Check | Failure |
+| --- | --- |
+| XML parse | Any `.xml` part fails `ElementTree` parse |
+| Relationship targets | `.rels` Target does not resolve in package |
+| Duplicate table names | Two `table` parts share `displayName` or `name` |
+| R1C1 CF leakage | `RC\d` in `<f>` inside conditional formatting |
+| Missing `CF_Dictionary` | NW PRJ dashboard profile detected, sheet absent |
+| Column A override | Done row still matches queue-amber CF only |
+
+## Excel Web repair symptoms
+
+- File opens as repaired
+- Filename becomes `Deprecated_repaired_...`
+- Excel Web refuses to repair
+- Tables disappear
+- CF behaves but workbook structure is poisoned
+
+**Likely causes:** duplicate tables, broken worksheet relationships, table relationship mismatch, inherited cruft, unsupported formulas/names, bad CF references.
+
+## Integration
+
+- Core battery: `triage/gate_checks.py`
+- NW PRJ profile: `triage/nw_prj_dashboard_validator.py`
+- Billing wrapper pattern: `triage/billing_bridge_validator.py`
+- Contract doc: `docs/billing_bridge/WEB_EXCEL_VALIDATION.md`

--- a/tests/test_nw_prj_dashboard.py
+++ b/tests/test_nw_prj_dashboard.py
@@ -1,0 +1,278 @@
+"""NW PRJ dashboard v6 contract, gates, generator, and comparator tests."""
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from triage import gate_checks
+from triage.nw_prj_artifact_compare import CompareInputs, compare_artifacts
+from triage.nw_prj_config import is_repair_filename
+from triage.nw_prj_dashboard_validator import review_status_bucket
+from triage.nw_prj_dashboard_generator import GenerateInputs, generate_dashboard
+from triage.nw_prj_dashboard_validator import (
+    check_cf_dictionary_exists,
+    validate_nw_prj_dashboard,
+)
+
+
+def _minimal_xlsx(
+    sheet_names: list[str] | None = None,
+    cf_block: str = "",
+    formula: str = "",
+    table_parts: list[tuple[str, str]] | None = None,
+) -> bytes:
+    sheet_names = sheet_names or ["Sheet1"]
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr(
+            "[Content_Types].xml",
+            b'<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">'
+            b'<Default Extension="xml" ContentType="application/xml"/>'
+            b'<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>'
+            b"</Types>",
+        )
+        sheets_xml = "".join(
+            f'<sheet name="{n}" sheetId="{i+1}" r:id="rId{i+1}"/>' for i, n in enumerate(sheet_names)
+        )
+        z.writestr(
+            "xl/workbook.xml",
+            (
+                '<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+                'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+                f"<sheets>{sheets_xml}</sheets></workbook>"
+            ).encode(),
+        )
+        rels = "".join(
+            f'<Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+            f'Target="worksheets/sheet{i+1}.xml" Id="rId{i+1}"/>'
+            for i in range(len(sheet_names))
+        )
+        z.writestr(
+            "xl/_rels/workbook.xml.rels",
+            (
+                '<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+                f"{rels}</Relationships>"
+            ).encode(),
+        )
+        fxml = f"<c r='A1'><f>{formula}</f></c>" if formula else ""
+        cfxml = cf_block or ""
+        for i in range(len(sheet_names)):
+            z.writestr(
+                f"xl/worksheets/sheet{i+1}.xml",
+                (
+                    '<?xml version="1.0"?><worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+                    f"<sheetData><row r='1'>{fxml}</row></sheetData>{cfxml}</worksheet>"
+                ).encode(),
+            )
+        for i, (tname, tpart) in enumerate(table_parts or []):
+            z.writestr(
+                tpart,
+                f'<?xml version="1.0"?><table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+                f'displayName="{tname}" name="{tname}" ref="A1:B2"/>'.encode(),
+            )
+    return buf.getvalue()
+
+
+def _write_prior_dashboard(path: Path, rows: list[dict]) -> None:
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Active_Admin_Targets"
+    headers = list(rows[0].keys()) if rows else ["Review Status", "Tech", "Date", "Edit Sheet", "Edit Row"]
+    ws.append(headers)
+    for r in rows:
+        ws.append([r.get(h, "") for h in headers])
+    wb.create_sheet("CF_Dictionary")
+    wb["CF_Dictionary"].append(["Rule ID"])
+    wb.save(path)
+
+
+# ── config / filename ──
+
+
+def test_no_repair_chain_filename():
+    assert is_repair_filename("Deprecated_repaired_foo.xlsx")
+    assert is_repair_filename("repaired_bar.xlsx")
+    assert not is_repair_filename("NW_PRJ_Tech_Roster_Dashboard_v6_7_OK_WEBSAFE.xlsx")
+
+
+# ── gate checks ──
+
+
+def test_no_web_excel_bad_tokens(tmp_path: Path):
+    p = tmp_path / "bad.xlsx"
+    p.write_bytes(_minimal_xlsx(formula='SUM(_xlfn.CONCAT(A1))'))
+    rpt = gate_checks.run_all(str(p))
+    assert rpt.stopship
+
+
+def test_no_rc_formula_refs(tmp_path: Path):
+    cf = '<conditionalFormatting sqref="A2:A10"><cfRule type="expression"><formula>RC2="AMBER"</formula></cfRule></conditionalFormatting>'
+    p = tmp_path / "rc.xlsx"
+    p.write_bytes(_minimal_xlsx(cf_block=cf))
+    rpt = gate_checks.run_all(str(p))
+    assert rpt.rc_formula_refs
+
+
+def test_unique_table_names(tmp_path: Path):
+    p = tmp_path / "dup.xlsx"
+    p.write_bytes(
+        _minimal_xlsx(
+            table_parts=[
+                ("tblA", "xl/tables/table1.xml"),
+                ("tblA", "xl/tables/table2.xml"),
+            ]
+        )
+    )
+    rpt = gate_checks.run_all(str(p))
+    assert rpt.duplicate_table_names
+
+
+def test_xml_parts_parse(tmp_path: Path):
+    p = tmp_path / "ok.xlsx"
+    p.write_bytes(_minimal_xlsx(sheet_names=["CF_Dictionary", "Active_Admin_Targets"]))
+    rpt = gate_checks.run_all(str(p))
+    assert not rpt.xml_wellformed
+
+
+# ── profile validator ──
+
+
+def test_cf_dictionary_exists(tmp_path: Path):
+    p = tmp_path / "nodict.xlsx"
+    p.write_bytes(_minimal_xlsx(sheet_names=["Active_Admin_Targets"]))
+    assert check_cf_dictionary_exists(str(p))
+
+    p2 = tmp_path / "dict.xlsx"
+    p2.write_bytes(_minimal_xlsx(sheet_names=["CF_Dictionary", "Active_Admin_Targets"]))
+    assert not check_cf_dictionary_exists(str(p2))
+
+
+def test_column_a_override_wins(tmp_path: Path):
+    cf = '<conditionalFormatting sqref="A2:A10"><cfRule><formula>SEARCH("AMBER",RC2)</formula></cfRule></conditionalFormatting>'
+    p = tmp_path / "badcf.xlsx"
+    p.write_bytes(_minimal_xlsx(sheet_names=["Active_Admin_Targets"], cf_block=cf))
+    val = validate_nw_prj_dashboard(str(p))
+    assert any("column_a" in f for f in val.failures)
+
+
+# ── carry-forward / compare ──
+
+
+def test_manual_status_carryforward(tmp_path: Path):
+    dash = tmp_path / "prior.xlsx"
+    _write_prior_dashboard(
+        dash,
+        [
+            {
+                "Review Status": "Done",
+                "Tech": "Alice",
+                "Date": "2026-05-01",
+                "Edit Sheet": "Hours",
+                "Edit Row": "5",
+                "Manual Note / Resolution Note": "confirmed",
+                "Work Queue Status": "AMBER",
+            }
+        ],
+    )
+    scratch = tmp_path / "scratch.xlsx"
+    openpyxl.Workbook().save(scratch)
+    rpt = compare_artifacts(
+        CompareInputs(dashboard_path=str(dash), admin_scratch_path=str(scratch))
+    )
+    assert rpt.archive_rows
+    assert rpt.archive_rows[0]["Review Status"] == "Done"
+    assert rpt.archive_rows[0]["Manual Note / Resolution Note"] == "confirmed"
+
+
+def test_gray_rows_archived(tmp_path: Path):
+    dash = tmp_path / "gray.xlsx"
+    _write_prior_dashboard(
+        dash,
+        [
+            {
+                "Review Status": "Skipped/Gray",
+                "Tech": "Bob",
+                "Date": "2026-05-02",
+                "Edit Sheet": "Hours",
+                "Edit Row": "3",
+            }
+        ],
+    )
+    scratch = tmp_path / "scratch2.xlsx"
+    openpyxl.Workbook().save(scratch)
+    rpt = compare_artifacts(
+        CompareInputs(dashboard_path=str(dash), admin_scratch_path=str(scratch))
+    )
+    assert all(
+        review_status_bucket(r.get("Review Status", "")) == "skipped_gray"
+        for r in rpt.archive_rows
+    )
+    assert not rpt.active_rows
+
+
+def test_admin_scratch_targeting(tmp_path: Path):
+    scratch = tmp_path / "admin_scratch.xlsx"
+    openpyxl.Workbook().save(scratch)
+    rpt = compare_artifacts(CompareInputs(admin_scratch_path=str(scratch)))
+    assert rpt.admin_authority == "manual_admin_scratch"
+    assert rpt.inputs["admin_scratch"]
+
+
+def test_rich_guard_does_not_downgrade(tmp_path: Path):
+    dash = tmp_path / "rich.xlsx"
+    _write_prior_dashboard(
+        dash,
+        [
+            {
+                "Review Status": "",
+                "Tech": "Rich",
+                "Date": "2026-05-03",
+                "Edit Sheet": "H",
+                "Edit Row": "1",
+                "Current Admin Value": "8",
+                "Roster Latest Hours": "4",
+            }
+        ],
+    )
+    scratch = tmp_path / "scratch_rich.xlsx"
+    openpyxl.Workbook().save(scratch)
+    rpt = compare_artifacts(
+        CompareInputs(dashboard_path=str(dash), admin_scratch_path=str(scratch))
+    )
+    assert rpt.rich_guard_rows
+    assert "Preserve admin" in rpt.rich_guard_rows[0]["Action Needed"]
+    assert float(rpt.rich_guard_rows[0]["Current Admin Value"]) >= 8
+
+
+def test_partial_hours_are_review_not_error():
+    from triage.nw_prj_artifact_compare import _partial_hours
+
+    assert _partial_hours(4.5)
+    assert not _partial_hours(8)
+    assert not _partial_hours(0)
+
+
+def test_total_formula_protection(tmp_path: Path):
+    scratch = tmp_path / "adm.xlsx"
+    openpyxl.Workbook().save(scratch)
+    res = generate_dashboard(
+        GenerateInputs(
+            admin_scratch_path=str(scratch),
+            descriptor="TEST",
+            version_minor="9",
+            out_dir=str(tmp_path),
+        )
+    )
+    wb = openpyxl.load_workbook(res.output_path, data_only=True)
+    text = wb["Start Here"]["A1"].value or ""
+    assert "Total" in text
+    assert res.web_excel_safe
+
+
+def test_review_status_bucket():
+    assert review_status_bucket("Done") == "resolved_green"
+    assert review_status_bucket("Skipped/Gray") == "skipped_gray"

--- a/triage/gate_checks.py
+++ b/triage/gate_checks.py
@@ -17,6 +17,8 @@ from typing import Any, Dict, List
 from triage.cf_policy_deploymenttracker import check_cf_policy_deploymenttracker
 
 STOPSHIP_TOKENS = ("_xlfn.", "_xludf.", "_xlpm.", "AGGREGATE(")
+ERROR_LITERAL_TOKENS = ("#REF!", "#VALUE!", "#NAME?")
+RC_CF_PATTERN = re.compile(r"\bRC\d+\b")
 
 
 # ─────────────────────────── helpers ────────────────────────────
@@ -58,12 +60,49 @@ def _parse_ref(ref: str):
 
 def check_stopship_tokens(z: zipfile.ZipFile) -> List[dict]:
     hits: List[dict] = []
-    for name in _sheets(z):
+    scan_parts = list(_sheets(z)) + [
+        n for n in z.namelist()
+        if n.lower().endswith(".xml") and not n.startswith("xl/worksheets/")
+    ]
+    for name in scan_parts:
         s = _txt(z, name)
         for m in re.finditer(r"<f\b[^>]*>(.*?)</f>", s, re.DOTALL):
-            for tok in STOPSHIP_TOKENS:
-                if tok in m.group(1):
-                    hits.append({"part": name, "token": tok, "formula_snippet": m.group(1)[:120]})
+            frag = m.group(1)
+            for tok in STOPSHIP_TOKENS + ERROR_LITERAL_TOKENS:
+                if tok in frag:
+                    hits.append({"part": name, "token": tok, "formula_snippet": frag[:120]})
+    return hits
+
+
+def check_duplicate_table_names(z: zipfile.ZipFile) -> List[dict]:
+    seen: dict[str, str] = {}
+    hits: List[dict] = []
+    for name in z.namelist():
+        if not (name.startswith("xl/tables/table") and name.endswith(".xml")):
+            continue
+        txt = _txt(z, name)
+        for attr in ("displayName", "name"):
+            for m in re.finditer(rf'<table\b[^>]*\b{attr}="([^"]*)"', txt):
+                key = m.group(1)
+                if not key:
+                    continue
+                if key in seen and seen[key] != name:
+                    hits.append({"table_name": key, "first_part": seen[key], "duplicate_part": name})
+                else:
+                    seen[key] = name
+    return hits
+
+
+def check_rc_formula_refs(z: zipfile.ZipFile) -> List[dict]:
+    """Detect R1C1-style RC references inside conditional formatting blocks."""
+    hits: List[dict] = []
+    for name in _sheets(z):
+        s = _txt(z, name)
+        for block in re.finditer(r"<conditionalFormatting\b.*?</conditionalFormatting>", s, re.DOTALL):
+            blob = block.group(0)
+            for m in RC_CF_PATTERN.finditer(blob):
+                hits.append({"part": name, "token": m.group(0), "snippet": blob[:160]})
+                break
     return hits
 
 
@@ -327,6 +366,8 @@ class GateReport:
     xml_wellformed: List[dict] = field(default_factory=list)
     illegal_control: List[dict] = field(default_factory=list)
     rels_missing: List[dict] = field(default_factory=list)
+    duplicate_table_names: List[dict] = field(default_factory=list)
+    rc_formula_refs: List[dict] = field(default_factory=list)
     activetab: dict = field(default_factory=dict)
 
     def failing_gates(self) -> Dict[str, int]:
@@ -342,6 +383,8 @@ class GateReport:
             "xml_wellformed":       self.xml_wellformed,
             "illegal_control_chars":self.illegal_control,
             "rels_missing_targets": self.rels_missing,
+            "duplicate_table_names": self.duplicate_table_names,
+            "rc_formula_refs":      self.rc_formula_refs,
         }.items() if v}
 
     @property
@@ -365,6 +408,8 @@ class GateReport:
                 "xml_wellformed": self.xml_wellformed[:10],
                 "illegal_control": self.illegal_control[:10],
                 "rels_missing": self.rels_missing[:20],
+                "duplicate_table_names": self.duplicate_table_names[:20],
+                "rc_formula_refs": self.rc_formula_refs[:20],
             },
             "triage": {"activetab": self.activetab},
         }
@@ -384,6 +429,8 @@ def run_all(path: str) -> GateReport:
         rpt.xml_wellformed = check_xml_wellformed(z)
         rpt.illegal_control = check_illegal_control_chars(z)
         rpt.rels_missing = check_rels_missing(z)
+        rpt.duplicate_table_names = check_duplicate_table_names(z)
+        rpt.rc_formula_refs = check_rc_formula_refs(z)
         rpt.activetab = check_workbook_activetab(z)
     return rpt
 

--- a/triage/nw_prj_artifact_compare.py
+++ b/triage/nw_prj_artifact_compare.py
@@ -1,0 +1,143 @@
+"""
+Three-way reconciliation: prior dashboard, roster log, manual admin scratch.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from triage.nw_prj_config import is_repair_filename
+from triage.nw_prj_dashboard_validator import review_status_bucket
+from triage.nw_prj_dashboard_rows import DashboardRow, load_dashboard_rows, row_key
+
+
+@dataclass
+class CompareInputs:
+    dashboard_path: Optional[str] = None
+    roster_path: Optional[str] = None
+    admin_scratch_path: Optional[str] = None
+    official_admin_path: Optional[str] = None
+
+
+@dataclass
+class CompareReport:
+    inputs: Dict[str, str] = field(default_factory=dict)
+    admin_authority: str = "manual_admin_scratch"
+    active_rows: List[Dict[str, Any]] = field(default_factory=list)
+    archive_rows: List[Dict[str, Any]] = field(default_factory=list)
+    rich_guard_rows: List[Dict[str, Any]] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    failures: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "inputs": dict(self.inputs),
+            "admin_authority": self.admin_authority,
+            "active_count": len(self.active_rows),
+            "archive_count": len(self.archive_rows),
+            "rich_guard_count": len(self.rich_guard_rows),
+            "warnings": list(self.warnings),
+            "failures": list(self.failures),
+            "active_rows": self.active_rows[:500],
+            "archive_rows": self.archive_rows[:500],
+        }
+
+
+def _partial_hours(h: Any) -> bool:
+    try:
+        v = float(h)
+        return 0 < v < 8
+    except (TypeError, ValueError):
+        return False
+
+
+def compare_artifacts(inputs: CompareInputs) -> CompareReport:
+    rpt = CompareReport()
+    paths = {
+        "dashboard": inputs.dashboard_path,
+        "roster": inputs.roster_path,
+        "admin_scratch": inputs.admin_scratch_path,
+        "official_admin": inputs.official_admin_path,
+    }
+    for k, v in paths.items():
+        if v:
+            rpt.inputs[k] = str(Path(v).resolve())
+            if is_repair_filename(Path(v).name):
+                rpt.failures.append(f"repaired_input:{k}:{Path(v).name}")
+
+    if not inputs.admin_scratch_path:
+        rpt.failures.append("missing_admin_scratch")
+        return rpt
+
+    rpt.admin_authority = "manual_admin_scratch"
+    if inputs.official_admin_path and not inputs.admin_scratch_path:
+        rpt.admin_authority = "official_admin_workbook"
+        rpt.warnings.append("official_admin_without_scratch")
+
+    prior: Dict[str, DashboardRow] = {}
+    if inputs.dashboard_path:
+        prior = {row_key(r): r for r in load_dashboard_rows(inputs.dashboard_path)}
+
+    # Seed from prior dashboard with carry-forward
+    for key, row in prior.items():
+        bucket = review_status_bucket(row.review_status)
+        out = row.to_dict()
+        if bucket == "skipped_gray" or bucket == "resolved_green":
+            rpt.archive_rows.append(out)
+        else:
+            if _partial_hours(row.roster_latest_hours):
+                out["Work Queue Status"] = out.get("Work Queue Status") or "AMBER"
+                out["Reason Code"] = out.get("Reason Code") or "PARTIAL_HOURS_REVIEW"
+            rpt.active_rows.append(out)
+
+    # Rich Guard: admin full day with weak roster
+    for row in rpt.active_rows:
+        admin_h = row.get("Current Admin Value") or row.get("Roster Latest Hours")
+        roster_h = row.get("Roster Latest Hours")
+        try:
+            ah = float(admin_h) if admin_h not in (None, "") else None
+            rh = float(roster_h) if roster_h not in (None, "") else None
+        except (TypeError, ValueError):
+            ah = rh = None
+        if ah is not None and ah >= 8 and (rh is None or rh < ah):
+            guard = dict(row)
+            guard["Work Queue Status"] = "RICH_GUARD"
+            guard["Reason Code"] = "PRESERVE_ADMIN_FULL_DAY"
+            guard["Action Needed"] = (
+                "Preserve admin full/long-day hours unless explicit short-day evidence exists."
+            )
+            rpt.rich_guard_rows.append(guard)
+
+    # Demote gray resurrection
+    active_keys = {row_key(DashboardRow.from_dict(r)) for r in rpt.active_rows}
+    for key, row in prior.items():
+        if review_status_bucket(row.review_status) == "skipped_gray" and key in active_keys:
+            rpt.warnings.append(f"gray_resurrection:{key}")
+
+    return rpt
+
+
+def main() -> None:
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description="Compare NW PRJ dashboard artifacts")
+    ap.add_argument("--dashboard")
+    ap.add_argument("--roster")
+    ap.add_argument("--admin-scratch", required=True)
+    ap.add_argument("--official-admin")
+    args = ap.parse_args()
+    rpt = compare_artifacts(
+        CompareInputs(
+            dashboard_path=args.dashboard,
+            roster_path=args.roster,
+            admin_scratch_path=args.admin_scratch,
+            official_admin_path=args.official_admin,
+        )
+    )
+    print(json.dumps(rpt.to_dict(), indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/nw_prj_config.py
+++ b/triage/nw_prj_config.py
@@ -1,0 +1,59 @@
+"""
+Load NW PRJ dashboard v6 JSON contracts from configs/.
+"""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CONFIG_DIR = _REPO_ROOT / "configs"
+
+
+def _load(name: str) -> Dict[str, Any]:
+    path = _CONFIG_DIR / name
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@lru_cache(maxsize=1)
+def dashboard_schema() -> Dict[str, Any]:
+    return _load("nw_prj_dashboard_v6_schema.json")
+
+
+@lru_cache(maxsize=1)
+def cf_palette() -> Dict[str, Any]:
+    return _load("cf_palette_v1.json")
+
+
+@lru_cache(maxsize=1)
+def status_values() -> Dict[str, Any]:
+    return _load("status_values_v1.json")
+
+
+@lru_cache(maxsize=1)
+def team_scope_values() -> Dict[str, Any]:
+    return _load("team_scope_values_v1.json")
+
+
+@lru_cache(maxsize=1)
+def stop_ship_tokens() -> Dict[str, Any]:
+    return _load("web_excel_stop_ship_tokens.json")
+
+
+def resolved_review_statuses() -> frozenset[str]:
+    return frozenset(status_values()["review_status"]["resolved_green"])
+
+
+def skipped_review_statuses() -> frozenset[str]:
+    return frozenset(status_values()["review_status"]["skipped_gray"])
+
+
+def is_repair_filename(name: str) -> bool:
+    low = name.lower()
+    for marker in stop_ship_tokens()["filename_markers"]:
+        if marker.lower() in low:
+            return True
+    return False

--- a/triage/nw_prj_dashboard_generator.py
+++ b/triage/nw_prj_dashboard_generator.py
@@ -1,0 +1,220 @@
+"""
+Generate NW PRJ Tech Roster Dashboard v6_x WEBSAFE workbooks.
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from triage.nw_prj_artifact_compare import CompareInputs, compare_artifacts
+from triage.nw_prj_config import cf_palette, dashboard_schema, is_repair_filename, status_values
+from triage.nw_prj_dashboard_validator import validate_nw_prj_dashboard
+
+
+def _require_openpyxl():
+    try:
+        import openpyxl  # noqa: F401
+        from openpyxl import Workbook, load_workbook
+        from openpyxl.styles import Font, PatternFill
+        from openpyxl.utils import get_column_letter
+    except ImportError as e:
+        raise RuntimeError("openpyxl is required: pip install openpyxl") from e
+    return openpyxl, Workbook, load_workbook, Font, PatternFill, get_column_letter
+
+
+def _write_sheet_table(ws, headers: List[str], data_rows: List[Dict[str, Any]]) -> None:
+    _, _, _, Font, PatternFill, get_column_letter = _require_openpyxl()
+    header_fill = PatternFill("solid", fgColor="FF4472C4")
+    for c, h in enumerate(headers, 1):
+        cell = ws.cell(row=1, column=c, value=h)
+        cell.font = Font(bold=True, color="FFFFFFFF")
+        cell.fill = header_fill
+    for r_idx, row in enumerate(data_rows, 2):
+        for c, h in enumerate(headers, 1):
+            ws.cell(row=r_idx, column=c, value=row.get(h, ""))
+    for c in range(1, len(headers) + 1):
+        ws.column_dimensions[get_column_letter(c)].width = 16
+
+
+def _apply_tab_colors(wb) -> None:
+    palette = cf_palette().get("tab_colors", {})
+    for name in wb.sheetnames:
+        if name in palette:
+            wb[name].sheet_properties.tabColor = palette[name]
+
+
+def _cf_dictionary_rows() -> List[Dict[str, Any]]:
+    return [
+        {
+            "Rule ID": "CF_A_DONE",
+            "Priority": 1,
+            "Applies To": "Active queues; Column A",
+            "Condition (plain English)": "Review Status is Done, Confirmed Valid, Addressed, or Resolved",
+            "Formula (audit)": '=$A2="Done"',
+            "Fill / Font": "resolved_green",
+            "Overrides": "Wins over all queue colors",
+        },
+        {
+            "Rule ID": "CF_A_GRAY",
+            "Priority": 2,
+            "Applies To": "Active queues; Column A",
+            "Condition (plain English)": "Review Status is Skipped/Gray or Gray/Skip",
+            "Formula (audit)": '=$A2="Skipped/Gray"',
+            "Fill / Font": "skipped_gray",
+            "Overrides": "Demote to Resolved_Archive",
+        },
+    ]
+
+
+@dataclass
+class GenerateInputs:
+    dashboard_path: Optional[str] = None
+    roster_path: Optional[str] = None
+    admin_scratch_path: str = ""
+    official_admin_path: Optional[str] = None
+    version_minor: str = "7"
+    descriptor: str = "GENERATED"
+    out_dir: str = "Outputs"
+
+
+@dataclass
+class GenerateResult:
+    output_path: str = ""
+    compare_report: Optional[Dict[str, Any]] = None
+    validation: Optional[Dict[str, Any]] = None
+    web_excel_safe: bool = False
+
+
+def generate_dashboard(inputs: GenerateInputs) -> GenerateResult:
+    if not inputs.admin_scratch_path:
+        raise ValueError("admin_scratch_path is required")
+    if is_repair_filename(Path(inputs.admin_scratch_path).name):
+        raise ValueError(f"repaired admin scratch rejected: {inputs.admin_scratch_path}")
+
+    openpyxl, Workbook, *_ = _require_openpyxl()
+    schema = dashboard_schema()
+    headers = schema["required_active_columns"]
+
+    cmp = compare_artifacts(
+        CompareInputs(
+            dashboard_path=inputs.dashboard_path,
+            roster_path=inputs.roster_path,
+            admin_scratch_path=inputs.admin_scratch_path,
+            official_admin_path=inputs.official_admin_path,
+        )
+    )
+
+    out_name = (
+        f"NW_PRJ_Tech_Roster_Dashboard_v6_{inputs.version_minor}_"
+        f"{inputs.descriptor}_WEBSAFE.xlsx"
+    )
+    out_path = Path(inputs.out_dir) / out_name
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    wb = Workbook()
+    default = wb.active
+    wb.remove(default)
+
+    sheet_plan = [
+        ("Start Here", [["NW PRJ Dashboard v6 — edit In/Out cells only; do not overwrite Total formulas."]]),
+        (f"Dashboard_Tool_v6_{inputs.version_minor}", [["Generated", time.strftime("%Y-%m-%d %H:%M")]]),
+        ("Active_Admin_Targets", []),
+        ("Partial_Hours_Active", []),
+        ("Review_Guardrails", []),
+        ("Quiet_Queues", []),
+        ("Resolved_Archive", []),
+        ("Tech_Summary", []),
+        ("CF_Dictionary", []),
+        ("Definitions_Current", []),
+        (f"Visual_System_v6_{inputs.version_minor}", []),
+        ("Dropdown_Values", []),
+        ("Repo_Automation_Notes", []),
+    ]
+
+    for title, _ in sheet_plan:
+        wb.create_sheet(title)
+
+    wb["Start Here"]["A1"] = (
+        "NW PRJ Dashboard v6 — edit In/Out cells only; do not overwrite Total formulas. "
+        "Check Expected Total before submission."
+    )
+
+    _write_sheet_table(wb["Active_Admin_Targets"], headers, cmp.active_rows)
+    _write_sheet_table(wb["Resolved_Archive"], headers, cmp.archive_rows)
+    _write_sheet_table(wb["Review_Guardrails"], headers, cmp.rich_guard_rows)
+
+    partials = [
+        r for r in cmp.active_rows
+        if str(r.get("Reason Code", "")).startswith("PARTIAL")
+        or str(r.get("Work Queue Status", "")) == "AMBER"
+    ]
+    _write_sheet_table(wb["Partial_Hours_Active"], headers, partials)
+
+    cf_headers = list(_cf_dictionary_rows()[0].keys())
+    _write_sheet_table(wb["CF_Dictionary"], cf_headers, _cf_dictionary_rows())
+
+    dv = status_values()
+    _write_sheet_table(
+        wb["Dropdown_Values"],
+        ["List", "Values"],
+        [
+            {"List": "Review Status", "Values": ", ".join(dv["review_status"]["resolved_green"])},
+            {"List": "Team Scope", "Values": "Cybernet/Neuron Active, Tracked Only, Out of Scope"},
+        ],
+    )
+
+    notes = [
+        ["Input", "Path"],
+        ["admin_scratch", inputs.admin_scratch_path],
+        ["dashboard", inputs.dashboard_path or ""],
+        ["roster", inputs.roster_path or ""],
+        ["official_admin", inputs.official_admin_path or ""],
+        ["admin_authority", cmp.admin_authority],
+    ]
+    for r_idx, row in enumerate(notes, 1):
+        for c_idx, val in enumerate(row, 1):
+            wb["Repo_Automation_Notes"].cell(row=r_idx, column=c_idx, value=val)
+
+    _apply_tab_colors(wb)
+    wb.save(out_path)
+
+    val = validate_nw_prj_dashboard(str(out_path))
+    return GenerateResult(
+        output_path=str(out_path),
+        compare_report=cmp.to_dict(),
+        validation=val.to_dict(),
+        web_excel_safe=val.web_excel_safe,
+    )
+
+
+def main() -> None:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Generate NW PRJ dashboard v6 WEBSAFE workbook")
+    ap.add_argument("--admin-scratch", required=True)
+    ap.add_argument("--dashboard")
+    ap.add_argument("--roster")
+    ap.add_argument("--official-admin")
+    ap.add_argument("--minor", default="7")
+    ap.add_argument("--descriptor", default="GENERATED")
+    ap.add_argument("--out-dir", default="Outputs")
+    args = ap.parse_args()
+    res = generate_dashboard(
+        GenerateInputs(
+            admin_scratch_path=args.admin_scratch,
+            dashboard_path=args.dashboard,
+            roster_path=args.roster,
+            official_admin_path=args.official_admin,
+            version_minor=args.minor,
+            descriptor=args.descriptor,
+            out_dir=args.out_dir,
+        )
+    )
+    print(json.dumps({"output": res.output_path, "web_excel_safe": res.web_excel_safe}, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/nw_prj_dashboard_rows.py
+++ b/triage/nw_prj_dashboard_rows.py
@@ -1,0 +1,149 @@
+"""Shared row model and dashboard sheet readers for NW PRJ v6."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from triage.nw_prj_config import dashboard_schema
+
+
+def _require_openpyxl():
+    try:
+        from openpyxl import load_workbook
+    except ImportError as e:
+        raise RuntimeError("openpyxl is required: pip install openpyxl") from e
+    return load_workbook
+
+
+@dataclass
+class DashboardRow:
+    review_status: str = ""
+    work_queue_status: str = ""
+    target_type: str = ""
+    action_needed: str = ""
+    target_workbook: str = ""
+    edit_sheet: str = ""
+    edit_row: str = ""
+    edit_in_cell: str = ""
+    proposed_in: str = ""
+    edit_out_cell: str = ""
+    proposed_out: str = ""
+    total_cell: str = ""
+    expected_total: str = ""
+    tech: str = ""
+    date: str = ""
+    team_scope: str = ""
+    current_admin_value: str = ""
+    roster_latest_in: str = ""
+    roster_latest_out: str = ""
+    roster_latest_hours: str = ""
+    roster_check: str = ""
+    roster_check_notes: str = ""
+    reason_code: str = ""
+    confidence: str = ""
+    submission_blocker: str = ""
+    manual_note: str = ""
+
+    @staticmethod
+    def from_dict(d: Dict[str, Any]) -> "DashboardRow":
+        return DashboardRow(
+            review_status=str(d.get("Review Status", d.get("review_status", "")) or ""),
+            work_queue_status=str(d.get("Work Queue Status", "") or ""),
+            target_type=str(d.get("Target Type", "") or ""),
+            action_needed=str(d.get("Action Needed", "") or ""),
+            target_workbook=str(d.get("Target Workbook", "") or ""),
+            edit_sheet=str(d.get("Edit Sheet", "") or ""),
+            edit_row=str(d.get("Edit Row", "") or ""),
+            edit_in_cell=str(d.get("Edit In Cell", "") or ""),
+            proposed_in=str(d.get("Proposed In", "") or ""),
+            edit_out_cell=str(d.get("Edit Out Cell", "") or ""),
+            proposed_out=str(d.get("Proposed Out", "") or ""),
+            total_cell=str(d.get("Total Cell", "") or ""),
+            expected_total=str(d.get("Expected Total", "") or ""),
+            tech=str(d.get("Tech", "") or ""),
+            date=str(d.get("Date", "") or ""),
+            team_scope=str(d.get("Team Scope", "") or ""),
+            current_admin_value=str(d.get("Current Admin Value", "") or ""),
+            roster_latest_in=str(d.get("Roster Latest In", "") or ""),
+            roster_latest_out=str(d.get("Roster Latest Out", "") or ""),
+            roster_latest_hours=str(d.get("Roster Latest Hours", "") or ""),
+            roster_check=str(d.get("Roster Check", "") or ""),
+            roster_check_notes=str(d.get("Roster Check Notes", "") or ""),
+            reason_code=str(d.get("Reason Code", "") or ""),
+            confidence=str(d.get("Confidence", "") or ""),
+            submission_blocker=str(d.get("Submission Blocker", "") or ""),
+            manual_note=str(d.get("Manual Note / Resolution Note", d.get("manual_note", "")) or ""),
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "Review Status": self.review_status,
+            "Work Queue Status": self.work_queue_status,
+            "Target Type": self.target_type,
+            "Action Needed": self.action_needed,
+            "Target Workbook": self.target_workbook,
+            "Edit Sheet": self.edit_sheet,
+            "Edit Row": self.edit_row,
+            "Edit In Cell": self.edit_in_cell,
+            "Proposed In": self.proposed_in,
+            "Edit Out Cell": self.edit_out_cell,
+            "Proposed Out": self.proposed_out,
+            "Total Cell": self.total_cell,
+            "Expected Total": self.expected_total,
+            "Tech": self.tech,
+            "Date": self.date,
+            "Team Scope": self.team_scope,
+            "Current Admin Value": self.current_admin_value,
+            "Roster Latest In": self.roster_latest_in,
+            "Roster Latest Out": self.roster_latest_out,
+            "Roster Latest Hours": self.roster_latest_hours,
+            "Roster Check": self.roster_check,
+            "Roster Check Notes": self.roster_check_notes,
+            "Reason Code": self.reason_code,
+            "Confidence": self.confidence,
+            "Submission Blocker": self.submission_blocker,
+            "Manual Note / Resolution Note": self.manual_note,
+        }
+
+
+def row_key(row: DashboardRow) -> str:
+    return f"{row.tech}|{row.date}|{row.edit_sheet}|{row.edit_row}"
+
+
+def _find_sheet(wb, base_name: str):
+    if base_name in wb.sheetnames:
+        return wb[base_name]
+    for n in wb.sheetnames:
+        if n.startswith(base_name.rstrip("_x")) or base_name.rstrip("_x") in n:
+            return wb[n]
+    return None
+
+
+def load_dashboard_rows(path: str) -> List[DashboardRow]:
+    load_workbook = _require_openpyxl()
+    wb = load_workbook(path, data_only=True, read_only=True)
+    schema = dashboard_schema()
+    rows: List[DashboardRow] = []
+    sheets = list(schema.get("active_queue_sheets", []))
+    sheets.append(schema.get("archive_sheet", "Resolved_Archive"))
+    for sheet_name in sheets:
+        ws = _find_sheet(wb, sheet_name)
+        if ws is None:
+            continue
+        headers: Dict[str, int] = {}
+        for row_cells in ws.iter_rows(min_row=1, max_row=1, values_only=True):
+            for i, h in enumerate(row_cells):
+                if h:
+                    headers[str(h).strip()] = i
+        if "Review Status" not in headers:
+            continue
+        for row_cells in ws.iter_rows(min_row=2, values_only=True):
+            if not row_cells or not any(row_cells):
+                continue
+            d: Dict[str, Any] = {}
+            for h, idx in headers.items():
+                if idx < len(row_cells):
+                    d[h] = row_cells[idx]
+            rows.append(DashboardRow.from_dict(d))
+    wb.close()
+    return rows

--- a/triage/nw_prj_dashboard_validator.py
+++ b/triage/nw_prj_dashboard_validator.py
@@ -1,0 +1,139 @@
+"""
+NW PRJ dashboard v6 validation — schema + gate battery + profile checks.
+READ-ONLY.
+"""
+from __future__ import annotations
+
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from triage.gate_checks import run_all, GateReport
+from triage.nw_prj_config import (
+    dashboard_schema,
+    is_repair_filename,
+    resolved_review_statuses,
+    skipped_review_statuses,
+    stop_ship_tokens,
+)
+
+
+def _sheet_names_in_workbook(path: Path) -> List[str]:
+    with zipfile.ZipFile(path, "r") as z:
+        if "xl/workbook.xml" not in z.namelist():
+            return []
+        import re as _re
+        wb = z.read("xl/workbook.xml").decode("utf-8", errors="ignore")
+        return _re.findall(r'<sheet\b[^>]*\bname="([^"]+)"', wb)
+
+
+def _has_cf_dictionary(sheet_names: List[str]) -> bool:
+    schema = dashboard_schema()
+    required = schema["cf_dictionary_sheet"]
+    if required in sheet_names:
+        return True
+    return any(required in n for n in sheet_names)
+
+
+def check_cf_dictionary_exists(path: str) -> List[dict]:
+    names = _sheet_names_in_workbook(Path(path))
+    if not names:
+        return [{"issue": "unreadable_workbook"}]
+    if not _has_cf_dictionary(names):
+        return [{"issue": "missing_cf_dictionary", "sheets": names[:30]}]
+    return []
+
+
+def check_column_a_override_wins(path: str) -> List[dict]:
+    """
+    Heuristic: flag CF blocks that reference RC* or SEARCH("AMBER") on sheets
+    that look like dashboard active queues — contract smell.
+    """
+    hits: List[dict] = []
+    forbidden = stop_ship_tokens().get("cf_forbidden_patterns", [])
+    with zipfile.ZipFile(path, "r") as z:
+        for name in z.namelist():
+            if not name.startswith("xl/worksheets/"):
+                continue
+            s = z.read(name).decode("utf-8", errors="ignore")
+            if "conditionalFormatting" not in s:
+                continue
+            for pat in forbidden:
+                if re.search(pat, s):
+                    hits.append({"part": name, "pattern": pat})
+                    break
+    return hits
+
+
+@dataclass
+class NwPrjDashboardValidationReport:
+    path: str
+    web_excel_safe: bool = False
+    failures: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    gate: Optional[Dict[str, Any]] = None
+    profile_checks: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "web_excel_safe": self.web_excel_safe,
+            "failures": list(self.failures),
+            "warnings": list(self.warnings),
+            "gate": self.gate,
+            "profile_checks": dict(self.profile_checks),
+        }
+
+
+def validate_nw_prj_dashboard(path: str) -> NwPrjDashboardValidationReport:
+    p = Path(path)
+    rpt = NwPrjDashboardValidationReport(path=str(p.resolve()))
+
+    if is_repair_filename(p.name):
+        rpt.failures.append(f"repair_filename_stop_ship:{p.name}")
+
+    gate = run_all(str(p))
+    rpt.gate = gate.to_dict()
+    if not gate.pass_all:
+        for k, n in gate.failing_gates().items():
+            rpt.failures.append(f"gate:{k} ({n})")
+
+    cf_dict = check_cf_dictionary_exists(str(p))
+    rpt.profile_checks["cf_dictionary_exists"] = "pass" if not cf_dict else "fail"
+    if cf_dict:
+        rpt.failures.append("missing_cf_dictionary")
+
+    col_a = check_column_a_override_wins(str(p))
+    rpt.profile_checks["column_a_override_wins"] = "pass" if not col_a else "fail"
+    if col_a:
+        rpt.failures.append("column_a_cf_override_risk")
+
+    rpt.web_excel_safe = not rpt.failures
+    return rpt
+
+
+def review_status_bucket(status: str) -> str:
+    s = (status or "").strip()
+    if s in resolved_review_statuses():
+        return "resolved_green"
+    if s in skipped_review_statuses():
+        return "skipped_gray"
+    return "active"
+
+
+def main() -> None:
+    import argparse
+    import json
+
+    ap = argparse.ArgumentParser(description="Validate NW PRJ dashboard v6 workbook")
+    ap.add_argument("workbook")
+    args = ap.parse_args()
+    rpt = validate_nw_prj_dashboard(args.workbook)
+    print(json.dumps(rpt.to_dict(), indent=2))
+    raise SystemExit(0 if rpt.web_excel_safe else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## **User description**
## Summary

- Adds NW PRJ dashboard v6 doctrine docs (contract, CF dictionary, STOP-SHIP, reconciliation insights, artifact ledger).
- Adds JSON configs for schema, status/team scope, CF palette, and stop-ship tokens.
- Extends `gate_checks` with duplicate table names, R1C1 CF leakage, and `#VALUE!` / `#NAME?` scans.
- Adds `nw_prj_dashboard_validator`, `nw_prj_dashboard_generator`, and `nw_prj_artifact_compare` with 14 contract tests.

## Supersedes

Overlaps doc-only PR #12 (`docs/nw-prj-websafe-insights-2026-05-26`); prefer merging this branch and closing #12 after review.

## Test plan

- [x] `pytest tests/test_nw_prj_dashboard.py tests/test_billing_bridge_validator.py`
- [ ] Validate a local v6.5/v6.6 WEBSAFE artifact with `python -m triage.nw_prj_dashboard_validator`
- [ ] Generate from manual admin scratch: `python -m triage.nw_prj_dashboard_generator --admin-scratch <scratch.xlsx> --dashboard <prior.xlsx>`

## Known gaps (post-merge)

- Roster/admin cell parsing not yet wired into generator rows (compare seeds from prior dashboard only).
- CF rules are documented in `CF_Dictionary`; OOXML CF XML emission not yet automated.
- Layout fingerprint enforcement is schema-defined but not fully enforced at runtime.


___

## **CodeAnt-AI Description**
**Add NW PRJ dashboard v6 generation, validation, and reconciliation support**

### What Changed
- Added a new NW PRJ dashboard workflow that generates a web-safe workbook with the required sheets, column layout, tab colors, and CF dictionary.
- Added validation checks that reject repaired filenames, missing CF dictionary sheets, duplicate table names, and risky conditional formatting patterns.
- Added three-way artifact comparison to carry forward prior manual notes, archive resolved or gray rows, and flag Rich Guard cases where admin hours should stay intact.
- Added new dashboard contract docs and config files that define the allowed statuses, team scope values, stop-ship tokens, and visual rules.
- Expanded test coverage for the new dashboard rules, generator output, and gate checks.

### Impact
`✅ Fewer web-Excel repair failures`
`✅ Clearer dashboard queue triage`
`✅ Safer carry-forward of resolved work`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
