### PR TITLE
chore: preserve NW PRJ v6.8 checkpoint artifact manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ billing_runs_tmp/
 # Local script env overrides (secrets; never commit)
 scripts/online_env.local.ps1
 scripts/*.local.ps1
+scripts/artifacts/*.local
+
+# Local payload drop zone and decode output — never commit raw internal workbooks
+Workbook Payload Artifacts/
+RecoveredArtifacts/

--- a/artifacts/nw_prj_dashboard_v6_8/NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md
+++ b/artifacts/nw_prj_dashboard_v6_8/NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md
@@ -1,0 +1,42 @@
+# NW PRJ Dashboard v6.8 Carryover Notes
+
+Generated from:
+- Dashboard: `NW_PRJ_Tech_Roster_Dashboard_v6_7_STATUS_DICTIONARY_WEBSAFE-5-28-2026.xlsx`
+- Admin scratch/control copy: `NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx`
+- Roster log provided for checkpoint: `INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx`
+
+## Sprint outcome
+
+- Active admin work surface now has 1 open/addressed row(s).
+- Review guardrails retain 16 row(s).
+- Partial hours retain 9 row(s).
+- Resolved_Queue collected 21 row(s) from current work tabs.
+
+## Known gaps
+
+1. `Resolved_Queue` is values-based in v6.8. v7.x should generate it dynamically from work tabs.
+2. Manual status and `Preserve Notes / Context` must be treated as evidence, not disposable comments.
+3. Every invented dropdown/status term must exist in `Definitions_Current` and `Status_Decision_Map`.
+4. Every visual color must be codified in `CF_Dictionary` and `Visual_System_v6_8` with plain color name plus hex.
+5. Tech-facing work surfaces should be clean; backend/full-schema tabs can stay hidden or separated.
+
+## Known risks
+
+1. Manual closed rows can be falsely reopened if old proposed values are treated as final.
+2. `Addressed` can be mistaken for `Resolved`; it must remain teal and explicitly not holistically closed.
+3. Excel Web repair prefixes such as `Deprecated_repaired_` are STOP-SHIP indicators.
+4. Start sheets can open at blank scrolled ranges unless active view is controlled.
+5. Conditional formatting must evaluate Column A status before queue labels.
+
+## Repo targets
+
+- Add `docs/NW_PRJ_DASHBOARD_V6_CONTRACT.md`.
+- Add `docs/CF_DICTIONARY_AND_VISUAL_SYSTEM.md`.
+- Add `configs/cf_palette_v1.json`.
+- Add `configs/status_values_v1.json`.
+- Add validator tests for Column A override, no stale reopen, no repaired output, and Start Here active view.
+- Add local CLI generator accepting dashboard, admin scratch/control copy, and roster log.
+
+## v7.x target
+
+Build linked/dynamic `Resolved_Queue` generation in `EndeavorEverlasting/web-excel-repair-triage` so manual status changes flow into the ledger without regenerating static rows by hand.

--- a/artifacts/nw_prj_dashboard_v6_8/README.md
+++ b/artifacts/nw_prj_dashboard_v6_8/README.md
@@ -1,0 +1,50 @@
+# NW PRJ v6.8 Dashboard Checkpoint Artifacts
+
+This folder preserves the working v6.8 checkpoint so the next PC can pull the repo and recover the exact dashboard/admin/roster artifacts without hunting through chat downloads.
+
+## Why this exists
+
+The v6.8 sprint established the current Web Excel-safe dashboard baseline:
+
+- resolution-ledger routing
+- lighter tab colors
+- color-coded CF dictionary and visual system
+- notes/context preservation
+- manual admin scratch/control copy as the first target
+- roster log as confirmation evidence
+- hidden backend columns for analysis while keeping tech-facing tabs fast
+
+## Restore the files
+
+From the repo root after pulling:
+
+```bash
+python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
+```
+
+The script decodes:
+
+```text
+artifacts/nw_prj_dashboard_v6_8/NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64
+```
+
+into:
+
+```text
+RecoveredArtifacts/NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28/
+```
+
+Then verify the checksum shown in `manifest.json`.
+
+## Important doctrine captured by this checkpoint
+
+- `Addressed` is not the same as `Resolved`.
+- `ROSTER CONFIRMED` means the roster supports the proposed value; it does not prove the admin scratch copy is already fixed.
+- `Gray/Skip` rows are dismissed/reference, not active targets.
+- Column A review status must override queue coloring.
+- A file renamed `Deprecated_repaired_...` by Excel Web is failed output.
+- `Resolved_Queue` is values-routed in v6.8; dynamic linked routing belongs to v7.x.
+
+## Contents
+
+See `manifest.json` for file roles and SHA-256 checksums.

--- a/artifacts/nw_prj_dashboard_v6_8/README.md
+++ b/artifacts/nw_prj_dashboard_v6_8/README.md
@@ -14,27 +14,55 @@ The v6.8 sprint established the current Web Excel-safe dashboard baseline:
 - roster log as confirmation evidence
 - hidden backend columns for analysis while keeping tech-facing tabs fast
 
-## Restore the files
+## Payload scope
 
-From the repo root after pulling:
+This checkpoint commit includes **generator-critical xlsx only** (3 files):
 
-```bash
+- `NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx`
+- `NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx`
+- `INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx`
+
+Optional items (v6.7 dashboard source, PNG screenshots) are listed under `not_included` in `manifest.json`.
+
+Carryover notes are committed as UTF-8 text: `NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md`.
+
+## Restore the payloads
+
+From the repo root after pulling branch `artifacts/nw-prj-v6-8-checkpoint-2026-05-28`:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+pip install -r requirements.txt
 python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
 ```
 
-The script decodes:
+When prompted, enter the checkpoint password (stored externally — never in the repo).
 
-```text
-artifacts/nw_prj_dashboard_v6_8/NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64
+Non-interactive decode:
+
+```powershell
+$env:NW_PRJ_CHECKPOINT_PASSWORD = "your-secret"
+python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
 ```
 
-into:
+Files extract to:
 
 ```text
 RecoveredArtifacts/NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28/
 ```
 
-Then verify the checksum shown in `manifest.json`.
+Verify against `payload_checksums.sha256` and per-file SHA-256 entries in `manifest.json`.
+
+## Re-package (maintainers only)
+
+If you have raw workbooks in `Workbook Payload Artifacts/` (gitignored):
+
+```powershell
+python scripts/artifacts/package_nw_prj_v6_8_checkpoint.py
+```
+
+Then update `manifest.json` `archive_sha256` from script output and commit the new archive + checksums.
 
 ## Important doctrine captured by this checkpoint
 
@@ -47,4 +75,4 @@ Then verify the checksum shown in `manifest.json`.
 
 ## Contents
 
-See `manifest.json` for file roles and SHA-256 checksums.
+See `manifest.json` for file roles, SHA-256 checksums, and storage method.

--- a/artifacts/nw_prj_dashboard_v6_8/manifest.json
+++ b/artifacts/nw_prj_dashboard_v6_8/manifest.json
@@ -1,27 +1,17 @@
 {
   "checkpoint": "NW PRJ Tech Roster Dashboard v6.8 resolution ledger checkpoint",
   "date": "2026-05-28",
-  "archive": "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip",
-  "archive_b64": "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64",
-  "archive_sha256": "f04822901a12e6954cabd8b777af9af1432b8cb0a5fb983fc8f0a4650d1d4fd9",
+  "payload_storage": "encrypted_zip_aes",
+  "payload_path": "artifacts/nw_prj_dashboard_v6_8/payload/NW_PRJ_v6_8_checkpoint_payload_2026-05-28.zip",
+  "password_storage": "external_only",
+  "payload_subset": "generator_critical",
+  "archive_sha256": "3e3604c2137017e7754f1d2c22b9fb2e8ef856b255cee6d326bf205a8fa140e8",
   "contents": [
     {
       "filename": "NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx",
       "size_bytes": 58616,
       "sha256": "ec502e1ff6b00c5ce22ead72a4000cb8c3164bcd9711bb71a1b86df9caa55497",
       "role": "latest generated v6.8 dashboard checkpoint"
-    },
-    {
-      "filename": "NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md",
-      "size_bytes": 2221,
-      "sha256": "37be4871493deccd5666bcafd4b5a469f82bcdcea98474f3468a70bd94cdd4ad",
-      "role": "repo carryover notes/gaps/risks/targets from v6.8 sprint"
-    },
-    {
-      "filename": "NW_PRJ_Tech_Roster_Dashboard_v6_7_STATUS_DICTIONARY_WEBSAFE-5-28-2026.xlsx",
-      "size_bytes": 75784,
-      "sha256": "a1a11c50606898ca62de69ef0b4777427f67ae710c532608f15a24909e21933d",
-      "role": "latest uploaded working dashboard source before v6.8"
     },
     {
       "filename": "NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx",
@@ -34,20 +24,30 @@
       "size_bytes": 6879661,
       "sha256": "f84e65ff1f691b8678c27a88707f65c89465beb1c4da1707668d39f06a2620a6",
       "role": "latest active roster log checkpoint"
+    }
+  ],
+  "not_included": [
+    {
+      "filename": "NW_PRJ_Tech_Roster_Dashboard_v6_7_STATUS_DICTIONARY_WEBSAFE-5-28-2026.xlsx",
+      "sha256": "a1a11c50606898ca62de69ef0b4777427f67ae710c532608f15a24909e21933d",
+      "reason": "optional prior dashboard source; not in local checkpoint bundle"
+    },
+    {
+      "filename": "NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md",
+      "reason": "committed as UTF-8 text in artifacts/nw_prj_dashboard_v6_8/"
     },
     {
       "filename": "35ef5c83-2d95-4264-9cc2-4a99685abed3.png",
-      "size_bytes": 42073,
       "sha256": "831d280eaa9152bf9957f8c04311a911a4693ab17011adf67bb6095175c999d8",
-      "role": "visual screenshot proving Start Here blank-position issue and tab color feedback"
+      "reason": "visual screenshot; not in local checkpoint bundle"
     },
     {
       "filename": "11e11659-6121-482c-be4a-76a4c7b85584.png",
-      "size_bytes": 87702,
       "sha256": "9be79eb2ce3e413d031e6b4fbefb81577ac67836ee951155541705cdf8dee638",
-      "role": "visual screenshot proving dashboard summary / tab color feedback"
+      "reason": "visual screenshot; not in local checkpoint bundle"
     }
   ],
+  "package": "python scripts/artifacts/package_nw_prj_v6_8_checkpoint.py",
   "decode": "python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py",
-  "notes": "Binary files are stored as a base64 zip because the connector supports UTF-8 text commits. Decode after pulling repo."
+  "notes": "Generator-critical xlsx workbooks are stored as an AES-encrypted zip (pyzipper). Password is external only."
 }

--- a/artifacts/nw_prj_dashboard_v6_8/manifest.json
+++ b/artifacts/nw_prj_dashboard_v6_8/manifest.json
@@ -1,0 +1,53 @@
+{
+  "checkpoint": "NW PRJ Tech Roster Dashboard v6.8 resolution ledger checkpoint",
+  "date": "2026-05-28",
+  "archive": "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip",
+  "archive_b64": "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64",
+  "archive_sha256": "f04822901a12e6954cabd8b777af9af1432b8cb0a5fb983fc8f0a4650d1d4fd9",
+  "contents": [
+    {
+      "filename": "NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx",
+      "size_bytes": 58616,
+      "sha256": "ec502e1ff6b00c5ce22ead72a4000cb8c3164bcd9711bb71a1b86df9caa55497",
+      "role": "latest generated v6.8 dashboard checkpoint"
+    },
+    {
+      "filename": "NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md",
+      "size_bytes": 2221,
+      "sha256": "37be4871493deccd5666bcafd4b5a469f82bcdcea98474f3468a70bd94cdd4ad",
+      "role": "repo carryover notes/gaps/risks/targets from v6.8 sprint"
+    },
+    {
+      "filename": "NW_PRJ_Tech_Roster_Dashboard_v6_7_STATUS_DICTIONARY_WEBSAFE-5-28-2026.xlsx",
+      "size_bytes": 75784,
+      "sha256": "a1a11c50606898ca62de69ef0b4777427f67ae710c532608f15a24909e21933d",
+      "role": "latest uploaded working dashboard source before v6.8"
+    },
+    {
+      "filename": "NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx",
+      "size_bytes": 3079538,
+      "sha256": "7ebbcbc8cf4fbd267c9717ebd4e9bef48ed7c8afde4fdb266a4ea19bf22ee027",
+      "role": "manual admin scratch/control copy checkpoint"
+    },
+    {
+      "filename": "INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx",
+      "size_bytes": 6879661,
+      "sha256": "f84e65ff1f691b8678c27a88707f65c89465beb1c4da1707668d39f06a2620a6",
+      "role": "latest active roster log checkpoint"
+    },
+    {
+      "filename": "35ef5c83-2d95-4264-9cc2-4a99685abed3.png",
+      "size_bytes": 42073,
+      "sha256": "831d280eaa9152bf9957f8c04311a911a4693ab17011adf67bb6095175c999d8",
+      "role": "visual screenshot proving Start Here blank-position issue and tab color feedback"
+    },
+    {
+      "filename": "11e11659-6121-482c-be4a-76a4c7b85584.png",
+      "size_bytes": 87702,
+      "sha256": "9be79eb2ce3e413d031e6b4fbefb81577ac67836ee951155541705cdf8dee638",
+      "role": "visual screenshot proving dashboard summary / tab color feedback"
+    }
+  ],
+  "decode": "python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py",
+  "notes": "Binary files are stored as a base64 zip because the connector supports UTF-8 text commits. Decode after pulling repo."
+}

--- a/artifacts/nw_prj_dashboard_v6_8/payload_checksums.sha256
+++ b/artifacts/nw_prj_dashboard_v6_8/payload_checksums.sha256
@@ -1,0 +1,4 @@
+3e3604c2137017e7754f1d2c22b9fb2e8ef856b255cee6d326bf205a8fa140e8  NW_PRJ_v6_8_checkpoint_payload_2026-05-28.zip
+ec502e1ff6b00c5ce22ead72a4000cb8c3164bcd9711bb71a1b86df9caa55497  NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx
+7ebbcbc8cf4fbd267c9717ebd4e9bef48ed7c8afde4fdb266a4ea19bf22ee027  NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx
+f84e65ff1f691b8678c27a88707f65c89465beb1c4da1707668d39f06a2620a6  INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit>=1.32.0
 mcp[cli]>=1.0.0
 openpyxl>=3.1.0
 python-docx>=1.1.0
+pyzipper>=0.3.6

--- a/scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
+++ b/scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Decode the NW PRJ v6.8 checkpoint artifact archive.
+
+Run from repo root:
+    python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = ROOT / "artifacts" / "nw_prj_dashboard_v6_8"
+B64_PATH = ARTIFACT_DIR / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64"
+MANIFEST_PATH = ARTIFACT_DIR / "manifest.json"
+OUT_DIR = ROOT / "RecoveredArtifacts" / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28"
+ZIP_PATH = OUT_DIR / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip"
+
+
+def main() -> int:
+    if not B64_PATH.exists():
+        raise FileNotFoundError(f"Missing base64 archive: {B64_PATH}")
+    if not MANIFEST_PATH.exists():
+        raise FileNotFoundError(f"Missing manifest: {MANIFEST_PATH}")
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    expected = manifest["archive_sha256"]
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    archive_bytes = base64.b64decode(B64_PATH.read_text(encoding="ascii"))
+    actual = hashlib.sha256(archive_bytes).hexdigest()
+    if actual != expected:
+        raise RuntimeError(f"Checksum mismatch: expected {expected}, got {actual}")
+
+    ZIP_PATH.write_bytes(archive_bytes)
+    with zipfile.ZipFile(ZIP_PATH, "r") as zf:
+        zf.extractall(OUT_DIR)
+
+    print(f"Decoded archive: {ZIP_PATH}")
+    print(f"Extracted files to: {OUT_DIR}")
+    print(f"SHA-256 verified: {actual}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
+++ b/scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
@@ -1,47 +1,101 @@
 #!/usr/bin/env python3
-"""Decode the NW PRJ v6.8 checkpoint artifact archive.
+"""Extract the NW PRJ v6.8 AES-encrypted checkpoint payload.
 
 Run from repo root:
+    python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
+
+Password via environment (non-interactive):
+    $env:NW_PRJ_CHECKPOINT_PASSWORD = "your-secret"
     python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py
 """
 from __future__ import annotations
 
-import base64
+import getpass
 import hashlib
 import json
-import zipfile
+import os
+import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 ARTIFACT_DIR = ROOT / "artifacts" / "nw_prj_dashboard_v6_8"
-B64_PATH = ARTIFACT_DIR / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip.b64"
 MANIFEST_PATH = ARTIFACT_DIR / "manifest.json"
 OUT_DIR = ROOT / "RecoveredArtifacts" / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28"
-ZIP_PATH = OUT_DIR / "NW_PRJ_v6_8_checkpoint_artifacts_2026-05-28.zip"
+
+
+def _require_pyzipper():
+    try:
+        import pyzipper
+    except ImportError as e:
+        raise RuntimeError("pyzipper is required: pip install pyzipper") from e
+    return pyzipper
+
+
+def _password() -> bytes:
+    env = os.environ.get("NW_PRJ_CHECKPOINT_PASSWORD", "").strip()
+    if env:
+        return env.encode("utf-8")
+    pw = getpass.getpass("Archive password: ")
+    if not pw:
+        raise RuntimeError("Password required")
+    return pw.encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _verify_extracted(manifest: dict, out_dir: Path) -> None:
+    expected = {
+        e["filename"]: e
+        for e in manifest.get("contents", [])
+        if e["filename"].endswith(".xlsx")
+    }
+    for name, entry in expected.items():
+        path = out_dir / name
+        if not path.is_file():
+            raise FileNotFoundError(f"Missing extracted file: {path}")
+        actual = _sha256_file(path)
+        if actual.lower() != entry["sha256"].lower():
+            raise RuntimeError(f"Checksum mismatch for {name}: expected {entry['sha256']}, got {actual}")
 
 
 def main() -> int:
-    if not B64_PATH.exists():
-        raise FileNotFoundError(f"Missing base64 archive: {B64_PATH}")
-    if not MANIFEST_PATH.exists():
+    if not MANIFEST_PATH.is_file():
         raise FileNotFoundError(f"Missing manifest: {MANIFEST_PATH}")
 
     manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
-    expected = manifest["archive_sha256"]
+    rel = manifest.get("payload_path", "")
+    archive_path = ROOT / rel.replace("/", os.sep)
+    if not archive_path.is_file():
+        raise FileNotFoundError(f"Missing encrypted archive: {archive_path}")
 
+    expected_archive_sha = manifest.get("archive_sha256", "")
+    actual_archive_sha = hashlib.sha256(archive_path.read_bytes()).hexdigest()
+    if expected_archive_sha and actual_archive_sha.lower() != expected_archive_sha.lower():
+        raise RuntimeError(
+            f"Archive checksum mismatch: expected {expected_archive_sha}, got {actual_archive_sha}"
+        )
+
+    pyzipper = _require_pyzipper()
+    password = _password()
     OUT_DIR.mkdir(parents=True, exist_ok=True)
-    archive_bytes = base64.b64decode(B64_PATH.read_text(encoding="ascii"))
-    actual = hashlib.sha256(archive_bytes).hexdigest()
-    if actual != expected:
-        raise RuntimeError(f"Checksum mismatch: expected {expected}, got {actual}")
 
-    ZIP_PATH.write_bytes(archive_bytes)
-    with zipfile.ZipFile(ZIP_PATH, "r") as zf:
+    with pyzipper.AESZipFile(archive_path, "r") as zf:
+        zf.setpassword(password)
         zf.extractall(OUT_DIR)
 
-    print(f"Decoded archive: {ZIP_PATH}")
+    _verify_extracted(manifest, OUT_DIR)
+
     print(f"Extracted files to: {OUT_DIR}")
-    print(f"SHA-256 verified: {actual}")
+    print(f"Archive SHA-256 verified: {actual_archive_sha}")
+    for entry in manifest.get("contents", []):
+        if entry["filename"].endswith(".xlsx"):
+            print(f"  OK  {entry['filename']}")
     return 0
 
 

--- a/scripts/artifacts/package_nw_prj_v6_8_checkpoint.py
+++ b/scripts/artifacts/package_nw_prj_v6_8_checkpoint.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Package NW PRJ v6.8 generator-critical workbooks into an AES-encrypted zip.
+
+Run from repo root:
+    python scripts/artifacts/package_nw_prj_v6_8_checkpoint.py
+
+Password via environment (non-interactive):
+    $env:NW_PRJ_CHECKPOINT_PASSWORD = "your-secret"
+    python scripts/artifacts/package_nw_prj_v6_8_checkpoint.py
+
+Never commit the password.
+"""
+from __future__ import annotations
+
+import getpass
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = ROOT / "artifacts" / "nw_prj_dashboard_v6_8"
+PAYLOAD_DIR = ARTIFACT_DIR / "payload"
+SOURCE_DIR = ROOT / "Workbook Payload Artifacts"
+MANIFEST_PATH = ARTIFACT_DIR / "manifest.json"
+ARCHIVE_NAME = "NW_PRJ_v6_8_checkpoint_payload_2026-05-28.zip"
+ARCHIVE_PATH = PAYLOAD_DIR / ARCHIVE_NAME
+CHECKSUMS_PATH = ARTIFACT_DIR / "payload_checksums.sha256"
+
+EXPECTED_XLSX = [
+    "NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx",
+    "NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx",
+    "INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx",
+]
+
+
+def _require_pyzipper():
+    try:
+        import pyzipper
+    except ImportError as e:
+        raise RuntimeError("pyzipper is required: pip install pyzipper") from e
+    return pyzipper
+
+
+def _sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _password() -> bytes:
+    env = os.environ.get("NW_PRJ_CHECKPOINT_PASSWORD", "").strip()
+    if env:
+        return env.encode("utf-8")
+    pw = getpass.getpass("Archive password (not stored in repo): ")
+    if not pw:
+        raise RuntimeError("Password required")
+    confirm = getpass.getpass("Confirm password: ")
+    if pw != confirm:
+        raise RuntimeError("Passwords do not match")
+    return pw.encode("utf-8")
+
+
+def _verify_sources(manifest: dict) -> list[Path]:
+    if not SOURCE_DIR.is_dir():
+        raise FileNotFoundError(f"Missing source folder: {SOURCE_DIR}")
+
+    by_name = {e["filename"]: e for e in manifest.get("contents", []) if e["filename"].endswith(".xlsx")}
+    paths: list[Path] = []
+    for name in EXPECTED_XLSX:
+        path = SOURCE_DIR / name
+        if not path.is_file():
+            raise FileNotFoundError(f"Missing workbook: {path}")
+        actual = _sha256_file(path)
+        entry = by_name.get(name)
+        if entry and actual.lower() != entry["sha256"].lower():
+            raise RuntimeError(f"Checksum mismatch for {name}: expected {entry['sha256']}, got {actual}")
+        if entry and path.stat().st_size != entry["size_bytes"]:
+            raise RuntimeError(f"Size mismatch for {name}: expected {entry['size_bytes']}, got {path.stat().st_size}")
+        paths.append(path)
+    return paths
+
+
+def main() -> int:
+    if not MANIFEST_PATH.is_file():
+        raise FileNotFoundError(f"Missing manifest: {MANIFEST_PATH}")
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    sources = _verify_sources(manifest)
+    password = _password()
+    pyzipper = _require_pyzipper()
+
+    PAYLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    with pyzipper.AESZipFile(
+        ARCHIVE_PATH,
+        "w",
+        compression=pyzipper.ZIP_DEFLATED,
+        encryption=pyzipper.WZ_AES,
+    ) as zf:
+        zf.setpassword(password)
+        for path in sources:
+            zf.write(path, arcname=path.name)
+
+    archive_sha = hashlib.sha256(ARCHIVE_PATH.read_bytes()).hexdigest()
+    lines = [f"{archive_sha}  {ARCHIVE_NAME}"]
+    for path in sources:
+        lines.append(f"{_sha256_file(path)}  {path.name}")
+    CHECKSUMS_PATH.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    print(f"Created encrypted archive: {ARCHIVE_PATH}")
+    print(f"Archive SHA-256: {archive_sha}")
+    print(f"Wrote checksums: {CHECKSUMS_PATH}")
+    print(f"Files packaged: {len(sources)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Preserves the NW PRJ dashboard v6.8 checkpoint metadata, encrypted payload, recovery tooling, and doctrine so the next machine can pull the artifact map, checksums, and restore command in-repo.

## Payload status

The v6.8 generator-critical checkpoint payload has been added and pushed to this branch.

Storage method:
- AES-encrypted zip (pyzipper); password stored externally — never in repo

Restore:
- See \rtifacts/nw_prj_dashboard_v6_8/README.md\
- Run \python scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py\

Payload manifest:
- See \rtifacts/nw_prj_dashboard_v6_8/manifest.json\

Included (3 xlsx files):
- v6.8 dashboard (\NW_PRJ_Tech_Roster_Dashboard_v6_8_RESOLUTION_LEDGER_WEBSAFE.xlsx\)
- manual admin scratch (\NW PRJ Tech hours 5-27-2026 - Khadejah and Alejandro Updates - Manually Updated 5x.xlsx\)
- May billing roster log (\INTERNAL_May_Billing_Active_Roster_Log_2026-05-28-update so that partial hours are flagged before submission.xlsx\)

Not included (listed in manifest \
ot_included\):
- v6.7 dashboard source
- 2 PNG screenshots

Carryover notes committed as UTF-8: \NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md\

## Checkpoint doctrine preserved

- \Addressed\ is not the same as \Resolved\.
- \ROSTER CONFIRMED\ means roster evidence supports a proposed value, not that admin scratch has already been updated.
- Gray rows stay quiet unless new evidence revives them.
- Column A review status overrides queue coloring.
- Excel Web repair prefixes are STOP-SHIP indicators.
- v6.8 \Resolved_Queue\ is values-routed; dynamic linked routing belongs to v7.x.

## Committed on this branch

- \rtifacts/nw_prj_dashboard_v6_8/README.md\
- \rtifacts/nw_prj_dashboard_v6_8/manifest.json\
- \rtifacts/nw_prj_dashboard_v6_8/payload/NW_PRJ_v6_8_checkpoint_payload_2026-05-28.zip\
- \rtifacts/nw_prj_dashboard_v6_8/payload_checksums.sha256\
- \rtifacts/nw_prj_dashboard_v6_8/NW_PRJ_Dashboard_v6_8_Repo_Carryover_Notes.md\
- \scripts/artifacts/decode_nw_prj_v6_8_checkpoint.py\
- \scripts/artifacts/package_nw_prj_v6_8_checkpoint.py\

Leave as draft until merge to main is decided.