### PR TITLE
Add contextual billing artifact exporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,8 @@ billing_runs_tmp/
 # Local script env overrides (secrets; never commit)
 scripts/online_env.local.ps1
 scripts/*.local.ps1
+scripts/artifacts/*.local
+
+# Local payload drop zone and decode output — never commit raw internal workbooks
+Workbook Payload Artifacts/
+RecoveredArtifacts/

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Generate leadership-safe contextualized billing workbooks, mismatch reports, and
 - **Rules (canonical):** [`docs/BILLING_WORK_CONTEXT_RULES.md`](docs/BILLING_WORK_CONTEXT_RULES.md)
 - **Output quality:** [`docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md`](docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md)
 - **CLI / usage:** [`docs/BILLING_CONTEXT_EXPORTER.md`](docs/BILLING_CONTEXT_EXPORTER.md)
-- **Run:** `python -m triage.billing_context.cli --track-hours ... --april-context ... --out-dir Outputs --html`
+- **Sprint carryover:** [`docs/ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md`](docs/ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md)
+- **Run:** `python -m triage.billing_context.cli --track-hours ... --april-context ... --out-dir Outputs --html --zip`
 
 Related admin posture pipeline: [`docs/2026-05-20-admin-billing-context-pipeline.md`](docs/2026-05-20-admin-billing-context-pipeline.md)
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ conditional formatting, or shared-string references.
 - **MCP-first** — every triage phase is also an MCP tool, so Augment Code can
   orchestrate the full pipeline from a chat prompt.
 
+### Billing context exporter (April/May contextualized artifacts)
+
+Generate leadership-safe contextualized billing workbooks, mismatch reports, and a browser dashboard:
+
+- **Rules (canonical):** [`docs/BILLING_WORK_CONTEXT_RULES.md`](docs/BILLING_WORK_CONTEXT_RULES.md)
+- **Output quality:** [`docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md`](docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md)
+- **CLI / usage:** [`docs/BILLING_CONTEXT_EXPORTER.md`](docs/BILLING_CONTEXT_EXPORTER.md)
+- **Run:** `python -m triage.billing_context.cli --track-hours ... --april-context ... --out-dir Outputs --html`
+
+Related admin posture pipeline: [`docs/2026-05-20-admin-billing-context-pipeline.md`](docs/2026-05-20-admin-billing-context-pipeline.md)
+
 ### NW PRJ dashboard v6 (Tech Roster)
 
 Contract, configs, generator, and validators for the NW PRJ Tech Roster Dashboard workflow:

--- a/docs/ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md
+++ b/docs/ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md
@@ -1,0 +1,33 @@
+# Artifact Sprint Carryover: 2026-05-30
+
+Lessons from the May 2026 billing artifact sprint, encoded for the repo.
+
+Related docs:
+
+- [`BILLING_WORK_CONTEXT_RULES.md`](BILLING_WORK_CONTEXT_RULES.md)
+- [`BILLING_SUMMARY_TEXT_QUALITY.md`](BILLING_SUMMARY_TEXT_QUALITY.md)
+- [`ADMIN_LOG_FORMAT_PRESERVATION.md`](ADMIN_LOG_FORMAT_PRESERVATION.md)
+- [`BILLING_CONTEXT_EXPORTER.md`](BILLING_CONTEXT_EXPORTER.md)
+
+## Lessons
+
+- Return one ZIP bundle when multiple artifacts are produced (`--zip`).
+- Verify every linked output path exists before reporting it (manifest validation in CLI).
+- Separate leadership artifacts from internal review artifacts (leadership XLSX vs `--internal-xlsx`).
+- Leadership outputs must not expose raw provenance, confidence fields, private notes, or internal mismatch machinery.
+- Work Context must be complete — no ellipses, no clipped generated text (see text-quality doc).
+- Charts are required for monthly billing summaries.
+- Static HTML dashboard is useful, but all workbook-sourced text must be escaped.
+- CSV outputs must neutralize formula prefixes (`=`, `+`, `-`, `@`).
+- Internal admin log copy formatting is a separate workflow and must preserve the uploaded control workbook (see admin log doc).
+- Context rules must handle April Saturdays, May Saturdays, evenings, day hours, and warehouse/inventory logistics.
+- Do not commit real billing workbooks — engines, docs, tests, and synthetic fixtures only.
+
+## Leadership vs internal surfaces
+
+| Surface | Includes | Excludes |
+|---------|----------|----------|
+| Leadership XLSX | Date, Tech, Hours, Work Context, charts | Source row/sheet, context reason, raw assignment, confidence |
+| Internal XLSX / HTML / CSV | Full provenance, mismatches, reason, notes | — |
+
+Tracker Import tab is internal-only unless `--include-tracker-import` is explicitly passed.

--- a/docs/BILLING_CONTEXT_EXPORTER.md
+++ b/docs/BILLING_CONTEXT_EXPORTER.md
@@ -16,10 +16,18 @@ python -m triage.billing_context.cli \
   --admin-copy "<admin-copy.xlsx>" \
   --dashboard "<dashboard.xlsx>" \
   --out-dir Outputs \
-  --html
+  --html \
+  --zip \
+  --internal-xlsx
 ```
 
-Drop input workbooks in [`Candidates/`](../Candidates/) locally (gitignored contents).
+Optional flags:
+
+- `--include-tracker-import` — add internal Tracker Import sheet to monthly summaries
+- `--internal-xlsx` — separate internal detail workbook with provenance columns
+- `--zip` — bundle all outputs into one ZIP with manifest validation
+
+Sprint carryover: [`ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md`](ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md)
 
 ## Outputs
 

--- a/docs/BILLING_CONTEXT_EXPORTER.md
+++ b/docs/BILLING_CONTEXT_EXPORTER.md
@@ -1,0 +1,50 @@
+# Billing Context Exporter
+
+Generate contextualized April/May billing artifacts and a self-contained browser dashboard.
+
+**Classification rules (canonical):** [`BILLING_WORK_CONTEXT_RULES.md`](BILLING_WORK_CONTEXT_RULES.md)
+
+**Output quality / leadership boundaries:** [`CONTEXTUALIZED_BILLING_ARTIFACTS.md`](CONTEXTUALIZED_BILLING_ARTIFACTS.md)
+
+## Command
+
+```bash
+python -m triage.billing_context.cli \
+  --track-hours "<track-hours.xlsx>" \
+  --april-context "<task-context.xlsx>" \
+  --roster-log "<roster-log.xlsx>" \
+  --admin-copy "<admin-copy.xlsx>" \
+  --dashboard "<dashboard.xlsx>" \
+  --out-dir Outputs \
+  --html
+```
+
+Drop input workbooks in [`Candidates/`](../Candidates/) locally (gitignored contents).
+
+## Outputs
+
+| File | Purpose |
+|------|---------|
+| `Neuron_Project_Hours_April_May_2026_CONTEXTUALIZED_WEBSAFE.xlsx` | Row-level context by month + summary charts |
+| `April_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx` | April leadership summary with charts |
+| `May_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx` | May leadership summary with charts |
+| `billing_context_dashboard.html` | Self-contained browser review (no Office, no network) |
+| `billing_context_mismatches.json` / `.csv` | Internal cross-source mismatch report |
+
+## Validation
+
+```bash
+python -m pytest tests/test_billing_context_rules.py tests/test_billing_context_reconcile.py tests/test_billing_context_html.py -q
+```
+
+Stop-ship checks (CLI enforces language and formula-error scan):
+
+- `Neuron Installation` must not dominate work context
+- Summary workbooks must contain charts
+- Leadership workbooks must not contain blocked language or internal fields
+- No `#REF!`, `#VALUE!`, etc.
+
+## Related
+
+- Admin posture pipeline: [`2026-05-20-admin-billing-context-pipeline.md`](2026-05-20-admin-billing-context-pipeline.md)
+- NW PRJ dashboard (separate artifact family): [`NW_PRJ_DASHBOARD_V6_CONTRACT.md`](NW_PRJ_DASHBOARD_V6_CONTRACT.md)

--- a/docs/BILLING_WORK_CONTEXT_RULES.md
+++ b/docs/BILLING_WORK_CONTEXT_RULES.md
@@ -1,0 +1,121 @@
+# Billing Work Context Rules
+
+**Canonical classification spec.** When classification logic changes, update this document in the same PR as code. Tests in `tests/test_billing_context_rules.py` must cover every rule below.
+
+Related docs:
+
+- Output quality and leadership boundaries: [`CONTEXTUALIZED_BILLING_ARTIFACTS.md`](CONTEXTUALIZED_BILLING_ARTIFACTS.md)
+- CLI and exporter usage: [`BILLING_CONTEXT_EXPORTER.md`](BILLING_CONTEXT_EXPORTER.md)
+- Admin posture, Friday batch, language guardrails: [`2026-05-20-admin-billing-context-pipeline.md`](2026-05-20-admin-billing-context-pipeline.md)
+
+Implementation: [`triage/billing_context/context_rules.py`](../triage/billing_context/context_rules.py)
+
+---
+
+## 1. Placeholder labels (suspect by default)
+
+These assignment labels are **placeholders**, not acceptable final work context when better evidence exists:
+
+- `Neuron Installation`
+- `installation` / `install`
+- `neuron install` / `neuron installation`
+
+Most hours must **not** be summarized as installation work unless task evidence directly supports installation activity.
+
+When a placeholder is replaced, record an internal mismatch (`placeholder_assignment_replaced`); leadership exports show the resolved context only.
+
+---
+
+## 2. Context hierarchy (evidence order)
+
+Apply evidence in this order. Stop at the first decisive source:
+
+1. **Task tracker text** — highest priority; keyword classification from admin billing context submission.
+2. **Non-placeholder roster/project assignment** — retain when task text is absent or inconclusive.
+3. **Timing and day-pattern rules** — see §3; used when steps 1–2 do not resolve context.
+4. **Explicit operator notes** — free-text fields in tracker or roster rows.
+5. **Last-resort generic category** — `Unknown / Needs Review` only when no better source exists.
+
+---
+
+## 3. Timing and day-pattern rules
+
+These are **rules**, not suggestions. They reflect April–May 2026 operational reality.
+
+| When | Default work context | Notes |
+|------|---------------------|-------|
+| **April Saturdays** | `Deployment Support` | April billing was deployment-heavy on Saturdays unless task evidence says otherwise |
+| **May+ Saturdays** | `Inventory Management` (default) or `Configuration` | May onward: configuration and inventory work — **not** deployment-first, **not** logistics-first |
+| **Evening hours** (start ≥ 16:00 or end ≥ 18:00) | `Inventory Management` (default) or `Configuration` | Evenings are configuration/inventory work — **not** `Logistics` |
+| **Sundays** | `Logistics` | Cleanup operations, stock movement, warehouse recovery |
+| **Weekday daytime** | `Mixed Operational Support` | Hospital stock delivery, logistics runs, inventory management, incident response, ticket coordination, client coordination |
+| **Warehouse / staging / stock** (in task text) | `Inventory Management & Logistics` | When text mentions warehouse, staging, stock, delivery, pickup |
+
+### Anti-patterns
+
+- Do **not** classify May+ Saturday or evening hours as `Logistics` unless task text explicitly describes delivery or cleanup.
+- Do **not** use `Inventory Management & Logistics` as a lazy timing fallback for May evenings or Saturdays.
+- April vs May **Saturday behavior differs by design** (deployment-heavy April vs config/inventory May+).
+
+### Configuration vs Inventory Management (May+ timing fallback)
+
+When timing rules apply but task text does not decide:
+
+- Default to **`Inventory Management`**.
+- Use **`Configuration`** when assignment or notes hint at build, imaging, setup, or device configuration language.
+
+---
+
+## 4. Task-text keyword buckets
+
+When task tracker text is present, classify by keywords (first match wins):
+
+| Keywords (case-insensitive) | Work context |
+|----------------------------|--------------|
+| configure, configuration, imaged, image, setup, build | `Configuration` |
+| inventory, warehouse, stock, staging, deliver, delivery, pickup, logistics | `Inventory Management & Logistics` |
+| deploy, deployment, go live, go-live, floor support | `Deployment Support` |
+| incident, break/fix, outage, urgent, support issue | `Incident Response` |
+| ticket, servicenow, ritm, req | `Ticket Coordination` |
+| client, pm, coordination, coordinate, follow up, follow-up | `Client Coordination` |
+
+If no keyword matches, fall through to hierarchy steps 2–5.
+
+---
+
+## 5. Allowed work-context labels
+
+| Label | Meaning |
+|-------|---------|
+| `Configuration` | Device imaging, build, setup, configuration work |
+| `Inventory Management` | Stock control, staging, warehouse operations without primary delivery |
+| `Inventory Management & Logistics` | Combined inventory and stock movement / delivery |
+| `Deployment Support` | Go-live, floor support, deployment activity |
+| `Incident Response` | Break/fix, outage, urgent support |
+| `Ticket Coordination` | ServiceNow / RITM / REQ coordination |
+| `Client Coordination` | PM follow-up, client-facing coordination |
+| `Logistics` | Delivery runs, cleanup, stock movement (especially Sundays) |
+| `Mixed Operational Support` | Weekday daytime blend when no single category dominates |
+| `Unknown / Needs Review` | No decisive evidence — internal review required |
+
+---
+
+## 6. Leadership vs internal surfaces
+
+### Leadership artifacts (contextualized `.xlsx`)
+
+Include: `Date`, `Tech`, `Hours`, `Work Context`, optional `Original Assignment`, `Start Time`, `End Time`.
+
+**Exclude:** confidence, context-reason, raw task notes, pay-petition framing, internal exception machinery, draft reasoning, review scaffolding.
+
+Scan all string cells for blocked language per [`admin_billing_context_rules.py`](../triage/admin_billing_context_rules.py) before export.
+
+### Internal artifacts (HTML dashboard, mismatch JSON/CSV)
+
+May include: context reason, confidence, full notes, cross-source hour deltas, partial-hour flags, dashboard unresolved rows.
+
+---
+
+## 7. Maintenance rule
+
+> Classification changes require **both** an update to this document **and** matching tests. Do not change `context_rules.py` behavior without updating §3–§4 here.

--- a/docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md
+++ b/docs/CONTEXTUALIZED_BILLING_ARTIFACTS.md
@@ -47,6 +47,8 @@ Leadership-facing billing artifacts must not include employee pay-petition frami
 
 Pay-difference analysis belongs in a separate comparison workbook or internal review artifact.
 
+**Work context classification rules:** see [`BILLING_WORK_CONTEXT_RULES.md`](BILLING_WORK_CONTEXT_RULES.md).
+
 ## Failure modes
 
 Stop and revise if any leadership-facing workbook:

--- a/tests/test_billing_context_html.py
+++ b/tests/test_billing_context_html.py
@@ -30,3 +30,26 @@ def test_html_dashboard_exports(tmp_path):
     assert "Inventory Management" in text
     assert "no Office license required" in text
     assert "https://" not in text
+
+
+def test_html_escapes_script_breakout(tmp_path):
+    entries = [
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="May",
+            row_number=2,
+            tech="</script><img src=x onerror=alert(1)>",
+            work_date=date(2026, 5, 14),
+            start_time=None,
+            end_time=None,
+            hours=1,
+            original_assignment="test",
+            work_context="Configuration",
+            context_reason="</script>",
+        )
+    ]
+    out = tmp_path / "dashboard.html"
+    export_html_dashboard(entries, [], str(out))
+    text = out.read_text(encoding="utf-8")
+    assert "<\\/script>" in text
+    assert "function esc(" in text

--- a/tests/test_billing_context_html.py
+++ b/tests/test_billing_context_html.py
@@ -1,0 +1,32 @@
+from datetime import date, time
+from pathlib import Path
+
+from triage.billing_context.html_dashboard import export_html_dashboard
+from triage.billing_context.models import WorkEntry
+
+
+def test_html_dashboard_exports(tmp_path):
+    entries = [
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="May",
+            row_number=2,
+            tech="Example Tech",
+            work_date=date(2026, 5, 30),
+            start_time=time(9, 0),
+            end_time=time(17, 0),
+            hours=8,
+            original_assignment="Neuron Installation",
+            work_context="Inventory Management",
+            context_reason="May+ Saturday rule applied.",
+        )
+    ]
+
+    out = tmp_path / "dashboard.html"
+    export_html_dashboard(entries, [], str(out))
+
+    text = out.read_text(encoding="utf-8")
+    assert "Billing Context Dashboard" in text
+    assert "Inventory Management" in text
+    assert "no Office license required" in text
+    assert "https://" not in text

--- a/tests/test_billing_context_reconcile.py
+++ b/tests/test_billing_context_reconcile.py
@@ -1,0 +1,55 @@
+from datetime import date, time
+
+from triage.billing_context.models import WorkEntry
+from triage.billing_context.reconcile import find_all_mismatches, find_context_mismatches
+
+
+def test_placeholder_mismatch_created():
+    entries = [
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="April",
+            row_number=2,
+            tech="Example Tech",
+            work_date=date(2026, 4, 26),
+            start_time=time(9, 0),
+            end_time=time(17, 0),
+            hours=8,
+            original_assignment="Neuron Installation",
+            work_context="Deployment Support",
+            context_reason="April Saturday rule applied.",
+            notes="",
+            confidence="medium",
+        )
+    ]
+
+    mismatches = find_context_mismatches(entries)
+    assert len(mismatches) == 1
+    assert mismatches[0].mismatch_type == "placeholder_assignment_replaced"
+
+
+def test_hours_delta_mismatch():
+    entries = [
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="May",
+            row_number=2,
+            tech="Example Tech",
+            work_date=date(2026, 5, 14),
+            start_time=time(9, 0),
+            end_time=time(17, 0),
+            hours=8,
+            original_assignment="Configuration",
+            work_context="Configuration",
+            context_reason="Non-placeholder assignment retained.",
+        )
+    ]
+    roster_index = {("example tech", "2026-05-14"): 6.0}
+    mismatches = find_all_mismatches(entries, roster_path=None)
+    cross = [m for m in mismatches if m.mismatch_type == "hours_delta"]
+    assert not cross
+
+    from triage.billing_context.reconcile import find_cross_source_mismatches
+
+    cross_only = find_cross_source_mismatches(entries, roster_index=roster_index)
+    assert any(m.mismatch_type == "hours_delta" for m in cross_only)

--- a/tests/test_billing_context_reconcile.py
+++ b/tests/test_billing_context_reconcile.py
@@ -1,7 +1,13 @@
 from datetime import date, time
 
-from triage.billing_context.models import WorkEntry
-from triage.billing_context.reconcile import find_all_mismatches, find_context_mismatches
+from triage.billing_context.models import Mismatch, WorkEntry
+from triage.billing_context.reconcile import (
+    aggregate_daily_track_hours,
+    find_all_mismatches,
+    find_context_mismatches,
+    find_cross_source_mismatches,
+    parse_time,
+)
 
 
 def test_placeholder_mismatch_created():
@@ -18,8 +24,6 @@ def test_placeholder_mismatch_created():
             original_assignment="Neuron Installation",
             work_context="Deployment Support",
             context_reason="April Saturday rule applied.",
-            notes="",
-            confidence="medium",
         )
     ]
 
@@ -28,7 +32,48 @@ def test_placeholder_mismatch_created():
     assert mismatches[0].mismatch_type == "placeholder_assignment_replaced"
 
 
-def test_hours_delta_mismatch():
+def test_hours_delta_uses_daily_aggregate():
+    entries = [
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="May",
+            row_number=2,
+            tech="Example Tech",
+            work_date=date(2026, 5, 14),
+            start_time=time(9, 0),
+            end_time=time(12, 0),
+            hours=4,
+            original_assignment="Configuration",
+            work_context="Configuration",
+            context_reason="",
+        ),
+        WorkEntry(
+            source="x.xlsx",
+            sheet_name="May",
+            row_number=3,
+            tech="Example Tech",
+            work_date=date(2026, 5, 14),
+            start_time=time(13, 0),
+            end_time=time(17, 0),
+            hours=4,
+            original_assignment="Configuration",
+            work_context="Configuration",
+            context_reason="",
+        ),
+    ]
+    daily, _ = aggregate_daily_track_hours(entries)
+    assert daily[("example tech", "2026-05-14")] == 8.0
+
+    roster_index = {("example tech", "2026-05-14"): 8.0}
+    cross = find_cross_source_mismatches(
+        entries,
+        roster_index=roster_index,
+        roster_enabled=True,
+    )
+    assert not any(m.mismatch_type == "hours_delta" for m in cross)
+
+
+def test_missing_source_only_when_enabled():
     entries = [
         WorkEntry(
             source="x.xlsx",
@@ -41,15 +86,37 @@ def test_hours_delta_mismatch():
             hours=8,
             original_assignment="Configuration",
             work_context="Configuration",
-            context_reason="Non-placeholder assignment retained.",
+            context_reason="",
         )
     ]
-    roster_index = {("example tech", "2026-05-14"): 6.0}
-    mismatches = find_all_mismatches(entries, roster_path=None)
-    cross = [m for m in mismatches if m.mismatch_type == "hours_delta"]
-    assert not cross
+    disabled = find_cross_source_mismatches(entries, roster_enabled=False)
+    assert not any(m.mismatch_type == "missing_in_source" for m in disabled)
 
-    from triage.billing_context.reconcile import find_cross_source_mismatches
+    enabled = find_cross_source_mismatches(entries, roster_index={}, roster_enabled=True)
+    assert any(m.mismatch_type == "missing_in_source" for m in enabled)
 
-    cross_only = find_cross_source_mismatches(entries, roster_index=roster_index)
-    assert any(m.mismatch_type == "hours_delta" for m in cross_only)
+
+def test_parse_time_datetime_string():
+    assert parse_time("2026-05-14 18:00") == time(18, 0)
+
+
+def test_csv_injection_neutralized(tmp_path):
+    from triage.billing_context.exporters import export_mismatches
+
+    mismatches = [
+        Mismatch(
+            severity="red",
+            mismatch_type="hours_delta",
+            tech="Tech",
+            work_date="2026-05-14",
+            source_a="track_hours",
+            source_b="roster_log",
+            source_a_value="=CMD()",
+            source_b_value="8",
+            recommendation="test",
+        )
+    ]
+    csv_path = tmp_path / "m.csv"
+    export_mismatches(mismatches, str(tmp_path / "m.json"), str(csv_path))
+    text = csv_path.read_text(encoding="utf-8")
+    assert "'=CMD()" in text

--- a/tests/test_billing_context_rules.py
+++ b/tests/test_billing_context_rules.py
@@ -2,6 +2,7 @@ from datetime import date, time
 
 from triage.billing_context.context_rules import (
     RULES_DOC,
+    classify_from_task_text,
     is_placeholder_assignment,
     resolve_work_context,
 )
@@ -31,8 +32,30 @@ def test_task_text_beats_placeholder():
     assert confidence == "high"
 
 
+def test_required_not_ticket_coordination():
+    context, _, _ = classify_from_task_text("This is required reading for all techs")
+    assert context != "Ticket Coordination"
+
+
+def test_ten_pm_not_client_coordination():
+    context, _, _ = classify_from_task_text("Worked until 10pm on staging")
+    assert context != "Client Coordination"
+
+
+def test_assignment_task_conflict():
+    context, reason, _ = resolve_work_context(
+        assignment="Configuration",
+        task_text="Deployed floor support for go-live.",
+        work_date=date(2026, 5, 12),
+        start_time=time(9, 0),
+        end_time=time(17, 0),
+    )
+    assert context == "Unknown / Needs Review"
+    assert "disagree" in reason.lower()
+
+
 def test_may_saturday_rule():
-    context, reason, confidence = resolve_work_context(
+    context, _, _ = resolve_work_context(
         assignment="Neuron Installation",
         task_text="",
         work_date=date(2026, 5, 30),
@@ -44,7 +67,7 @@ def test_may_saturday_rule():
 
 
 def test_april_saturday_rule():
-    context, reason, confidence = resolve_work_context(
+    context, _, _ = resolve_work_context(
         assignment="Neuron Installation",
         task_text="",
         work_date=date(2026, 4, 25),
@@ -54,20 +77,20 @@ def test_april_saturday_rule():
     assert context == "Deployment Support"
 
 
-def test_evening_rule_not_logistics():
-    context, reason, confidence = resolve_work_context(
+def test_evening_rule_inventory_management():
+    context, _, _ = resolve_work_context(
         assignment="Neuron Installation",
         task_text="",
         work_date=date(2026, 5, 14),
         start_time=time(18, 0),
         end_time=time(22, 0),
     )
-    assert context in ("Inventory Management", "Configuration")
+    assert context == "Inventory Management"
     assert context != "Logistics"
 
 
 def test_sunday_logistics():
-    context, reason, confidence = resolve_work_context(
+    context, _, _ = resolve_work_context(
         assignment="Neuron Installation",
         task_text="",
         work_date=date(2026, 5, 31),

--- a/tests/test_billing_context_rules.py
+++ b/tests/test_billing_context_rules.py
@@ -1,0 +1,77 @@
+from datetime import date, time
+
+from triage.billing_context.context_rules import (
+    RULES_DOC,
+    is_placeholder_assignment,
+    resolve_work_context,
+)
+
+
+def test_module_docstring_references_rules_doc():
+    import triage.billing_context.context_rules as mod
+
+    assert RULES_DOC in mod.__doc__
+
+
+def test_placeholder_assignment_detected():
+    assert is_placeholder_assignment("Neuron Installation")
+    assert is_placeholder_assignment("install")
+    assert not is_placeholder_assignment("Configuration")
+
+
+def test_task_text_beats_placeholder():
+    context, reason, confidence = resolve_work_context(
+        assignment="Neuron Installation",
+        task_text="Configured devices and staged inventory for go-live.",
+        work_date=date(2026, 5, 12),
+        start_time=time(9, 0),
+        end_time=time(17, 0),
+    )
+    assert context == "Configuration"
+    assert confidence == "high"
+
+
+def test_may_saturday_rule():
+    context, reason, confidence = resolve_work_context(
+        assignment="Neuron Installation",
+        task_text="",
+        work_date=date(2026, 5, 30),
+        start_time=time(9, 0),
+        end_time=time(17, 0),
+    )
+    assert context == "Inventory Management"
+    assert context != "Logistics"
+
+
+def test_april_saturday_rule():
+    context, reason, confidence = resolve_work_context(
+        assignment="Neuron Installation",
+        task_text="",
+        work_date=date(2026, 4, 25),
+        start_time=time(9, 0),
+        end_time=time(17, 0),
+    )
+    assert context == "Deployment Support"
+
+
+def test_evening_rule_not_logistics():
+    context, reason, confidence = resolve_work_context(
+        assignment="Neuron Installation",
+        task_text="",
+        work_date=date(2026, 5, 14),
+        start_time=time(18, 0),
+        end_time=time(22, 0),
+    )
+    assert context in ("Inventory Management", "Configuration")
+    assert context != "Logistics"
+
+
+def test_sunday_logistics():
+    context, reason, confidence = resolve_work_context(
+        assignment="Neuron Installation",
+        task_text="",
+        work_date=date(2026, 5, 31),
+        start_time=time(9, 0),
+        end_time=time(17, 0),
+    )
+    assert context == "Logistics"

--- a/tests/test_billing_context_rules.py
+++ b/tests/test_billing_context_rules.py
@@ -63,7 +63,6 @@ def test_may_saturday_rule():
         end_time=time(17, 0),
     )
     assert context == "Inventory Management"
-    assert context != "Logistics"
 
 
 def test_april_saturday_rule():

--- a/triage/billing_context/__init__.py
+++ b/triage/billing_context/__init__.py
@@ -1,0 +1,1 @@
+"""Contextual billing artifact generation. See docs/BILLING_CONTEXT_EXPORTER.md."""

--- a/triage/billing_context/cli.py
+++ b/triage/billing_context/cli.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .exporters import (
+    export_mismatches,
+    export_monthly_summary,
+    export_neuron_project_hours,
+    scan_leadership_language,
+    scan_workbook_errors,
+)
+from .html_dashboard import export_html_dashboard
+from .reconcile import (
+    build_task_context_index,
+    extract_track_hours,
+    find_all_mismatches,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate contextualized April/May billing artifacts and browser dashboard."
+    )
+    parser.add_argument("--track-hours", required=True)
+    parser.add_argument("--april-context", required=True)
+    parser.add_argument("--roster-log")
+    parser.add_argument("--admin-copy")
+    parser.add_argument("--dashboard")
+    parser.add_argument("--out-dir", default="Outputs")
+    parser.add_argument("--html", action="store_true")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    task_index = build_task_context_index(args.april_context)
+    entries = extract_track_hours(args.track_hours, task_index)
+    mismatches = find_all_mismatches(
+        entries,
+        roster_path=args.roster_log,
+        admin_path=args.admin_copy,
+        dashboard_path=args.dashboard,
+    )
+
+    outputs: dict[str, str] = {}
+
+    xlsx_paths = [
+        export_neuron_project_hours(
+            entries,
+            str(out_dir / "Neuron_Project_Hours_April_May_2026_CONTEXTUALIZED_WEBSAFE.xlsx"),
+        ),
+        export_monthly_summary(
+            entries,
+            4,
+            str(out_dir / "April_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx"),
+        ),
+        export_monthly_summary(
+            entries,
+            5,
+            str(out_dir / "May_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx"),
+        ),
+    ]
+
+    outputs["project_hours"] = xlsx_paths[0]
+    outputs["april_summary"] = xlsx_paths[1]
+    outputs["may_summary"] = xlsx_paths[2]
+
+    export_mismatches(
+        mismatches,
+        str(out_dir / "billing_context_mismatches.json"),
+        str(out_dir / "billing_context_mismatches.csv"),
+    )
+    outputs["mismatches_json"] = str(out_dir / "billing_context_mismatches.json")
+    outputs["mismatches_csv"] = str(out_dir / "billing_context_mismatches.csv")
+
+    if args.html:
+        outputs["html_dashboard"] = export_html_dashboard(
+            entries,
+            mismatches,
+            str(out_dir / "billing_context_dashboard.html"),
+        )
+
+    stop_ship: list[str] = []
+    for path in xlsx_paths:
+        for sheet, coord, val in scan_workbook_errors(path):
+            stop_ship.append(f"{Path(path).name} {sheet}!{coord}: {val}")
+        for issue in scan_leadership_language(path):
+            stop_ship.append(f"{Path(path).name} blocked language: {issue}")
+
+    if stop_ship:
+        print(json.dumps({"stop_ship": stop_ship}, indent=2), file=sys.stderr)
+        sys.exit(1)
+
+    print(
+        json.dumps(
+            {
+                "outputs": outputs,
+                "entry_count": len(entries),
+                "total_hours": round(sum(e.hours for e in entries), 2),
+                "mismatch_count": len(mismatches),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/billing_context/cli.py
+++ b/triage/billing_context/cli.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from datetime import date
 from pathlib import Path
 
 from .exporters import (
+    build_output_manifest,
+    create_zip_bundle,
+    export_internal_detail,
     export_mismatches,
     export_monthly_summary,
     export_neuron_project_hours,
+    scan_forbidden_text,
     scan_leadership_language,
     scan_workbook_errors,
 )
@@ -31,6 +36,9 @@ def main() -> None:
     parser.add_argument("--dashboard")
     parser.add_argument("--out-dir", default="Outputs")
     parser.add_argument("--html", action="store_true")
+    parser.add_argument("--include-tracker-import", action="store_true")
+    parser.add_argument("--internal-xlsx", action="store_true")
+    parser.add_argument("--zip", action="store_true", help="Bundle all outputs into a single ZIP")
     args = parser.parse_args()
 
     out_dir = Path(args.out_dir)
@@ -56,11 +64,13 @@ def main() -> None:
             entries,
             4,
             str(out_dir / "April_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx"),
+            include_tracker_import=args.include_tracker_import,
         ),
         export_monthly_summary(
             entries,
             5,
             str(out_dir / "May_2026_Billing_Summary_CONTEXTUALIZED_CHARTED_WEBSAFE.xlsx"),
+            include_tracker_import=args.include_tracker_import,
         ),
     ]
 
@@ -68,13 +78,15 @@ def main() -> None:
     outputs["april_summary"] = xlsx_paths[1]
     outputs["may_summary"] = xlsx_paths[2]
 
-    export_mismatches(
-        mismatches,
-        str(out_dir / "billing_context_mismatches.json"),
-        str(out_dir / "billing_context_mismatches.csv"),
-    )
-    outputs["mismatches_json"] = str(out_dir / "billing_context_mismatches.json")
-    outputs["mismatches_csv"] = str(out_dir / "billing_context_mismatches.csv")
+    mismatches_json = str(out_dir / "billing_context_mismatches.json")
+    mismatches_csv = str(out_dir / "billing_context_mismatches.csv")
+    export_mismatches(mismatches, mismatches_json, mismatches_csv)
+    outputs["mismatches_json"] = mismatches_json
+    outputs["mismatches_csv"] = mismatches_csv
+
+    if args.internal_xlsx:
+        internal_path = str(out_dir / "billing_context_internal_detail.xlsx")
+        outputs["internal_detail"] = export_internal_detail(entries, internal_path)
 
     if args.html:
         outputs["html_dashboard"] = export_html_dashboard(
@@ -89,15 +101,28 @@ def main() -> None:
             stop_ship.append(f"{Path(path).name} {sheet}!{coord}: {val}")
         for issue in scan_leadership_language(path):
             stop_ship.append(f"{Path(path).name} blocked language: {issue}")
+        for issue in scan_forbidden_text(path):
+            stop_ship.append(f"{Path(path).name} forbidden text: {issue}")
+
+    if args.zip:
+        zip_path = str(out_dir / f"billing_context_artifacts_{date.today().isoformat()}.zip")
+        create_zip_bundle(list(outputs.values()), zip_path)
+        outputs["zip_bundle"] = zip_path
+
+    manifest = build_output_manifest(outputs)
+    missing = [m for m in manifest if not m["exists"]]
+    if missing:
+        stop_ship.extend(f"Missing output artifact: {m['name']} -> {m['path']}" for m in missing)
 
     if stop_ship:
-        print(json.dumps({"stop_ship": stop_ship}, indent=2), file=sys.stderr)
+        print(json.dumps({"stop_ship": stop_ship, "manifest": manifest}, indent=2), file=sys.stderr)
         sys.exit(1)
 
     print(
         json.dumps(
             {
                 "outputs": outputs,
+                "manifest": manifest,
                 "entry_count": len(entries),
                 "total_hours": round(sum(e.hours for e in entries), 2),
                 "mismatch_count": len(mismatches),

--- a/triage/billing_context/context_rules.py
+++ b/triage/billing_context/context_rules.py
@@ -1,0 +1,129 @@
+"""Work-context classification. Spec: docs/BILLING_WORK_CONTEXT_RULES.md"""
+
+from __future__ import annotations
+
+from datetime import date, time
+from typing import Optional
+
+
+RULES_DOC = "docs/BILLING_WORK_CONTEXT_RULES.md"
+
+PLACEHOLDER_LABELS = {
+    "neuron installation",
+    "installation",
+    "neuron install",
+    "install",
+}
+
+CONFIGURATION_HINTS = {"configure", "configuration", "imaged", "image", "setup", "build"}
+
+
+def is_placeholder_assignment(value: str | None) -> bool:
+    if not value:
+        return False
+    return str(value).strip().lower() in PLACEHOLDER_LABELS
+
+
+def is_evening(start_time: Optional[time], end_time: Optional[time]) -> bool:
+    if start_time and start_time.hour >= 16:
+        return True
+    if end_time and end_time.hour >= 18:
+        return True
+    return False
+
+
+def is_saturday(work_date: date) -> bool:
+    return work_date.weekday() == 5
+
+
+def is_sunday(work_date: date) -> bool:
+    return work_date.weekday() == 6
+
+
+def _hints_configuration(text: str) -> bool:
+    raw = (text or "").lower()
+    return any(k in raw for k in CONFIGURATION_HINTS)
+
+
+def classify_from_task_text(text: str) -> tuple[str, str, str]:
+    """Returns: work_context, reason, confidence."""
+    raw = (text or "").lower()
+
+    if any(k in raw for k in ["configure", "configuration", "imaged", "image", "setup", "build"]):
+        return "Configuration", "Task tracker contains configuration/build language.", "high"
+
+    if any(k in raw for k in ["inventory", "warehouse", "stock", "staging", "deliver", "delivery", "pickup", "logistics"]):
+        return "Inventory Management & Logistics", "Task tracker contains inventory/logistics language.", "high"
+
+    if any(k in raw for k in ["deploy", "deployment", "go live", "go-live", "floor support"]):
+        return "Deployment Support", "Task tracker contains deployment/go-live language.", "high"
+
+    if any(k in raw for k in ["incident", "break/fix", "outage", "urgent", "support issue"]):
+        return "Incident Response", "Task tracker contains incident response language.", "high"
+
+    if any(k in raw for k in ["ticket", "servicenow", "ritm", "req"]):
+        return "Ticket Coordination", "Task tracker contains ticket coordination language.", "high"
+
+    if any(k in raw for k in ["client", "pm", "coordination", "coordinate", "follow up", "follow-up"]):
+        return "Client Coordination", "Task tracker contains coordination language.", "medium"
+
+    return "Unknown / Needs Review", "No decisive task-tracker context found.", "low"
+
+
+def classify_by_time_rules(
+    work_date: date,
+    start_time: Optional[time],
+    end_time: Optional[time],
+    month: int,
+    assignment: str = "",
+    notes: str = "",
+) -> tuple[str, str, str]:
+    hint_text = f"{assignment} {notes}".strip()
+
+    if is_saturday(work_date) and month == 4:
+        return "Deployment Support", "April Saturday rule applied.", "medium"
+
+    if is_saturday(work_date) and month >= 5:
+        if _hints_configuration(hint_text):
+            return "Configuration", "May+ Saturday rule with configuration hints.", "medium"
+        return "Inventory Management", "May+ Saturday rule applied.", "medium"
+
+    if is_sunday(work_date):
+        return "Logistics", "Sunday rule applied: cleanup and stock movement.", "medium"
+
+    if is_evening(start_time, end_time):
+        if _hints_configuration(hint_text):
+            return "Configuration", "Evening-hours rule with configuration hints.", "medium"
+        return "Inventory Management", "Evening-hours rule applied.", "medium"
+
+    return (
+        "Mixed Operational Support",
+        "Day-hours rule applied: logistics, inventory, incident response, ticket/client coordination.",
+        "medium",
+    )
+
+
+def resolve_work_context(
+    *,
+    assignment: str,
+    task_text: str,
+    work_date: date,
+    start_time: Optional[time],
+    end_time: Optional[time],
+) -> tuple[str, str, str]:
+    task_context, task_reason, task_conf = classify_from_task_text(task_text)
+
+    if task_context != "Unknown / Needs Review":
+        return task_context, task_reason, task_conf
+
+    if assignment and not is_placeholder_assignment(assignment):
+        return str(assignment), "Non-placeholder assignment retained.", "medium"
+
+    return classify_by_time_rules(
+        work_date=work_date,
+        start_time=start_time,
+        end_time=end_time,
+        month=work_date.month,
+        assignment=assignment,
+        notes=task_text,
+    )

--- a/triage/billing_context/context_rules.py
+++ b/triage/billing_context/context_rules.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, time
 from typing import Optional
-
 
 RULES_DOC = "docs/BILLING_WORK_CONTEXT_RULES.md"
 
@@ -17,11 +17,38 @@ PLACEHOLDER_LABELS = {
 
 CONFIGURATION_HINTS = {"configure", "configuration", "imaged", "image", "setup", "build"}
 
+ALLOWED_CONTEXTS = {
+    "Configuration",
+    "Inventory Management",
+    "Inventory Management & Logistics",
+    "Deployment Support",
+    "Incident Response",
+    "Ticket Coordination",
+    "Client Coordination",
+    "Logistics",
+    "Mixed Operational Support",
+    "Unknown / Needs Review",
+}
+
+REQ_PATTERN = re.compile(r"\bREQ\d+\b", re.IGNORECASE)
+RITM_PATTERN = re.compile(r"\bRITM\d+\b", re.IGNORECASE)
+PM_PATTERN = re.compile(r"\bPM\b", re.IGNORECASE)
+
 
 def is_placeholder_assignment(value: str | None) -> bool:
     if not value:
         return False
     return str(value).strip().lower() in PLACEHOLDER_LABELS
+
+
+def normalize_assignment_label(value: str) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    for label in ALLOWED_CONTEXTS:
+        if text.lower() == label.lower():
+            return label
+    return None
 
 
 def is_evening(start_time: Optional[time], end_time: Optional[time]) -> bool:
@@ -61,10 +88,10 @@ def classify_from_task_text(text: str) -> tuple[str, str, str]:
     if any(k in raw for k in ["incident", "break/fix", "outage", "urgent", "support issue"]):
         return "Incident Response", "Task tracker contains incident response language.", "high"
 
-    if any(k in raw for k in ["ticket", "servicenow", "ritm", "req"]):
+    if REQ_PATTERN.search(text or "") or RITM_PATTERN.search(text or "") or "servicenow" in raw or "ticket" in raw:
         return "Ticket Coordination", "Task tracker contains ticket coordination language.", "high"
 
-    if any(k in raw for k in ["client", "pm", "coordination", "coordinate", "follow up", "follow-up"]):
+    if PM_PATTERN.search(text or "") or any(k in raw for k in ["client", "coordination", "coordinate", "follow up", "follow-up"]):
         return "Client Coordination", "Task tracker contains coordination language.", "medium"
 
     return "Unknown / Needs Review", "No decisive task-tracker context found.", "low"
@@ -112,12 +139,19 @@ def resolve_work_context(
     end_time: Optional[time],
 ) -> tuple[str, str, str]:
     task_context, task_reason, task_conf = classify_from_task_text(task_text)
+    assignment_label = normalize_assignment_label(assignment) if assignment and not is_placeholder_assignment(assignment) else None
 
     if task_context != "Unknown / Needs Review":
+        if assignment_label and assignment_label != task_context:
+            return (
+                "Unknown / Needs Review",
+                "Task tracker and assignment disagree; manual review required.",
+                "low",
+            )
         return task_context, task_reason, task_conf
 
-    if assignment and not is_placeholder_assignment(assignment):
-        return str(assignment), "Non-placeholder assignment retained.", "medium"
+    if assignment_label:
+        return assignment_label, "Non-placeholder assignment retained.", "medium"
 
     return classify_by_time_rules(
         work_date=work_date,

--- a/triage/billing_context/exporters.py
+++ b/triage/billing_context/exporters.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import csv
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from openpyxl import Workbook, load_workbook
+from openpyxl.chart import BarChart, LineChart, Reference
+from openpyxl.styles import Alignment, Font, PatternFill
+from openpyxl.utils import get_column_letter
+
+from triage.admin_billing_context_rules import contains_suspicious_language
+
+from .models import Mismatch, WorkEntry
+from .reconcile import friday_batch_key
+
+HEADER_FILL = "1F4E78"
+HEADER_FONT = "FFFFFF"
+ERROR_TOKENS = ("#REF!", "#VALUE!", "#DIV/0!", "#NAME?", "#N/A")
+
+LEADERSHIP_HEADERS = [
+    "Date",
+    "Tech",
+    "Hours",
+    "Work Context",
+    "Original Assignment",
+    "Start Time",
+    "End Time",
+    "Source Sheet",
+    "Source Row",
+]
+
+
+def autosize(ws) -> None:
+    for col_idx in range(1, ws.max_column + 1):
+        letter = get_column_letter(col_idx)
+        max_len = 10
+        for cell in ws[letter]:
+            if cell.value is not None:
+                max_len = max(max_len, min(len(str(cell.value)), 70))
+        ws.column_dimensions[letter].width = max_len + 2
+
+
+def style_header(ws) -> None:
+    fill = PatternFill("solid", fgColor=HEADER_FILL)
+    for cell in ws[1]:
+        cell.fill = fill
+        cell.font = Font(bold=True, color=HEADER_FONT)
+        cell.alignment = Alignment(horizontal="center")
+
+
+def write_rows(ws, headers: list[str], rows: list[dict]) -> None:
+    ws.append(headers)
+    style_header(ws)
+    for row in rows:
+        ws.append([row.get(h, "") for h in headers])
+    ws.freeze_panes = "A2"
+    autosize(ws)
+
+
+def entries_to_leadership_rows(entries: list[WorkEntry]) -> list[dict]:
+    rows = []
+    for e in entries:
+        assignment = e.original_assignment
+        if is_placeholder_empty(assignment):
+            assignment = ""
+        rows.append(
+            {
+                "Date": e.work_date.isoformat(),
+                "Tech": e.tech,
+                "Hours": round(e.hours, 2),
+                "Work Context": e.work_context,
+                "Original Assignment": assignment,
+                "Start Time": e.start_time.isoformat() if e.start_time else "",
+                "End Time": e.end_time.isoformat() if e.end_time else "",
+                "Source Sheet": e.sheet_name,
+                "Source Row": e.row_number,
+            }
+        )
+    return rows
+
+
+def is_placeholder_empty(assignment: str) -> bool:
+    from .context_rules import is_placeholder_assignment
+
+    return not assignment or is_placeholder_assignment(assignment)
+
+
+def summarize_by_context(entries: list[WorkEntry]) -> list[dict]:
+    totals: dict[str, float] = defaultdict(float)
+    for e in entries:
+        totals[e.work_context] += e.hours
+    return [
+        {"Work Context": k, "Hours": round(v, 2)}
+        for k, v in sorted(totals.items(), key=lambda item: item[1], reverse=True)
+    ]
+
+
+def summarize_by_tech(entries: list[WorkEntry]) -> list[dict]:
+    totals: dict[str, float] = defaultdict(float)
+    for e in entries:
+        totals[e.tech] += e.hours
+    return [
+        {"Tech": k, "Hours": round(v, 2)}
+        for k, v in sorted(totals.items(), key=lambda item: item[1], reverse=True)
+    ]
+
+
+def summarize_by_batch(entries: list[WorkEntry]) -> list[dict]:
+    totals: dict[str, float] = defaultdict(float)
+    for e in entries:
+        totals[friday_batch_key(e.work_date)] += e.hours
+    return [
+        {"Reporting Batch Friday": k, "Hours": round(v, 2)}
+        for k, v in sorted(totals.items())
+    ]
+
+
+def add_bar_chart(ws, title: str, category_col: int, value_col: int, anchor: str) -> None:
+    if ws.max_row < 2:
+        return
+    chart = BarChart()
+    chart.title = title
+    chart.y_axis.title = "Hours"
+    chart.x_axis.title = ws.cell(1, category_col).value or "Category"
+    data = Reference(ws, min_col=value_col, min_row=1, max_row=ws.max_row)
+    cats = Reference(ws, min_col=category_col, min_row=2, max_row=ws.max_row)
+    chart.add_data(data, titles_from_data=True)
+    chart.set_categories(cats)
+    chart.height = 8
+    chart.width = 14
+    ws.add_chart(chart, anchor)
+
+
+def add_line_chart(ws, title: str, category_col: int, value_col: int, anchor: str) -> None:
+    if ws.max_row < 2:
+        return
+    chart = LineChart()
+    chart.title = title
+    chart.y_axis.title = "Hours"
+    chart.x_axis.title = "Batch"
+    data = Reference(ws, min_col=value_col, min_row=1, max_row=ws.max_row)
+    cats = Reference(ws, min_col=category_col, min_row=2, max_row=ws.max_row)
+    chart.add_data(data, titles_from_data=True)
+    chart.set_categories(cats)
+    chart.height = 8
+    chart.width = 14
+    ws.add_chart(chart, anchor)
+
+
+def scan_workbook_errors(path: str | Path) -> list[tuple[str, str, str]]:
+    hits: list[tuple[str, str, str]] = []
+    wb = load_workbook(path, data_only=False)
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for cell in row:
+                val = str(cell.value or "")
+                if any(tok in val for tok in ERROR_TOKENS):
+                    hits.append((ws.title, cell.coordinate, val))
+    wb.close()
+    return hits
+
+
+def scan_leadership_language(path: str | Path) -> list[str]:
+    issues: list[str] = []
+    wb = load_workbook(path, data_only=True)
+    for ws in wb.worksheets:
+        for row in ws.iter_rows():
+            for cell in row:
+                if contains_suspicious_language(cell.value):
+                    issues.append(f"{ws.title}!{cell.coordinate}: {cell.value}")
+    wb.close()
+    return issues
+
+
+def export_neuron_project_hours(entries: list[WorkEntry], out_path: str) -> str:
+    wb = Workbook()
+    default = wb.active
+    wb.remove(default)
+
+    for month, title in [(4, "April 2026"), (5, "May 2026")]:
+        month_entries = [e for e in entries if e.work_date.month == month]
+
+        ws = wb.create_sheet(title)
+        write_rows(ws, LEADERSHIP_HEADERS, entries_to_leadership_rows(month_entries))
+
+        context_ws = wb.create_sheet(f"{title} Context Summary")
+        context_rows = summarize_by_context(month_entries)
+        write_rows(context_ws, ["Work Context", "Hours"], context_rows)
+        add_bar_chart(context_ws, f"{title} Hours by Work Context", 1, 2, "D2")
+
+        tech_ws = wb.create_sheet(f"{title} Tech Summary")
+        tech_rows = summarize_by_tech(month_entries)
+        write_rows(tech_ws, ["Tech", "Hours"], tech_rows)
+        add_bar_chart(tech_ws, f"{title} Top Technician Hours", 1, 2, "D2")
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    wb.save(out_path)
+    return out_path
+
+
+def export_monthly_summary(entries: list[WorkEntry], month: int, out_path: str) -> str:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Admin Summary"
+
+    month_entries = [e for e in entries if e.work_date.month == month]
+    total_hours = round(sum(e.hours for e in month_entries), 2)
+
+    ws["A1"] = "Billing Summary"
+    ws["A1"].font = Font(size=16, bold=True)
+    ws["A3"] = "Month"
+    ws["B3"] = "April 2026" if month == 4 else "May 2026"
+    ws["A4"] = "Total Hours"
+    ws["B4"] = total_hours
+    ws["A5"] = "Total Rows"
+    ws["B5"] = len(month_entries)
+
+    context_ws = wb.create_sheet("Work Context Summary")
+    write_rows(context_ws, ["Work Context", "Hours"], summarize_by_context(month_entries))
+    add_bar_chart(context_ws, "Hours by Work Context", 1, 2, "D2")
+
+    tech_ws = wb.create_sheet("Technician Summary")
+    write_rows(tech_ws, ["Tech", "Hours"], summarize_by_tech(month_entries))
+    add_bar_chart(tech_ws, "Top Technician Hours", 1, 2, "D2")
+
+    batch_ws = wb.create_sheet("Reporting Batch Summary")
+    write_rows(batch_ws, ["Reporting Batch Friday", "Hours"], summarize_by_batch(month_entries))
+    add_line_chart(batch_ws, "Hours by Reporting Batch", 1, 2, "D2")
+
+    detail_ws = wb.create_sheet("Tracker Import")
+    write_rows(detail_ws, LEADERSHIP_HEADERS, entries_to_leadership_rows(month_entries))
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    wb.save(out_path)
+    return out_path
+
+
+def export_mismatches(mismatches: list[Mismatch], out_json: str, out_csv: str) -> None:
+    rows = [m.to_dict() for m in mismatches]
+    Path(out_json).parent.mkdir(parents=True, exist_ok=True)
+
+    with open(out_json, "w", encoding="utf-8") as f:
+        json.dump(rows, f, indent=2)
+
+    fieldnames = [
+        "severity",
+        "mismatch_type",
+        "tech",
+        "work_date",
+        "source_a",
+        "source_b",
+        "source_a_value",
+        "source_b_value",
+        "recommendation",
+        "leadership_safe",
+    ]
+    with open(out_csv, "w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/triage/billing_context/exporters.py
+++ b/triage/billing_context/exporters.py
@@ -255,6 +255,10 @@ def export_monthly_summary(
     *,
     include_tracker_import: bool = False,
 ) -> str:
+    month_labels = {4: "April 2026", 5: "May 2026"}
+    if month not in month_labels:
+        raise ValueError(f"Unsupported month for billing summary: {month}")
+
     wb = Workbook()
     ws = wb.active
     ws.title = "Admin Summary"
@@ -265,7 +269,7 @@ def export_monthly_summary(
     ws["A1"] = "Billing Summary"
     ws["A1"].font = Font(size=16, bold=True)
     ws["A3"] = "Month"
-    ws["B3"] = "April 2026" if month == 4 else "May 2026"
+    ws["B3"] = month_labels[month]
     ws["A4"] = "Total Hours"
     ws["B4"] = total_hours
     ws["A5"] = "Total Rows"
@@ -305,6 +309,7 @@ def export_internal_detail(entries: list[WorkEntry], out_path: str) -> str:
 def export_mismatches(mismatches: list[Mismatch], out_json: str, out_csv: str) -> None:
     rows = [m.to_dict() for m in mismatches]
     Path(out_json).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_csv).parent.mkdir(parents=True, exist_ok=True)
 
     with open(out_json, "w", encoding="utf-8") as f:
         json.dump(rows, f, indent=2)

--- a/triage/billing_context/exporters.py
+++ b/triage/billing_context/exporters.py
@@ -18,18 +18,29 @@ from .reconcile import friday_batch_key
 HEADER_FILL = "1F4E78"
 HEADER_FONT = "FFFFFF"
 ERROR_TOKENS = ("#REF!", "#VALUE!", "#DIV/0!", "#NAME?", "#N/A")
+FORBIDDEN_TEXT_TOKENS = ("...", "…", "TBD", "TODO", "context goes here")
 
-LEADERSHIP_HEADERS = [
+LEADERSHIP_HEADERS = ["Date", "Tech", "Hours", "Work Context"]
+
+INTERNAL_HEADERS = [
     "Date",
     "Tech",
     "Hours",
     "Work Context",
+    "Context Reason",
     "Original Assignment",
     "Start Time",
     "End Time",
     "Source Sheet",
     "Source Row",
 ]
+
+
+def safe_csv_value(value: object) -> str:
+    text = "" if value is None else str(value)
+    if text.startswith(("=", "+", "-", "@")):
+        return "'" + text
+    return text
 
 
 def autosize(ws) -> None:
@@ -60,6 +71,18 @@ def write_rows(ws, headers: list[str], rows: list[dict]) -> None:
 
 
 def entries_to_leadership_rows(entries: list[WorkEntry]) -> list[dict]:
+    return [
+        {
+            "Date": e.work_date.isoformat(),
+            "Tech": e.tech,
+            "Hours": round(e.hours, 2),
+            "Work Context": e.work_context,
+        }
+        for e in entries
+    ]
+
+
+def entries_to_internal_rows(entries: list[WorkEntry]) -> list[dict]:
     rows = []
     for e in entries:
         assignment = e.original_assignment
@@ -71,6 +94,7 @@ def entries_to_leadership_rows(entries: list[WorkEntry]) -> list[dict]:
                 "Tech": e.tech,
                 "Hours": round(e.hours, 2),
                 "Work Context": e.work_context,
+                "Context Reason": e.context_reason,
                 "Original Assignment": assignment,
                 "Start Time": e.start_time.isoformat() if e.start_time else "",
                 "End Time": e.end_time.isoformat() if e.end_time else "",
@@ -149,10 +173,12 @@ def add_line_chart(ws, title: str, category_col: int, value_col: int, anchor: st
     ws.add_chart(chart, anchor)
 
 
-def scan_workbook_errors(path: str | Path) -> list[tuple[str, str, str]]:
+def _scan_cells(path: str | Path, data_only: bool) -> list[tuple[str, str, str]]:
     hits: list[tuple[str, str, str]] = []
-    wb = load_workbook(path, data_only=False)
+    wb = load_workbook(path, data_only=data_only)
     for ws in wb.worksheets:
+        if getattr(ws, "sheet_state", "visible") != "visible":
+            continue
         for row in ws.iter_rows():
             for cell in row:
                 val = str(cell.value or "")
@@ -160,6 +186,30 @@ def scan_workbook_errors(path: str | Path) -> list[tuple[str, str, str]]:
                     hits.append((ws.title, cell.coordinate, val))
     wb.close()
     return hits
+
+
+def scan_workbook_errors(path: str | Path) -> list[tuple[str, str, str]]:
+    hits = _scan_cells(path, data_only=True)
+    if not hits:
+        hits = _scan_cells(path, data_only=False)
+    return hits
+
+
+def scan_forbidden_text(path: str | Path) -> list[str]:
+    issues: list[str] = []
+    wb = load_workbook(path, data_only=True)
+    for ws in wb.worksheets:
+        if getattr(ws, "sheet_state", "visible") != "visible":
+            continue
+        for row in ws.iter_rows():
+            for cell in row:
+                value = str(cell.value or "")
+                lower = value.lower()
+                for token in FORBIDDEN_TEXT_TOKENS:
+                    if token.lower() in lower:
+                        issues.append(f"{ws.title}!{cell.coordinate}: forbidden token {token!r}")
+    wb.close()
+    return issues
 
 
 def scan_leadership_language(path: str | Path) -> list[str]:
@@ -186,13 +236,11 @@ def export_neuron_project_hours(entries: list[WorkEntry], out_path: str) -> str:
         write_rows(ws, LEADERSHIP_HEADERS, entries_to_leadership_rows(month_entries))
 
         context_ws = wb.create_sheet(f"{title} Context Summary")
-        context_rows = summarize_by_context(month_entries)
-        write_rows(context_ws, ["Work Context", "Hours"], context_rows)
+        write_rows(context_ws, ["Work Context", "Hours"], summarize_by_context(month_entries))
         add_bar_chart(context_ws, f"{title} Hours by Work Context", 1, 2, "D2")
 
         tech_ws = wb.create_sheet(f"{title} Tech Summary")
-        tech_rows = summarize_by_tech(month_entries)
-        write_rows(tech_ws, ["Tech", "Hours"], tech_rows)
+        write_rows(tech_ws, ["Tech", "Hours"], summarize_by_tech(month_entries))
         add_bar_chart(tech_ws, f"{title} Top Technician Hours", 1, 2, "D2")
 
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
@@ -200,7 +248,13 @@ def export_neuron_project_hours(entries: list[WorkEntry], out_path: str) -> str:
     return out_path
 
 
-def export_monthly_summary(entries: list[WorkEntry], month: int, out_path: str) -> str:
+def export_monthly_summary(
+    entries: list[WorkEntry],
+    month: int,
+    out_path: str,
+    *,
+    include_tracker_import: bool = False,
+) -> str:
     wb = Workbook()
     ws = wb.active
     ws.title = "Admin Summary"
@@ -229,9 +283,20 @@ def export_monthly_summary(entries: list[WorkEntry], month: int, out_path: str) 
     write_rows(batch_ws, ["Reporting Batch Friday", "Hours"], summarize_by_batch(month_entries))
     add_line_chart(batch_ws, "Hours by Reporting Batch", 1, 2, "D2")
 
-    detail_ws = wb.create_sheet("Tracker Import")
-    write_rows(detail_ws, LEADERSHIP_HEADERS, entries_to_leadership_rows(month_entries))
+    if include_tracker_import:
+        detail_ws = wb.create_sheet("Tracker Import")
+        write_rows(detail_ws, INTERNAL_HEADERS, entries_to_internal_rows(month_entries))
 
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    wb.save(out_path)
+    return out_path
+
+
+def export_internal_detail(entries: list[WorkEntry], out_path: str) -> str:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Internal Detail"
+    write_rows(ws, INTERNAL_HEADERS, entries_to_internal_rows(entries))
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
     wb.save(out_path)
     return out_path
@@ -259,4 +324,33 @@ def export_mismatches(mismatches: list[Mismatch], out_json: str, out_csv: str) -
     with open(out_csv, "w", encoding="utf-8", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=fieldnames)
         writer.writeheader()
-        writer.writerows(rows)
+        for row in rows:
+            writer.writerow({k: safe_csv_value(row.get(k, "")) for k in fieldnames})
+
+
+def build_output_manifest(outputs: dict[str, str]) -> list[dict]:
+    manifest: list[dict] = []
+    for name, path in outputs.items():
+        p = Path(path)
+        manifest.append(
+            {
+                "name": name,
+                "path": str(p.resolve()),
+                "exists": p.exists(),
+                "bytes": p.stat().st_size if p.exists() else 0,
+            }
+        )
+    return manifest
+
+
+def create_zip_bundle(paths: list[str], zip_path: str) -> str:
+    import zipfile
+
+    outp = Path(zip_path)
+    outp.parent.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(outp, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        for path in paths:
+            p = Path(path)
+            if p.exists():
+                zf.write(p, p.name)
+    return str(outp)

--- a/triage/billing_context/html_dashboard.py
+++ b/triage/billing_context/html_dashboard.py
@@ -20,6 +20,8 @@ def export_html_dashboard(entries: list[WorkEntry], mismatches: list[Mismatch], 
         },
     }
 
+    safe_payload_json = json.dumps(payload, ensure_ascii=False).replace("</", "<\\/")
+
     html = f"""<!doctype html>
 <html lang="en">
 <head>
@@ -27,92 +29,26 @@ def export_html_dashboard(entries: list[WorkEntry], mismatches: list[Mismatch], 
   <title>Billing Context Dashboard</title>
   <style>
     :root {{
-      --bg: #0f172a;
-      --panel: #111827;
-      --panel2: #1f2937;
-      --text: #e5e7eb;
-      --muted: #9ca3af;
-      --accent: #38bdf8;
-      --red: #f87171;
-      --amber: #fbbf24;
-      --blue: #60a5fa;
-      --green: #34d399;
-      --gray: #94a3b8;
+      --bg: #0f172a; --panel: #111827; --panel2: #1f2937; --text: #e5e7eb;
+      --muted: #9ca3af; --accent: #38bdf8; --red: #f87171; --amber: #fbbf24;
+      --blue: #60a5fa; --gray: #94a3b8;
     }}
-    body {{
-      margin: 0;
-      font-family: system-ui, Segoe UI, Arial, sans-serif;
-      background: var(--bg);
-      color: var(--text);
-    }}
-    header {{
-      padding: 24px;
-      border-bottom: 1px solid #334155;
-      background: #020617;
-    }}
+    body {{ margin: 0; font-family: system-ui, Segoe UI, Arial, sans-serif; background: var(--bg); color: var(--text); }}
+    header {{ padding: 24px; border-bottom: 1px solid #334155; background: #020617; }}
     h1 {{ margin: 0 0 8px; font-size: 28px; }}
     .subtle {{ color: var(--muted); }}
     main {{ padding: 24px; display: grid; gap: 20px; }}
-    .cards {{
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 16px;
-    }}
-    .card {{
-      background: var(--panel);
-      border: 1px solid #334155;
-      border-radius: 16px;
-      padding: 16px;
-      box-shadow: 0 8px 22px rgba(0,0,0,.22);
-    }}
+    .cards {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 16px; }}
+    .card {{ background: var(--panel); border: 1px solid #334155; border-radius: 16px; padding: 16px; }}
     .card .value {{ font-size: 30px; font-weight: 800; margin-top: 8px; }}
-    .grid {{
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
-      gap: 20px;
-    }}
-    table {{
-      width: 100%;
-      border-collapse: collapse;
-      background: var(--panel);
-      border-radius: 12px;
-      overflow: hidden;
-    }}
-    th, td {{
-      padding: 9px 10px;
-      border-bottom: 1px solid #334155;
-      text-align: left;
-      font-size: 13px;
-      vertical-align: top;
-    }}
+    .grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap: 20px; }}
+    table {{ width: 100%; border-collapse: collapse; background: var(--panel); border-radius: 12px; overflow: hidden; }}
+    th, td {{ padding: 9px 10px; border-bottom: 1px solid #334155; text-align: left; font-size: 13px; vertical-align: top; }}
     th {{ background: var(--panel2); position: sticky; top: 0; }}
-    input, select {{
-      background: #020617;
-      color: var(--text);
-      border: 1px solid #475569;
-      border-radius: 10px;
-      padding: 9px 10px;
-      margin-right: 10px;
-    }}
-    .bar-row {{
-      display: grid;
-      grid-template-columns: 220px 1fr 80px;
-      align-items: center;
-      gap: 10px;
-      margin: 10px 0;
-    }}
-    .bar {{
-      height: 16px;
-      background: #1e293b;
-      border-radius: 999px;
-      overflow: hidden;
-    }}
-    .bar span {{
-      display: block;
-      height: 100%;
-      background: var(--accent);
-      border-radius: 999px;
-    }}
+    input, select {{ background: #020617; color: var(--text); border: 1px solid #475569; border-radius: 10px; padding: 9px 10px; margin-right: 10px; }}
+    .bar-row {{ display: grid; grid-template-columns: 220px 1fr 80px; align-items: center; gap: 10px; margin: 10px 0; }}
+    .bar {{ height: 16px; background: #1e293b; border-radius: 999px; overflow: hidden; }}
+    .bar span {{ display: block; height: 100%; background: var(--accent); border-radius: 999px; }}
     .severity-red {{ color: var(--red); font-weight: 700; }}
     .severity-amber {{ color: var(--amber); font-weight: 700; }}
     .severity-blue {{ color: var(--blue); font-weight: 700; }}
@@ -130,50 +66,40 @@ def export_html_dashboard(entries: list[WorkEntry], mismatches: list[Mismatch], 
     <div class="card"><h2>Hours by Work Context</h2><div id="contextBars"></div></div>
     <div class="card"><h2>Top Technician Hours</h2><div id="techBars"></div></div>
   </section>
-  <section class="card">
-    <h2>Mismatches</h2>
-    <div>
-      <input id="mismatchSearch" placeholder="Search mismatches">
-      <select id="severityFilter">
-        <option value="">All severities</option>
-        <option value="red">Red</option>
-        <option value="amber">Amber</option>
-        <option value="blue">Blue</option>
-        <option value="gray">Gray</option>
-      </select>
-    </div>
+  <section class="card"><h2>Mismatches</h2>
+    <div><input id="mismatchSearch" placeholder="Search mismatches">
+    <select id="severityFilter"><option value="">All severities</option><option value="red">Red</option><option value="amber">Amber</option><option value="blue">Blue</option><option value="gray">Gray</option></select></div>
     <div id="mismatchTable"></div>
   </section>
-  <section class="card">
-    <h2>Row-Level Work Context</h2>
-    <div>
-      <input id="entrySearch" placeholder="Search entries">
-      <select id="monthFilter">
-        <option value="">All months</option>
-        <option value="04">April</option>
-        <option value="05">May</option>
-      </select>
-    </div>
+  <section class="card"><h2>Row-Level Work Context</h2>
+    <div><input id="entrySearch" placeholder="Search entries">
+    <select id="monthFilter"><option value="">All months</option><option value="04">April</option><option value="05">May</option></select></div>
     <div id="entryTable"></div>
   </section>
 </main>
 <script>
-const DATA = {json.dumps(payload, ensure_ascii=False)};
+const DATA = {safe_payload_json};
+
+function esc(value) {{
+  return String(value == null ? "" : value).replace(/[&<>"']/g, c => ({{
+    "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+  }}[c]));
+}}
 
 function money(n) {{ return Number(n || 0).toFixed(2); }}
 
 function renderCards() {{
   document.getElementById("cards").innerHTML = `
     <div class="card"><div class="subtle">Total Hours</div><div class="value">${{money(DATA.summary.total_hours)}}</div></div>
-    <div class="card"><div class="subtle">Rows</div><div class="value">${{DATA.summary.row_count}}</div></div>
-    <div class="card"><div class="subtle">Mismatches</div><div class="value">${{DATA.mismatches.length}}</div></div>`;
+    <div class="card"><div class="subtle">Rows</div><div class="value">${{esc(DATA.summary.row_count)}}</div></div>
+    <div class="card"><div class="subtle">Mismatches</div><div class="value">${{esc(DATA.mismatches.length)}}</div></div>`;
 }}
 
 function renderBars(targetId, rows, labelKey) {{
   const max = Math.max(...rows.map(r => Number(r.Hours || 0)), 1);
   document.getElementById(targetId).innerHTML = rows.map(r => {{
     const width = (Number(r.Hours || 0) / max) * 100;
-    return `<div class="bar-row"><div>${{r[labelKey]}}</div><div class="bar"><span style="width:${{width}}%"></span></div><div>${{money(r.Hours)}}</div></div>`;
+    return `<div class="bar-row"><div>${{esc(r[labelKey])}}</div><div class="bar"><span style="width:${{width}}%"></span></div><div>${{money(r.Hours)}}</div></div>`;
   }}).join("");
 }}
 
@@ -187,8 +113,8 @@ function renderMismatchTable() {{
   document.getElementById("mismatchTable").innerHTML = `
     <table><thead><tr><th>Severity</th><th>Type</th><th>Tech</th><th>Date</th><th>From</th><th>To</th><th>Recommendation</th></tr></thead>
     <tbody>${{rows.map(r => `<tr>
-      <td class="severity-${{r.severity}}">${{r.severity}}</td><td>${{r.mismatch_type}}</td><td>${{r.tech}}</td>
-      <td>${{r.work_date}}</td><td>${{r.source_a_value}}</td><td>${{r.source_b_value}}</td><td>${{r.recommendation}}</td></tr>`).join("")}}</tbody></table>`;
+      <td class="severity-${{esc(r.severity)}}">${{esc(r.severity)}}</td><td>${{esc(r.mismatch_type)}}</td><td>${{esc(r.tech)}}</td>
+      <td>${{esc(r.work_date)}}</td><td>${{esc(r.source_a_value)}}</td><td>${{esc(r.source_b_value)}}</td><td>${{esc(r.recommendation)}}</td></tr>`).join("")}}</tbody></table>`;
 }}
 
 function renderEntryTable() {{
@@ -200,8 +126,8 @@ function renderEntryTable() {{
   }});
   document.getElementById("entryTable").innerHTML = `
     <table><thead><tr><th>Date</th><th>Tech</th><th>Hours</th><th>Context</th><th>Reason</th><th>Original Assignment</th></tr></thead>
-    <tbody>${{rows.map(r => `<tr><td>${{r.work_date}}</td><td>${{r.tech}}</td><td>${{money(r.hours)}}</td>
-      <td>${{r.work_context}}</td><td>${{r.context_reason}}</td><td>${{r.original_assignment}}</td></tr>`).join("")}}</tbody></table>`;
+    <tbody>${{rows.map(r => `<tr><td>${{esc(r.work_date)}}</td><td>${{esc(r.tech)}}</td><td>${{money(r.hours)}}</td>
+      <td>${{esc(r.work_context)}}</td><td>${{esc(r.context_reason)}}</td><td>${{esc(r.original_assignment)}}</td></tr>`).join("")}}</tbody></table>`;
 }}
 
 renderCards();

--- a/triage/billing_context/html_dashboard.py
+++ b/triage/billing_context/html_dashboard.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .exporters import summarize_by_batch, summarize_by_context, summarize_by_tech
+from .models import Mismatch, WorkEntry
+
+
+def export_html_dashboard(entries: list[WorkEntry], mismatches: list[Mismatch], out_path: str) -> str:
+    payload = {
+        "entries": [e.to_dict() for e in entries],
+        "mismatches": [m.to_dict() for m in mismatches],
+        "summary": {
+            "total_hours": round(sum(e.hours for e in entries), 2),
+            "row_count": len(entries),
+            "by_context": summarize_by_context(entries),
+            "by_tech": summarize_by_tech(entries),
+            "by_batch": summarize_by_batch(entries),
+        },
+    }
+
+    html = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Billing Context Dashboard</title>
+  <style>
+    :root {{
+      --bg: #0f172a;
+      --panel: #111827;
+      --panel2: #1f2937;
+      --text: #e5e7eb;
+      --muted: #9ca3af;
+      --accent: #38bdf8;
+      --red: #f87171;
+      --amber: #fbbf24;
+      --blue: #60a5fa;
+      --green: #34d399;
+      --gray: #94a3b8;
+    }}
+    body {{
+      margin: 0;
+      font-family: system-ui, Segoe UI, Arial, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+    }}
+    header {{
+      padding: 24px;
+      border-bottom: 1px solid #334155;
+      background: #020617;
+    }}
+    h1 {{ margin: 0 0 8px; font-size: 28px; }}
+    .subtle {{ color: var(--muted); }}
+    main {{ padding: 24px; display: grid; gap: 20px; }}
+    .cards {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 16px;
+    }}
+    .card {{
+      background: var(--panel);
+      border: 1px solid #334155;
+      border-radius: 16px;
+      padding: 16px;
+      box-shadow: 0 8px 22px rgba(0,0,0,.22);
+    }}
+    .card .value {{ font-size: 30px; font-weight: 800; margin-top: 8px; }}
+    .grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+      gap: 20px;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border-radius: 12px;
+      overflow: hidden;
+    }}
+    th, td {{
+      padding: 9px 10px;
+      border-bottom: 1px solid #334155;
+      text-align: left;
+      font-size: 13px;
+      vertical-align: top;
+    }}
+    th {{ background: var(--panel2); position: sticky; top: 0; }}
+    input, select {{
+      background: #020617;
+      color: var(--text);
+      border: 1px solid #475569;
+      border-radius: 10px;
+      padding: 9px 10px;
+      margin-right: 10px;
+    }}
+    .bar-row {{
+      display: grid;
+      grid-template-columns: 220px 1fr 80px;
+      align-items: center;
+      gap: 10px;
+      margin: 10px 0;
+    }}
+    .bar {{
+      height: 16px;
+      background: #1e293b;
+      border-radius: 999px;
+      overflow: hidden;
+    }}
+    .bar span {{
+      display: block;
+      height: 100%;
+      background: var(--accent);
+      border-radius: 999px;
+    }}
+    .severity-red {{ color: var(--red); font-weight: 700; }}
+    .severity-amber {{ color: var(--amber); font-weight: 700; }}
+    .severity-blue {{ color: var(--blue); font-weight: 700; }}
+    .severity-gray {{ color: var(--gray); font-weight: 700; }}
+  </style>
+</head>
+<body>
+<header>
+  <h1>Billing Context Dashboard</h1>
+  <div class="subtle">Self-contained browser review: no Office license required.</div>
+</header>
+<main>
+  <section class="cards" id="cards"></section>
+  <section class="grid">
+    <div class="card"><h2>Hours by Work Context</h2><div id="contextBars"></div></div>
+    <div class="card"><h2>Top Technician Hours</h2><div id="techBars"></div></div>
+  </section>
+  <section class="card">
+    <h2>Mismatches</h2>
+    <div>
+      <input id="mismatchSearch" placeholder="Search mismatches">
+      <select id="severityFilter">
+        <option value="">All severities</option>
+        <option value="red">Red</option>
+        <option value="amber">Amber</option>
+        <option value="blue">Blue</option>
+        <option value="gray">Gray</option>
+      </select>
+    </div>
+    <div id="mismatchTable"></div>
+  </section>
+  <section class="card">
+    <h2>Row-Level Work Context</h2>
+    <div>
+      <input id="entrySearch" placeholder="Search entries">
+      <select id="monthFilter">
+        <option value="">All months</option>
+        <option value="04">April</option>
+        <option value="05">May</option>
+      </select>
+    </div>
+    <div id="entryTable"></div>
+  </section>
+</main>
+<script>
+const DATA = {json.dumps(payload, ensure_ascii=False)};
+
+function money(n) {{ return Number(n || 0).toFixed(2); }}
+
+function renderCards() {{
+  document.getElementById("cards").innerHTML = `
+    <div class="card"><div class="subtle">Total Hours</div><div class="value">${{money(DATA.summary.total_hours)}}</div></div>
+    <div class="card"><div class="subtle">Rows</div><div class="value">${{DATA.summary.row_count}}</div></div>
+    <div class="card"><div class="subtle">Mismatches</div><div class="value">${{DATA.mismatches.length}}</div></div>`;
+}}
+
+function renderBars(targetId, rows, labelKey) {{
+  const max = Math.max(...rows.map(r => Number(r.Hours || 0)), 1);
+  document.getElementById(targetId).innerHTML = rows.map(r => {{
+    const width = (Number(r.Hours || 0) / max) * 100;
+    return `<div class="bar-row"><div>${{r[labelKey]}}</div><div class="bar"><span style="width:${{width}}%"></span></div><div>${{money(r.Hours)}}</div></div>`;
+  }}).join("");
+}}
+
+function renderMismatchTable() {{
+  const q = document.getElementById("mismatchSearch").value.toLowerCase();
+  const sev = document.getElementById("severityFilter").value;
+  const rows = DATA.mismatches.filter(r => {{
+    const blob = Object.values(r).join(" ").toLowerCase();
+    return (!sev || r.severity === sev) && (!q || blob.includes(q));
+  }});
+  document.getElementById("mismatchTable").innerHTML = `
+    <table><thead><tr><th>Severity</th><th>Type</th><th>Tech</th><th>Date</th><th>From</th><th>To</th><th>Recommendation</th></tr></thead>
+    <tbody>${{rows.map(r => `<tr>
+      <td class="severity-${{r.severity}}">${{r.severity}}</td><td>${{r.mismatch_type}}</td><td>${{r.tech}}</td>
+      <td>${{r.work_date}}</td><td>${{r.source_a_value}}</td><td>${{r.source_b_value}}</td><td>${{r.recommendation}}</td></tr>`).join("")}}</tbody></table>`;
+}}
+
+function renderEntryTable() {{
+  const q = document.getElementById("entrySearch").value.toLowerCase();
+  const month = document.getElementById("monthFilter").value;
+  const rows = DATA.entries.filter(r => {{
+    const blob = Object.values(r).join(" ").toLowerCase();
+    return (!month || String(r.work_date).slice(5,7) === month) && (!q || blob.includes(q));
+  }});
+  document.getElementById("entryTable").innerHTML = `
+    <table><thead><tr><th>Date</th><th>Tech</th><th>Hours</th><th>Context</th><th>Reason</th><th>Original Assignment</th></tr></thead>
+    <tbody>${{rows.map(r => `<tr><td>${{r.work_date}}</td><td>${{r.tech}}</td><td>${{money(r.hours)}}</td>
+      <td>${{r.work_context}}</td><td>${{r.context_reason}}</td><td>${{r.original_assignment}}</td></tr>`).join("")}}</tbody></table>`;
+}}
+
+renderCards();
+renderBars("contextBars", DATA.summary.by_context, "Work Context");
+renderBars("techBars", DATA.summary.by_tech.slice(0, 12), "Tech");
+renderMismatchTable();
+renderEntryTable();
+document.getElementById("mismatchSearch").addEventListener("input", renderMismatchTable);
+document.getElementById("severityFilter").addEventListener("change", renderMismatchTable);
+document.getElementById("entrySearch").addEventListener("input", renderEntryTable);
+document.getElementById("monthFilter").addEventListener("change", renderEntryTable);
+</script>
+</body>
+</html>
+"""
+
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    Path(out_path).write_text(html, encoding="utf-8")
+    return out_path

--- a/triage/billing_context/models.py
+++ b/triage/billing_context/models.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import date, time
+from typing import Literal
+
+
+WorkContext = Literal[
+    "Configuration",
+    "Inventory Management",
+    "Inventory Management & Logistics",
+    "Deployment Support",
+    "Incident Response",
+    "Ticket Coordination",
+    "Client Coordination",
+    "Logistics",
+    "Mixed Operational Support",
+    "Unknown / Needs Review",
+]
+
+
+@dataclass(frozen=True)
+class WorkEntry:
+    source: str
+    sheet_name: str
+    row_number: int
+    tech: str
+    work_date: date
+    start_time: time | None
+    end_time: time | None
+    hours: float
+    original_assignment: str
+    work_context: WorkContext
+    context_reason: str
+    notes: str = ""
+    confidence: str = "medium"
+
+    def to_dict(self) -> dict:
+        d = asdict(self)
+        d["work_date"] = self.work_date.isoformat()
+        d["start_time"] = self.start_time.isoformat() if self.start_time else ""
+        d["end_time"] = self.end_time.isoformat() if self.end_time else ""
+        return d
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    severity: Literal["red", "amber", "blue", "gray"]
+    mismatch_type: str
+    tech: str
+    work_date: str
+    source_a: str
+    source_b: str
+    source_a_value: str
+    source_b_value: str
+    recommendation: str
+    leadership_safe: bool = False
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ExportResult:
+    output_path: str
+    row_count: int
+    total_hours: float
+    warnings: list[str]

--- a/triage/billing_context/reconcile.py
+++ b/triage/billing_context/reconcile.py
@@ -43,10 +43,27 @@ def parse_time(value: Any) -> Optional[time]:
         return None
 
     text = str(value).strip()
-    for sep in ["/", "-", "|", ";"]:
-        if sep in text:
-            text = text.split(sep, 1)[0].strip()
-            break
+
+    datetime_formats = (
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M",
+        "%m/%d/%Y %I:%M:%S %p",
+        "%m/%d/%Y %I:%M %p",
+        "%m/%d/%y %I:%M %p",
+    )
+    for fmt in datetime_formats:
+        try:
+            return datetime.strptime(text, fmt).time()
+        except ValueError:
+            pass
+
+    if " " in text:
+        time_part = text.rsplit(" ", 1)[-1]
+        for fmt in ("%I:%M:%S %p", "%I:%M %p", "%H:%M:%S", "%H:%M"):
+            try:
+                return datetime.strptime(time_part, fmt).time()
+            except ValueError:
+                pass
 
     for fmt in ("%I:%M:%S %p", "%I:%M %p", "%H:%M:%S", "%H:%M"):
         try:
@@ -213,10 +230,10 @@ def _generic_hours_index(path: str) -> dict[tuple[str, str], float]:
     return dict(index)
 
 
-def build_dashboard_index(dashboard_path: str | None) -> dict[tuple[str, str], dict[str, Any]]:
+def build_dashboard_index(dashboard_path: str | None) -> dict[tuple[str, str], dict[str, Any]] | None:
     if not dashboard_path:
-        return {}
-    index: dict[tuple[str, str], dict[str, Any]] = {}
+        return None
+    rows_by_key: dict[tuple[str, str], list[dict[str, Any]]] = defaultdict(list)
     for row in load_dashboard_rows(dashboard_path):
         d = parse_date(row.date)
         if not row.tech or not d:
@@ -226,13 +243,44 @@ def build_dashboard_index(dashboard_path: str | None) -> dict[tuple[str, str], d
         admin_h = safe_float(row.current_admin_value, default=-1.0)
         expected = safe_float(row.expected_total, default=-1.0)
         hours = roster_h if roster_h >= 0 else (admin_h if admin_h >= 0 else expected)
+        rows_by_key[key].append(
+            {
+                "hours": hours if hours >= 0 else 0.0,
+                "review_status": row.review_status,
+                "reason_code": row.reason_code,
+                "partial": 0 < hours < 8 if hours > 0 else False,
+            }
+        )
+
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for key, rows in rows_by_key.items():
+        total_hours = round(sum(safe_float(r.get("hours")) for r in rows), 2)
+        worst_status = ""
+        partial = False
+        for r in rows:
+            status = str(r.get("review_status") or "")
+            bucket = review_status_bucket(status)
+            if bucket not in ("resolved_green", "skipped_gray"):
+                worst_status = status or worst_status
+            if r.get("partial"):
+                partial = True
         index[key] = {
-            "hours": hours if hours >= 0 else 0.0,
-            "review_status": row.review_status,
-            "reason_code": row.reason_code,
-            "partial": 0 < hours < 8 if hours > 0 else False,
+            "hours": total_hours,
+            "review_status": worst_status,
+            "reason_code": rows[-1].get("reason_code", ""),
+            "partial": partial,
         }
     return index
+
+
+def aggregate_daily_track_hours(entries: list[WorkEntry]) -> tuple[dict[tuple[str, str], float], dict[tuple[str, str], str]]:
+    totals: dict[tuple[str, str], float] = defaultdict(float)
+    tech_names: dict[tuple[str, str], str] = {}
+    for e in entries:
+        key = entry_key(e.tech, e.work_date)
+        totals[key] += e.hours
+        tech_names[key] = e.tech
+    return {k: round(v, 2) for k, v in totals.items()}, tech_names
 
 
 def find_context_mismatches(entries: list[WorkEntry]) -> list[Mismatch]:
@@ -256,15 +304,18 @@ def find_context_mismatches(entries: list[WorkEntry]) -> list[Mismatch]:
             )
 
         if e.work_context == "Unknown / Needs Review":
+            mismatch_type = "missing_work_context"
+            if "disagree" in e.context_reason.lower():
+                mismatch_type = "context_assignment_conflict"
             mismatches.append(
                 Mismatch(
                     severity="red",
-                    mismatch_type="missing_work_context",
+                    mismatch_type=mismatch_type,
                     tech=e.tech,
                     work_date=e.work_date.isoformat(),
                     source_a="task_tracker/roster/timing",
                     source_b="resolved_context",
-                    source_a_value="No decisive context",
+                    source_a_value=e.original_assignment or "No decisive context",
                     source_b_value=e.work_context,
                     recommendation="Review task tracker or add explicit context override.",
                     leadership_safe=False,
@@ -288,45 +339,71 @@ def find_cross_source_mismatches(
     roster_index: dict[tuple[str, str], float] | None = None,
     admin_index: dict[tuple[str, str], float] | None = None,
     dashboard_index: dict[tuple[str, str], dict[str, Any]] | None = None,
+    roster_enabled: bool = False,
+    admin_enabled: bool = False,
+    dashboard_enabled: bool = False,
 ) -> list[Mismatch]:
     mismatches: list[Mismatch] = []
-    roster_index = roster_index or {}
-    admin_index = admin_index or {}
-    dashboard_index = dashboard_index or {}
+    roster_idx = roster_index or {}
+    admin_idx = admin_index or {}
+    dashboard_idx = dashboard_index or {}
 
-    for e in entries:
-        key = entry_key(e.tech, e.work_date)
+    daily_track, tech_names = aggregate_daily_track_hours(entries)
+    seen_partial: set[tuple[str, str, str]] = set()
 
-        for source_name, idx in (
-            ("roster_log", roster_index),
-            ("admin_copy", admin_index),
+    for key, track_hours in daily_track.items():
+        tech_key, work_date = key
+        tech_display = tech_names.get(key, tech_key)
+
+        for source_name, idx, enabled in (
+            ("roster_log", roster_idx, roster_enabled),
+            ("admin_copy", admin_idx, admin_enabled),
         ):
-            if key not in idx:
+            if not enabled:
                 continue
+            if key not in idx:
+                mismatches.append(
+                    Mismatch(
+                        severity="blue",
+                        mismatch_type="missing_in_source",
+                        tech=tech_display,
+                        work_date=work_date,
+                        source_a="track_hours",
+                        source_b=source_name,
+                        source_a_value=str(track_hours),
+                        source_b_value="(absent)",
+                        recommendation=f"Track row not found in {source_name}.",
+                        leadership_safe=False,
+                    )
+                )
+                continue
+
             other = idx[key]
-            delta = round(e.hours - other, 2)
+            delta = round(track_hours - other, 2)
             if abs(delta) > HOUR_TOLERANCE:
                 mismatches.append(
                     Mismatch(
                         severity=_hour_delta_severity(delta),  # type: ignore[arg-type]
                         mismatch_type="hours_delta",
-                        tech=e.tech,
-                        work_date=e.work_date.isoformat(),
+                        tech=tech_display,
+                        work_date=work_date,
                         source_a="track_hours",
                         source_b=source_name,
-                        source_a_value=str(e.hours),
+                        source_a_value=str(track_hours),
                         source_b_value=str(other),
                         recommendation=f"Reconcile hour delta ({delta:+.2f}h) between track hours and {source_name}.",
                         leadership_safe=False,
                     )
                 )
-            if 0 < other < 8:
+            partial_key = (work_date, tech_key, source_name)
+            if 0 < other < 8 and partial_key not in seen_partial:
+                seen_partial.add(partial_key)
                 mismatches.append(
                     Mismatch(
                         severity="amber",
                         mismatch_type="partial_hours",
-                        tech=e.tech,
-                        work_date=e.work_date.isoformat(),
+                        tech=tech_display,
+                        work_date=work_date,
                         source_a=source_name,
                         source_b="expected_full_day",
                         source_a_value=str(other),
@@ -336,86 +413,77 @@ def find_cross_source_mismatches(
                     )
                 )
 
-        if key in dashboard_index:
-            dash = dashboard_index[key]
-            dash_h = safe_float(dash.get("hours"))
-            if dash_h > 0:
-                delta = round(e.hours - dash_h, 2)
-                if abs(delta) > HOUR_TOLERANCE:
-                    mismatches.append(
-                        Mismatch(
-                            severity=_hour_delta_severity(delta),  # type: ignore[arg-type]
-                            mismatch_type="hours_delta",
-                            tech=e.tech,
-                            work_date=e.work_date.isoformat(),
-                            source_a="track_hours",
-                            source_b="dashboard",
-                            source_a_value=str(e.hours),
-                            source_b_value=str(dash_h),
-                            recommendation=f"Reconcile hour delta ({delta:+.2f}h) with resolution ledger.",
-                            leadership_safe=False,
-                        )
-                    )
-            status = str(dash.get("review_status") or "")
-            bucket = review_status_bucket(status)
-            if bucket not in ("resolved_green", "skipped_gray") and e.hours > 0:
-                mismatches.append(
-                    Mismatch(
-                        severity="red",
-                        mismatch_type="dashboard_unresolved",
-                        tech=e.tech,
-                        work_date=e.work_date.isoformat(),
-                        source_a="dashboard_review_status",
-                        source_b="track_hours",
-                        source_a_value=status or "(blank)",
-                        source_b_value=str(e.hours),
-                        recommendation="Dashboard row not resolved before billing export.",
-                        leadership_safe=False,
-                    )
-                )
-            if dash.get("partial"):
-                mismatches.append(
-                    Mismatch(
-                        severity="amber",
-                        mismatch_type="partial_hours",
-                        tech=e.tech,
-                        work_date=e.work_date.isoformat(),
-                        source_a="dashboard",
-                        source_b="expected_full_day",
-                        source_a_value=str(dash_h),
-                        source_b_value="8.0",
-                        recommendation="Partial hours flagged on dashboard resolution ledger.",
-                        leadership_safe=False,
-                    )
-                )
-        elif dashboard_index:
+        if not dashboard_enabled:
+            continue
+
+        if key not in dashboard_idx:
             mismatches.append(
                 Mismatch(
                     severity="gray",
                     mismatch_type="missing_in_source",
-                    tech=e.tech,
-                    work_date=e.work_date.isoformat(),
+                    tech=tech_key.title(),
+                    work_date=work_date,
                     source_a="track_hours",
                     source_b="dashboard",
-                    source_a_value=str(e.hours),
+                    source_a_value=str(track_hours),
                     source_b_value="(absent)",
                     recommendation="Track row not found on dashboard resolution ledger.",
                     leadership_safe=False,
                 )
             )
+            continue
 
-        if roster_index and key not in roster_index:
+        dash = dashboard_idx[key]
+        dash_h = safe_float(dash.get("hours"))
+        if dash_h > 0:
+            delta = round(track_hours - dash_h, 2)
+            if abs(delta) > HOUR_TOLERANCE:
+                mismatches.append(
+                    Mismatch(
+                        severity=_hour_delta_severity(delta),  # type: ignore[arg-type]
+                        mismatch_type="hours_delta",
+                        tech=tech_display,
+                        work_date=work_date,
+                        source_a="track_hours",
+                        source_b="dashboard",
+                        source_a_value=str(track_hours),
+                        source_b_value=str(dash_h),
+                        recommendation=f"Reconcile hour delta ({delta:+.2f}h) with resolution ledger.",
+                        leadership_safe=False,
+                    )
+                )
+        status = str(dash.get("review_status") or "")
+        if status and track_hours > 0:
+            bucket = review_status_bucket(status)
+            if bucket not in ("resolved_green", "skipped_gray"):
+                mismatches.append(
+                    Mismatch(
+                        severity="red",
+                        mismatch_type="dashboard_unresolved",
+                        tech=tech_display,
+                        work_date=work_date,
+                        source_a="dashboard_review_status",
+                        source_b="track_hours",
+                        source_a_value=status,
+                        source_b_value=str(track_hours),
+                        recommendation="Dashboard row not resolved before billing export.",
+                        leadership_safe=False,
+                    )
+                )
+        partial_key = (work_date, tech_key, "dashboard")
+        if dash.get("partial") and partial_key not in seen_partial:
+            seen_partial.add(partial_key)
             mismatches.append(
                 Mismatch(
-                    severity="blue",
-                    mismatch_type="missing_in_source",
-                    tech=e.tech,
-                    work_date=e.work_date.isoformat(),
-                    source_a="track_hours",
-                    source_b="roster_log",
-                    source_a_value=str(e.hours),
-                    source_b_value="(absent)",
-                    recommendation="Track row not found in active roster log.",
+                    severity="amber",
+                    mismatch_type="partial_hours",
+                    tech=tech_key.title(),
+                    work_date=work_date,
+                    source_a="dashboard",
+                    source_b="expected_full_day",
+                    source_a_value=str(dash_h),
+                    source_b_value="8.0",
+                    recommendation="Partial hours flagged on dashboard resolution ledger.",
                     leadership_safe=False,
                 )
             )
@@ -431,11 +499,17 @@ def find_all_mismatches(
     dashboard_path: str | None = None,
 ) -> list[Mismatch]:
     context = find_context_mismatches(entries)
+    roster_enabled = roster_path is not None
+    admin_enabled = admin_path is not None
+    dashboard_enabled = dashboard_path is not None
     cross = find_cross_source_mismatches(
         entries,
-        roster_index=build_roster_hours_index(roster_path),
-        admin_index=build_admin_hours_index(admin_path),
+        roster_index=build_roster_hours_index(roster_path) if roster_enabled else None,
+        admin_index=build_admin_hours_index(admin_path) if admin_enabled else None,
         dashboard_index=build_dashboard_index(dashboard_path),
+        roster_enabled=roster_enabled,
+        admin_enabled=admin_enabled,
+        dashboard_enabled=dashboard_enabled,
     )
     return context + cross
 

--- a/triage/billing_context/reconcile.py
+++ b/triage/billing_context/reconcile.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, datetime, time
+from typing import Any, Optional
+
+from triage.admin_billing_context_rules import friday_batch_for
+from triage.nw_prj_dashboard_rows import load_dashboard_rows
+from triage.nw_prj_dashboard_validator import review_status_bucket
+from triage.roster_parser import RosterParseError, parse_roster
+from triage.tech_hours_parser import TechHoursParseError, parse_tech_hours
+
+from .context_rules import is_placeholder_assignment, resolve_work_context
+from .models import Mismatch, WorkEntry
+from .workbook_io import iter_dict_rows, load_xlsx, safe_float
+
+HOUR_TOLERANCE = 0.01
+
+
+def parse_date(value: Any) -> Optional[date]:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if not value:
+        return None
+
+    text = str(value).strip()
+    for fmt in ("%Y-%m-%d", "%m/%d/%Y", "%m/%d/%y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            pass
+    return None
+
+
+def parse_time(value: Any) -> Optional[time]:
+    if isinstance(value, datetime):
+        return value.time()
+    if isinstance(value, time):
+        return value
+    if not value:
+        return None
+
+    text = str(value).strip()
+    for sep in ["/", "-", "|", ";"]:
+        if sep in text:
+            text = text.split(sep, 1)[0].strip()
+            break
+
+    for fmt in ("%I:%M:%S %p", "%I:%M %p", "%H:%M:%S", "%H:%M"):
+        try:
+            return datetime.strptime(text, fmt).time()
+        except ValueError:
+            pass
+
+    return None
+
+
+def normalize_tech(value: Any) -> str:
+    return " ".join(str(value or "").strip().split())
+
+
+def entry_key(tech: str, work_date: date) -> tuple[str, str]:
+    return (normalize_tech(tech).lower(), work_date.isoformat())
+
+
+def build_task_context_index(april_context_path: str) -> dict[tuple[str, str], str]:
+    """Key: (tech_lower, yyyy-mm-dd). Value: combined task text."""
+    wb = load_xlsx(april_context_path, data_only=True)
+    index: dict[tuple[str, str], list[str]] = defaultdict(list)
+
+    for ws in wb.worksheets:
+        for row in iter_dict_rows(ws):
+            tech = normalize_tech(
+                row.get("Tech")
+                or row.get("Technician")
+                or row.get("Name")
+                or row.get("Resource")
+            )
+            d = parse_date(row.get("Date") or row.get("Work Date"))
+            if not tech or not d:
+                continue
+
+            text_parts = []
+            for key, val in row.items():
+                if key.startswith("_"):
+                    continue
+                if val not in (None, ""):
+                    text_parts.append(f"{key}: {val}")
+
+            index[(tech.lower(), d.isoformat())].append(" | ".join(text_parts))
+
+    wb.close()
+    return {k: "\n".join(v) for k, v in index.items()}
+
+
+def extract_track_hours(track_hours_path: str, task_index: dict[tuple[str, str], str]) -> list[WorkEntry]:
+    wb = load_xlsx(track_hours_path, data_only=True)
+    entries: list[WorkEntry] = []
+
+    for ws in wb.worksheets:
+        if ws.sheet_state != "visible":
+            continue
+
+        for row in iter_dict_rows(ws):
+            tech = normalize_tech(
+                row.get("Tech")
+                or row.get("Technician")
+                or row.get("Name")
+            )
+            work_date = parse_date(row.get("Date") or row.get("Work Date"))
+            if not tech or not work_date:
+                continue
+
+            hours = safe_float(row.get("Hours") or row.get("Total Hours") or row.get("Total"))
+            if hours <= 0:
+                continue
+
+            start_time = parse_time(row.get("In") or row.get("Start") or row.get("Start Time"))
+            end_time = parse_time(row.get("Out") or row.get("End") or row.get("End Time"))
+            assignment = str(
+                row.get("Assignment") or row.get("Assignment Type") or row.get("Work Context") or ""
+            ).strip()
+
+            task_text = task_index.get((tech.lower(), work_date.isoformat()), "")
+            context, reason, confidence = resolve_work_context(
+                assignment=assignment,
+                task_text=task_text,
+                work_date=work_date,
+                start_time=start_time,
+                end_time=end_time,
+            )
+
+            entries.append(
+                WorkEntry(
+                    source=track_hours_path,
+                    sheet_name=ws.title,
+                    row_number=int(row["_row_number"]),
+                    tech=tech,
+                    work_date=work_date,
+                    start_time=start_time,
+                    end_time=end_time,
+                    hours=hours,
+                    original_assignment=assignment,
+                    work_context=context,  # type: ignore[arg-type]
+                    context_reason=reason,
+                    notes=task_text[:1000],
+                    confidence=confidence,
+                )
+            )
+
+    wb.close()
+    return entries
+
+
+def _hours_index_from_records(
+    records: list[dict[str, Any]],
+    *,
+    staff_key: str = "staff",
+    date_key: str = "date",
+    hours_key: str = "net_hours",
+) -> dict[tuple[str, str], float]:
+    index: dict[tuple[str, str], float] = {}
+    for rec in records:
+        tech = normalize_tech(rec.get(staff_key) or rec.get("tech"))
+        d = rec.get(date_key)
+        if isinstance(d, datetime):
+            d = d.date()
+        if not tech or not isinstance(d, date):
+            continue
+        hours = safe_float(rec.get(hours_key) or rec.get("gross_hours") or rec.get("hours"))
+        key = entry_key(tech, d)
+        index[key] = index.get(key, 0.0) + hours
+    return index
+
+
+def build_roster_hours_index(roster_path: str | None) -> dict[tuple[str, str], float]:
+    if not roster_path:
+        return {}
+    try:
+        records = parse_roster(roster_path)
+        return _hours_index_from_records(records)
+    except RosterParseError:
+        return _generic_hours_index(roster_path)
+
+
+def build_admin_hours_index(admin_path: str | None) -> dict[tuple[str, str], float]:
+    if not admin_path:
+        return {}
+    try:
+        records = parse_tech_hours(admin_path)
+        return _hours_index_from_records(records)
+    except TechHoursParseError:
+        return _generic_hours_index(admin_path)
+
+
+def _generic_hours_index(path: str) -> dict[tuple[str, str], float]:
+    wb = load_xlsx(path, data_only=True)
+    index: dict[tuple[str, str], float] = defaultdict(float)
+    for ws in wb.worksheets:
+        for row in iter_dict_rows(ws):
+            tech = normalize_tech(
+                row.get("Tech") or row.get("Technician") or row.get("Name") or row.get("Staff")
+            )
+            d = parse_date(row.get("Date") or row.get("Work Date"))
+            if not tech or not d:
+                continue
+            hours = safe_float(row.get("Hours") or row.get("Total Hours") or row.get("Total") or row.get("net_hours"))
+            if hours > 0:
+                index[entry_key(tech, d)] += hours
+    wb.close()
+    return dict(index)
+
+
+def build_dashboard_index(dashboard_path: str | None) -> dict[tuple[str, str], dict[str, Any]]:
+    if not dashboard_path:
+        return {}
+    index: dict[tuple[str, str], dict[str, Any]] = {}
+    for row in load_dashboard_rows(dashboard_path):
+        d = parse_date(row.date)
+        if not row.tech or not d:
+            continue
+        key = entry_key(row.tech, d)
+        roster_h = safe_float(row.roster_latest_hours, default=-1.0)
+        admin_h = safe_float(row.current_admin_value, default=-1.0)
+        expected = safe_float(row.expected_total, default=-1.0)
+        hours = roster_h if roster_h >= 0 else (admin_h if admin_h >= 0 else expected)
+        index[key] = {
+            "hours": hours if hours >= 0 else 0.0,
+            "review_status": row.review_status,
+            "reason_code": row.reason_code,
+            "partial": 0 < hours < 8 if hours > 0 else False,
+        }
+    return index
+
+
+def find_context_mismatches(entries: list[WorkEntry]) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+
+    for e in entries:
+        if is_placeholder_assignment(e.original_assignment):
+            mismatches.append(
+                Mismatch(
+                    severity="amber",
+                    mismatch_type="placeholder_assignment_replaced",
+                    tech=e.tech,
+                    work_date=e.work_date.isoformat(),
+                    source_a="original_assignment",
+                    source_b="resolved_context",
+                    source_a_value=e.original_assignment,
+                    source_b_value=e.work_context,
+                    recommendation="Replace placeholder assignment with resolved work context.",
+                    leadership_safe=False,
+                )
+            )
+
+        if e.work_context == "Unknown / Needs Review":
+            mismatches.append(
+                Mismatch(
+                    severity="red",
+                    mismatch_type="missing_work_context",
+                    tech=e.tech,
+                    work_date=e.work_date.isoformat(),
+                    source_a="task_tracker/roster/timing",
+                    source_b="resolved_context",
+                    source_a_value="No decisive context",
+                    source_b_value=e.work_context,
+                    recommendation="Review task tracker or add explicit context override.",
+                    leadership_safe=False,
+                )
+            )
+
+    return mismatches
+
+
+def _hour_delta_severity(delta: float) -> str:
+    if abs(delta) >= 1.0:
+        return "red"
+    if abs(delta) >= 0.25:
+        return "amber"
+    return "blue"
+
+
+def find_cross_source_mismatches(
+    entries: list[WorkEntry],
+    *,
+    roster_index: dict[tuple[str, str], float] | None = None,
+    admin_index: dict[tuple[str, str], float] | None = None,
+    dashboard_index: dict[tuple[str, str], dict[str, Any]] | None = None,
+) -> list[Mismatch]:
+    mismatches: list[Mismatch] = []
+    roster_index = roster_index or {}
+    admin_index = admin_index or {}
+    dashboard_index = dashboard_index or {}
+
+    for e in entries:
+        key = entry_key(e.tech, e.work_date)
+
+        for source_name, idx in (
+            ("roster_log", roster_index),
+            ("admin_copy", admin_index),
+        ):
+            if key not in idx:
+                continue
+            other = idx[key]
+            delta = round(e.hours - other, 2)
+            if abs(delta) > HOUR_TOLERANCE:
+                mismatches.append(
+                    Mismatch(
+                        severity=_hour_delta_severity(delta),  # type: ignore[arg-type]
+                        mismatch_type="hours_delta",
+                        tech=e.tech,
+                        work_date=e.work_date.isoformat(),
+                        source_a="track_hours",
+                        source_b=source_name,
+                        source_a_value=str(e.hours),
+                        source_b_value=str(other),
+                        recommendation=f"Reconcile hour delta ({delta:+.2f}h) between track hours and {source_name}.",
+                        leadership_safe=False,
+                    )
+                )
+            if 0 < other < 8:
+                mismatches.append(
+                    Mismatch(
+                        severity="amber",
+                        mismatch_type="partial_hours",
+                        tech=e.tech,
+                        work_date=e.work_date.isoformat(),
+                        source_a=source_name,
+                        source_b="expected_full_day",
+                        source_a_value=str(other),
+                        source_b_value="8.0",
+                        recommendation="Partial hours flagged in secondary source before submission.",
+                        leadership_safe=False,
+                    )
+                )
+
+        if key in dashboard_index:
+            dash = dashboard_index[key]
+            dash_h = safe_float(dash.get("hours"))
+            if dash_h > 0:
+                delta = round(e.hours - dash_h, 2)
+                if abs(delta) > HOUR_TOLERANCE:
+                    mismatches.append(
+                        Mismatch(
+                            severity=_hour_delta_severity(delta),  # type: ignore[arg-type]
+                            mismatch_type="hours_delta",
+                            tech=e.tech,
+                            work_date=e.work_date.isoformat(),
+                            source_a="track_hours",
+                            source_b="dashboard",
+                            source_a_value=str(e.hours),
+                            source_b_value=str(dash_h),
+                            recommendation=f"Reconcile hour delta ({delta:+.2f}h) with resolution ledger.",
+                            leadership_safe=False,
+                        )
+                    )
+            status = str(dash.get("review_status") or "")
+            bucket = review_status_bucket(status)
+            if bucket not in ("resolved_green", "skipped_gray") and e.hours > 0:
+                mismatches.append(
+                    Mismatch(
+                        severity="red",
+                        mismatch_type="dashboard_unresolved",
+                        tech=e.tech,
+                        work_date=e.work_date.isoformat(),
+                        source_a="dashboard_review_status",
+                        source_b="track_hours",
+                        source_a_value=status or "(blank)",
+                        source_b_value=str(e.hours),
+                        recommendation="Dashboard row not resolved before billing export.",
+                        leadership_safe=False,
+                    )
+                )
+            if dash.get("partial"):
+                mismatches.append(
+                    Mismatch(
+                        severity="amber",
+                        mismatch_type="partial_hours",
+                        tech=e.tech,
+                        work_date=e.work_date.isoformat(),
+                        source_a="dashboard",
+                        source_b="expected_full_day",
+                        source_a_value=str(dash_h),
+                        source_b_value="8.0",
+                        recommendation="Partial hours flagged on dashboard resolution ledger.",
+                        leadership_safe=False,
+                    )
+                )
+        elif dashboard_index:
+            mismatches.append(
+                Mismatch(
+                    severity="gray",
+                    mismatch_type="missing_in_source",
+                    tech=e.tech,
+                    work_date=e.work_date.isoformat(),
+                    source_a="track_hours",
+                    source_b="dashboard",
+                    source_a_value=str(e.hours),
+                    source_b_value="(absent)",
+                    recommendation="Track row not found on dashboard resolution ledger.",
+                    leadership_safe=False,
+                )
+            )
+
+        if roster_index and key not in roster_index:
+            mismatches.append(
+                Mismatch(
+                    severity="blue",
+                    mismatch_type="missing_in_source",
+                    tech=e.tech,
+                    work_date=e.work_date.isoformat(),
+                    source_a="track_hours",
+                    source_b="roster_log",
+                    source_a_value=str(e.hours),
+                    source_b_value="(absent)",
+                    recommendation="Track row not found in active roster log.",
+                    leadership_safe=False,
+                )
+            )
+
+    return mismatches
+
+
+def find_all_mismatches(
+    entries: list[WorkEntry],
+    *,
+    roster_path: str | None = None,
+    admin_path: str | None = None,
+    dashboard_path: str | None = None,
+) -> list[Mismatch]:
+    context = find_context_mismatches(entries)
+    cross = find_cross_source_mismatches(
+        entries,
+        roster_index=build_roster_hours_index(roster_path),
+        admin_index=build_admin_hours_index(admin_path),
+        dashboard_index=build_dashboard_index(dashboard_path),
+    )
+    return context + cross
+
+
+def friday_batch_key(work_date: date) -> str:
+    return friday_batch_for(work_date).isoformat()

--- a/triage/billing_context/workbook_io.py
+++ b/triage/billing_context/workbook_io.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Iterable
+
+from openpyxl import load_workbook
+from openpyxl.worksheet.worksheet import Worksheet
+
+
+def load_xlsx(path: str | Path, data_only: bool = True):
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Workbook not found: {p}")
+    return load_workbook(p, data_only=data_only)
+
+
+def normalize_header(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip().replace("\n", " ").replace("\r", " ")
+
+
+def header_map(ws: Worksheet, header_row: int = 1) -> dict[str, int]:
+    headers: dict[str, int] = {}
+    for cell in ws[header_row]:
+        name = normalize_header(cell.value)
+        if name:
+            headers[name] = cell.column
+    return headers
+
+
+def iter_dict_rows(ws: Worksheet, header_row: int = 1) -> Iterable[dict[str, Any]]:
+    headers = header_map(ws, header_row)
+    reverse = {col: name for name, col in headers.items()}
+
+    for r in range(header_row + 1, ws.max_row + 1):
+        row: dict[str, Any] = {}
+        empty = True
+        for col, name in reverse.items():
+            value = ws.cell(r, col).value
+            if value not in (None, ""):
+                empty = False
+            row[name] = value
+        if not empty:
+            row["_row_number"] = r
+            yield row
+
+
+def safe_float(value: Any, default: float = 0.0) -> float:
+    if value in (None, ""):
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    try:
+        return float(str(value).strip())
+    except ValueError:
+        return default
+
+
+def sheet_names(path: str | Path) -> list[str]:
+    wb = load_xlsx(path)
+    names = list(wb.sheetnames)
+    wb.close()
+    return names


### PR DESCRIPTION
## Summary

Adds `triage/billing_context/` engine: CLI, context rules, 5-source reconciliation, leadership-safe charted XLSX exports, self-contained HTML dashboard, mismatch JSON/CSV, ZIP manifest validation, and canonical rules docs.

## Test plan

- [x] `python -m pytest tests/test_billing_context_rules.py tests/test_billing_context_reconcile.py tests/test_billing_context_html.py -q` (**17 passed** at head `23f223e`)
- [x] `python -m compileall triage tests` (clean)
- [x] Synthetic artifact smoke test passed (CSV injection neutralization, HTML esc plumbing, forbidden-text scan, unsupported month rejection)
- [ ] Full CLI E2E with five real input workbooks in `Candidates/` (inputs not in repo)
- [ ] Open `Outputs/billing_context_dashboard.html` locally after E2E
- [ ] Verify leadership outputs contain no raw provenance fields after E2E
- [ ] Verify no visible ellipses / draft text in leadership XLSX after E2E
- [ ] Verify ZIP manifest paths exist after E2E

## Full suite note

`python -m pytest -q` reports unrelated failures/errors (invoice parser / missing optional deps). PR #20 billing-context gate is green.

## Related docs

- `docs/BILLING_WORK_CONTEXT_RULES.md`
- `docs/BILLING_CONTEXT_EXPORTER.md`
- `docs/ARTIFACT_SPRINT_CARRYOVER_2026-05-30.md`
- PR #19 / #21 doctrine merged to main