### PR TITLE
Document billing summary text quality rules

### DIFF
--- a/docs/BILLING_SUMMARY_TEXT_QUALITY.md
+++ b/docs/BILLING_SUMMARY_TEXT_QUALITY.md
@@ -1,0 +1,91 @@
+# Billing Summary Text Quality
+
+## Scope
+
+This document applies to leadership-facing billing summaries and project-hours exports.
+
+It does not apply to the internal admin log copy format-preservation workflow.
+
+## Rule
+
+Billing-summary text must be complete, human-readable, and leadership-safe.
+
+Do not ship truncated generated text.
+
+Work Context fields must not contain ellipses or mid-word clipped text. A value such as `Provided operating control, reporting, tracker maintenance, and configuration...` is broken output, not a usable summary.
+
+## Work Context standard
+
+Each Work Context value should be a complete phrase or sentence that explains what the hours supported.
+
+Good examples:
+
+```text
+Operating Control / Reporting / Tracker / Configuration Support: Provided operating control, reporting, tracker maintenance, and configuration support.
+Configuration / inventory support: Provided weekday coverage for configuration support, staging, and inventory control.
+Project control / reporting / tracker closeout: Provided project control, reporting, tracker closeout, and limited client-facing coordination.
+Configuration workflow / inventory control / QA readiness / ticket follow-through: Supported Cybernet configuration, inventory organization, QA readiness, and ticket follow-through.
+```
+
+## Forbidden visible text markers
+
+Fail the artifact if any leadership-facing workbook contains visible text markers that indicate unfinished output, including ellipses, mid-word clipping, to-be-completed labels, or draft filler.
+
+The rule applies especially to:
+
+- Tracker Import tabs,
+- Work Context columns,
+- Context Reason columns,
+- Project Hours exports,
+- executive/admin summary notes,
+- chart captions if present.
+
+## Required validation
+
+Before exporting a billing summary, scan all visible sheets for truncation markers and unfinished text.
+
+Suggested Python validation:
+
+```python
+FORBIDDEN_TEXT_TOKENS = ["...", "…", "TBD", "TODO", "context goes here"]
+
+
+def scan_for_forbidden_text(workbook) -> list[dict]:
+    hits = []
+    for ws in workbook.worksheets:
+        if getattr(ws, "sheet_state", "visible") != "visible":
+            continue
+        for row in ws.iter_rows():
+            for cell in row:
+                value = str(cell.value or "")
+                for token in FORBIDDEN_TEXT_TOKENS:
+                    if token.lower() in value.lower():
+                        hits.append({
+                            "sheet": ws.title,
+                            "cell": cell.coordinate,
+                            "token": token,
+                            "value": value,
+                        })
+    return hits
+```
+
+If this scan returns hits, the generator must stop and require correction before the workbook is blessed.
+
+## Stop-ship checks
+
+Do not send a leadership-facing billing summary if:
+
+- Work Context text is truncated,
+- an ellipsis appears in visible workbook text,
+- generated context is cut mid-word,
+- generic labels replace actual task context,
+- the workbook has charts but the underlying context text is sloppy,
+- or the workbook passes structural validation but fails human-readable review.
+
+## Relationship to visual quality
+
+Charts help, but they do not excuse weak text.
+
+A charted workbook with truncated Work Context is still failed output.
+
+The operator should be able to open the Tracker Import tab and understand why each row was included without guessing what a clipped sentence was supposed to say.


### PR DESCRIPTION
## **User description**
## Summary

Adds billing-summary text-quality doctrine so leadership-facing workbooks fail validation when generated context text is truncated, clipped, or unfinished.

## Why

The latest April Billing Summary had Work Context values with clipped generated text. A structurally valid workbook can still be failed output if visible leadership-facing text is incomplete.

## What changed

- Defines complete Work Context text as a billing artifact requirement.
- Adds forbidden visible text markers for leadership-facing outputs.
- Requires a pre-export scan for ellipses, draft filler, and unfinished context text.
- Adds stop-ship checks so charted summaries cannot hide sloppy row-level context.

## Scope

This applies to leadership-facing billing summaries and project-hours exports. It does not apply to the internal admin log copy format-preservation workflow.


___

## **CodeAnt-AI Description**
**Document billing summary text quality stop-ship rules**

### What Changed
- Adds rules for leadership-facing billing summaries to reject truncated, clipped, or unfinished visible text
- Requires Work Context values to read as complete, human-readable summaries instead of ending with ellipses or mid-word cuts
- Lists visible text markers and workbook areas that must be checked before export, and says the workbook must be stopped if any are found
- Clarifies that charts do not override poor text quality and that the Tracker Import tab should still explain each included row clearly

### Impact
`✅ Fewer truncated billing summaries`
`✅ Clearer leadership-facing workbook text`
`✅ Fewer stop-ship surprises in export review`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
