### PR TITLE
feat(nw-prj): scaffold admin scratch and roster ingestion contracts

### DIFF
--- a/tests/test_nw_prj_input_ingestion.py
+++ b/tests/test_nw_prj_input_ingestion.py
@@ -105,14 +105,12 @@ def test_read_roster_log_returns_evidence_list(tmp_path: Path):
     assert all(isinstance(r, RosterEvidence) for r in result)
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
 def test_split_note_bearing_punch_separates_time_and_note():
     time_text, note_text = split_note_bearing_punch("9:28:00 AM/ Bonita")
     assert time_text.strip() == "9:28:00 AM"
     assert note_text == "Bonita"
 
 
-@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
 def test_split_note_bearing_punch_pure_time_has_empty_note():
     time_text, note_text = split_note_bearing_punch("9:28:00 AM")
     assert time_text == "9:28:00 AM"

--- a/tests/test_nw_prj_input_ingestion.py
+++ b/tests/test_nw_prj_input_ingestion.py
@@ -1,0 +1,162 @@
+"""
+Contract tests for NW PRJ input ingestion (admin scratch + roster readers).
+
+These tests are xfail-strict against ``NotImplementedError`` because the
+readers are scaffolded for feature/nw-prj-ingest-admin-roster-rows and the
+ingestion PR has not landed yet. When implementation arrives, the xfails
+flip to passes automatically and the strict flag fails the suite if a test
+unexpectedly passes for the wrong reason.
+
+The body of each test describes the binding contract for the reader so the
+implementation PR has a clear target.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from triage.nw_prj_admin_scratch_reader import (
+    AdminScratchEvidence,
+    read_admin_scratch,
+    read_official_admin,
+)
+from triage.nw_prj_roster_reader import (
+    RosterEvidence,
+    read_roster_log,
+    split_note_bearing_punch,
+)
+
+
+# ── shape ──
+
+
+def test_admin_scratch_evidence_is_frozen_dataclass():
+    ev = AdminScratchEvidence(
+        tech="Alice",
+        date="2026-05-01",
+        source_workbook="scratch.xlsx",
+        source_sheet="Hours",
+        source_row=5,
+    )
+    with pytest.raises(Exception):
+        ev.tech = "Bob"  # type: ignore[misc]
+
+
+def test_roster_evidence_is_frozen_dataclass():
+    ev = RosterEvidence(
+        tech="Alice",
+        date="2026-05-01",
+        project="NW PRJ",
+        clock_in_raw=None,
+        clock_out_raw=None,
+        clock_in_hours=None,
+        clock_out_hours=None,
+        gross_hours=None,
+        lunch_deduction=None,
+        net_hours=None,
+        long_shift=False,
+    )
+    with pytest.raises(Exception):
+        ev.tech = "Bob"  # type: ignore[misc]
+
+
+# ── admin scratch reader contract ──
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_read_admin_scratch_returns_evidence_list(tmp_path: Path):
+    import openpyxl
+
+    p = tmp_path / "scratch.xlsx"
+    openpyxl.Workbook().save(p)
+    result = read_admin_scratch(p)
+    assert isinstance(result, list)
+    assert all(isinstance(r, AdminScratchEvidence) for r in result)
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_read_official_admin_returns_evidence_list(tmp_path: Path):
+    import openpyxl
+
+    p = tmp_path / "official.xlsx"
+    openpyxl.Workbook().save(p)
+    result = read_official_admin(p)
+    assert isinstance(result, list)
+    assert all(isinstance(r, AdminScratchEvidence) for r in result)
+
+
+def test_read_admin_scratch_missing_file_raises(tmp_path: Path):
+    with pytest.raises((FileNotFoundError, NotImplementedError)):
+        read_admin_scratch(tmp_path / "does_not_exist.xlsx")
+
+
+# ── roster reader contract ──
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_read_roster_log_returns_evidence_list(tmp_path: Path):
+    import openpyxl
+
+    p = tmp_path / "roster.xlsx"
+    openpyxl.Workbook().save(p)
+    result = read_roster_log(p)
+    assert isinstance(result, list)
+    assert all(isinstance(r, RosterEvidence) for r in result)
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_split_note_bearing_punch_separates_time_and_note():
+    time_text, note_text = split_note_bearing_punch("9:28:00 AM/ Bonita")
+    assert time_text.strip() == "9:28:00 AM"
+    assert note_text == "Bonita"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_split_note_bearing_punch_pure_time_has_empty_note():
+    time_text, note_text = split_note_bearing_punch("9:28:00 AM")
+    assert time_text == "9:28:00 AM"
+    assert note_text == ""
+
+
+# ── readers stay dumb ──
+
+
+def _imported_modules(module) -> set[str]:
+    import ast
+
+    src = Path(module.__file__).read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                names.add(node.module)
+    return names
+
+
+def test_admin_scratch_reader_does_not_import_classifier():
+    """Reader must not import the classifier or status taxonomy.
+
+    Readers extract evidence only. Authority and classification belong to
+    ``triage.nw_prj_target_classifier``. Importing the classifier from a
+    reader would invert the dependency direction.
+    """
+    import triage.nw_prj_admin_scratch_reader as mod
+
+    imports = _imported_modules(mod)
+    assert "triage.nw_prj_target_classifier" not in imports
+    assert "triage.nw_prj_config" not in imports
+    assert "triage.nw_prj_dashboard_validator" not in imports
+
+
+def test_roster_reader_does_not_import_classifier():
+    import triage.nw_prj_roster_reader as mod
+
+    imports = _imported_modules(mod)
+    assert "triage.nw_prj_target_classifier" not in imports
+    assert "triage.nw_prj_config" not in imports
+    assert "triage.nw_prj_dashboard_validator" not in imports

--- a/tests/test_nw_prj_target_classifier.py
+++ b/tests/test_nw_prj_target_classifier.py
@@ -1,0 +1,220 @@
+"""
+Contract tests for the NW PRJ target classifier.
+
+These tests are xfail-strict against ``NotImplementedError`` because the
+classifier is scaffolded for feature/nw-prj-ingest-admin-roster-rows and the
+resolution logic has not landed yet. When implementation arrives, the xfails
+flip to passes automatically and the strict flag fails the suite if a test
+unexpectedly passes for the wrong reason.
+
+Each test pins one rule from the binding contract in
+``triage.nw_prj_target_classifier.classify``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from triage.nw_prj_admin_scratch_reader import AdminScratchEvidence
+from triage.nw_prj_dashboard_rows import DashboardRow
+from triage.nw_prj_roster_reader import RosterEvidence
+from triage.nw_prj_target_classifier import (
+    ClassifierInputs,
+    ClassifierOutput,
+    classify,
+    is_rich_guard,
+    resolve_hours_authority,
+)
+
+
+def _scratch(tech: str, date: str, total: float | None = None) -> AdminScratchEvidence:
+    return AdminScratchEvidence(
+        tech=tech,
+        date=date,
+        source_workbook="scratch.xlsx",
+        source_sheet="Hours",
+        source_row=2,
+        total_value=total,
+    )
+
+
+def _roster(tech: str, date: str, net: float | None) -> RosterEvidence:
+    return RosterEvidence(
+        tech=tech,
+        date=date,
+        project="NW PRJ",
+        clock_in_raw=None,
+        clock_out_raw=None,
+        clock_in_hours=None,
+        clock_out_hours=None,
+        gross_hours=net,
+        lunch_deduction=None,
+        net_hours=net,
+        long_shift=False,
+    )
+
+
+# ── shape ──
+
+
+def test_classifier_inputs_defaults_are_empty():
+    inp = ClassifierInputs()
+    assert inp.admin_scratch_rows == []
+    assert inp.official_admin_rows == []
+    assert inp.roster_evidence == []
+    assert inp.prior_rows == []
+
+
+def test_classifier_output_partitions_exist():
+    out = ClassifierOutput()
+    assert out.active_rows == []
+    assert out.archive_rows == []
+    assert out.rich_guard_rows == []
+    assert out.false_flag_rows == []
+    assert out.submission_blockers == []
+
+
+# ── authority hierarchy ──
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_scratch_beats_official_and_roster():
+    hours, label = resolve_hours_authority(
+        scratch=_scratch("Alice", "2026-05-01", total=7.5),
+        official=_scratch("Alice", "2026-05-01", total=8.0),
+        roster=_roster("Alice", "2026-05-01", net=4.0),
+    )
+    assert hours == 7.5
+    assert label == "manual_admin_scratch"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_official_beats_roster_when_scratch_silent():
+    hours, label = resolve_hours_authority(
+        scratch=None,
+        official=_scratch("Alice", "2026-05-01", total=8.0),
+        roster=_roster("Alice", "2026-05-01", net=4.0),
+    )
+    assert hours == 8.0
+    assert label == "official_admin_workbook"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_roster_used_when_no_admin_evidence():
+    hours, label = resolve_hours_authority(
+        scratch=None, official=None, roster=_roster("Alice", "2026-05-01", net=4.0)
+    )
+    assert hours == 4.0
+    assert label == "roster_log"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_no_evidence_returns_none_authority():
+    hours, label = resolve_hours_authority(scratch=None, official=None, roster=None)
+    assert hours is None
+    assert label == "none"
+
+
+# ── Rich hours protection ──
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_rich_guard_triggers_when_admin_full_and_roster_weak():
+    assert is_rich_guard(resolved_hours=8.0, roster_hours=4.0) is True
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_rich_guard_triggers_when_admin_full_and_roster_missing():
+    assert is_rich_guard(resolved_hours=8.0, roster_hours=None) is True
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_rich_guard_silent_when_admin_short():
+    assert is_rich_guard(resolved_hours=4.0, roster_hours=4.0) is False
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_rich_guard_silent_when_roster_meets_admin():
+    assert is_rich_guard(resolved_hours=8.0, roster_hours=8.0) is False
+
+
+# ── classify: end-to-end rules ──
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_partial_hours_become_amber_review():
+    out = classify(
+        ClassifierInputs(
+            admin_scratch_rows=[_scratch("Alice", "2026-05-01", total=4.5)],
+        )
+    )
+    assert out.active_rows
+    row = out.active_rows[0]
+    assert row.reason_code == "PARTIAL_HOURS_REVIEW"
+    assert row.work_queue_status == "AMBER"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_gray_prior_rows_are_archived_not_resurrected():
+    prior = DashboardRow(
+        review_status="Skipped/Gray",
+        tech="Bob",
+        date="2026-05-02",
+        edit_sheet="Hours",
+        edit_row="3",
+    )
+    out = classify(
+        ClassifierInputs(
+            admin_scratch_rows=[_scratch("Bob", "2026-05-02", total=8.0)],
+            prior_rows=[prior],
+        )
+    )
+    assert any(r.review_status == "Skipped/Gray" for r in out.archive_rows)
+    assert not any(
+        r.tech == "Bob" and r.date == "2026-05-02" for r in out.active_rows
+    )
+    assert any("gray_resurrection" in w for w in out.warnings)
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_rich_guard_row_emitted_with_preserve_reason():
+    out = classify(
+        ClassifierInputs(
+            admin_scratch_rows=[_scratch("Rich", "2026-05-03", total=8.0)],
+            roster_evidence=[_roster("Rich", "2026-05-03", net=4.0)],
+        )
+    )
+    assert out.rich_guard_rows
+    assert out.rich_guard_rows[0].reason_code == "PRESERVE_ADMIN_FULL_DAY"
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_note_bearing_punch_preserves_note_in_roster_check_notes():
+    ev = RosterEvidence(
+        tech="Carol",
+        date="2026-05-04",
+        project="NW PRJ",
+        clock_in_raw="9:28:00 AM/ Bonita",
+        clock_out_raw=None,
+        clock_in_hours=9.466,
+        clock_out_hours=None,
+        gross_hours=None,
+        lunch_deduction=None,
+        net_hours=None,
+        long_shift=False,
+        in_note="Bonita",
+    )
+    out = classify(ClassifierInputs(roster_evidence=[ev]))
+    assert out.active_rows
+    row = out.active_rows[0]
+    assert row.reason_code == "NOTE_BEARING_PUNCH"
+    assert "Bonita" in row.roster_check_notes
+
+
+@pytest.mark.xfail(raises=NotImplementedError, strict=True, reason="ingestion PR pending")
+def test_submission_blockers_are_duplicated_into_blocker_list():
+    out = classify(
+        ClassifierInputs(
+            admin_scratch_rows=[_scratch("Dana", "2026-05-05", total=0.0)],
+        )
+    )
+    assert any(r.submission_blocker == "Yes" for r in out.submission_blockers)

--- a/triage/nw_prj_admin_scratch_reader.py
+++ b/triage/nw_prj_admin_scratch_reader.py
@@ -1,0 +1,85 @@
+"""
+NW PRJ admin scratch reader — evidence extractor only.
+
+Reads tech / date / hours / cell-reference evidence from a manual admin scratch
+workbook. This module is intentionally dumb: it does not decide authority, does
+not apply Rich hours protection, does not classify issue types, and does not
+build dashboard rows. Resolution and authority logic live in
+``triage.nw_prj_target_classifier``.
+
+Status: scaffolded for feature/nw-prj-ingest-admin-roster-rows. Implementations
+raise NotImplementedError until the ingestion PR lands.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class AdminScratchEvidence:
+    """One evidence record extracted from an admin scratch workbook.
+
+    Cell references are preserved verbatim so the classifier can map proposed
+    edits back to the originating workbook coordinates without re-reading.
+
+    Fields:
+      tech:            staff name as written in the scratch cell.
+      date:            ISO-like date string as written in the scratch cell.
+      source_workbook: file name of the admin scratch workbook (no path).
+      source_sheet:    sheet name the row was read from.
+      source_row:      1-based row index inside ``source_sheet``.
+      in_cell:         A1-style coordinate of the clock-in cell, if present.
+      out_cell:        A1-style coordinate of the clock-out cell, if present.
+      total_cell:      A1-style coordinate of the daily-total cell, if present.
+      in_value:        raw clock-in cell value, stringified, untrimmed of notes.
+      out_value:       raw clock-out cell value, stringified, untrimmed of notes.
+      total_value:     parsed numeric daily total if the cell is numeric.
+      notes:           raw adjacent note text (e.g. "/ Bonita"), uninterpreted.
+    """
+
+    tech: str
+    date: str
+    source_workbook: str
+    source_sheet: str
+    source_row: int
+    in_cell: str = ""
+    out_cell: str = ""
+    total_cell: str = ""
+    in_value: Optional[str] = None
+    out_value: Optional[str] = None
+    total_value: Optional[float] = None
+    notes: str = ""
+
+
+def read_admin_scratch(path: str | Path) -> List[AdminScratchEvidence]:
+    """Extract evidence rows from a manual admin scratch workbook.
+
+    Contract:
+      * Returns one ``AdminScratchEvidence`` per tech/date/row observed.
+      * Empty rows are skipped.
+      * Note-bearing punches keep both the time portion (in ``in_value`` /
+        ``out_value`` as the raw cell text) and the note portion (in ``notes``).
+        Splitting and time parsing belong to downstream callers, not here.
+      * Does not interpret authority, does not flag mismatches, does not infer
+        project assignment.
+      * Raises ``FileNotFoundError`` if ``path`` does not exist.
+      * Raises ``RuntimeError`` if the workbook cannot be opened by openpyxl.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("read_admin_scratch is scaffolded; implementation pending")
+
+
+def read_official_admin(path: str | Path) -> List[AdminScratchEvidence]:
+    """Extract evidence rows from an official admin workbook.
+
+    Same evidence shape as ``read_admin_scratch``. The classifier is responsible
+    for treating ``official_admin_workbook`` as a lower authority than
+    ``manual_admin_scratch`` per the schema's ``input_hierarchy``. This reader
+    does not enforce that ordering.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("read_official_admin is scaffolded; implementation pending")

--- a/triage/nw_prj_dashboard_generator.py
+++ b/triage/nw_prj_dashboard_generator.py
@@ -1,5 +1,12 @@
 """
 Generate NW PRJ Tech Roster Dashboard v6_x WEBSAFE workbooks.
+
+Current status: carry-forward / skeleton generator. Active and archive rows
+come almost entirely from prior dashboard carry-forward via
+``nw_prj_artifact_compare``. Fresh row generation from admin scratch and
+roster evidence lands with the readers and classifier in
+``triage.nw_prj_admin_scratch_reader``, ``triage.nw_prj_roster_reader``, and
+``triage.nw_prj_target_classifier``.
 """
 from __future__ import annotations
 

--- a/triage/nw_prj_roster_reader.py
+++ b/triage/nw_prj_roster_reader.py
@@ -92,13 +92,20 @@ def read_roster_log(path: str | Path) -> List[RosterEvidence]:
 def split_note_bearing_punch(cell_text: str) -> tuple[str, str]:
     """Split a roster punch cell into ``(time_text, note_text)``.
 
-    The time portion is whatever precedes the first ``/`` (or equivalent
-    separator). The note portion is the remainder, with surrounding whitespace
-    stripped. Either portion may be empty.
+    The time portion is whatever precedes the first ``/`` separator, stripped
+    of surrounding whitespace. The note portion is everything after the first
+    ``/``, also stripped. Either portion may be empty.
+
+    Examples::
+
+        split_note_bearing_punch("9:28:00 AM/ Bonita") -> ("9:28:00 AM", "Bonita")
+        split_note_bearing_punch("9:28:00 AM")         -> ("9:28:00 AM", "")
 
     This utility is used by ``read_roster_log`` to preserve note context that
-    the underlying time parser strips. Pure-time cells return ``(cell_text, "")``.
-
-    Implementation is pending the ingestion PR.
+    the underlying time parser strips. Pure-time cells return
+    ``(cell_text.strip(), "")``.
     """
-    raise NotImplementedError("split_note_bearing_punch is scaffolded; implementation pending")
+    if "/" not in cell_text:
+        return (cell_text.strip(), "")
+    time_part, _, note_part = cell_text.partition("/")
+    return (time_part.strip(), note_part.strip())

--- a/triage/nw_prj_roster_reader.py
+++ b/triage/nw_prj_roster_reader.py
@@ -1,0 +1,104 @@
+"""
+NW PRJ roster reader — evidence extractor only.
+
+Reads tech / date / punch / hours evidence from the Active Roster Log. This
+module is intentionally dumb: it does not decide authority, does not apply
+Rich hours protection, does not classify issue types, and does not build
+dashboard rows. Resolution and authority logic live in
+``triage.nw_prj_target_classifier``.
+
+The lower-level wide-form parsing of the roster workbook is handled by
+``triage.roster_parser``. This module wraps that output into the NW PRJ
+evidence shape and preserves note-bearing punch text that ``roster_parser``
+strips during numeric time conversion.
+
+Status: scaffolded for feature/nw-prj-ingest-admin-roster-rows. Implementations
+raise NotImplementedError until the ingestion PR lands.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class RosterEvidence:
+    """One evidence record extracted from the Active Roster Log.
+
+    Fields:
+      tech:              staff name as written in the roster row.
+      date:              ISO-like date string for the column this punch came from.
+      project:           raw project name from the roster's project column. The
+                         classifier decides whether overrides apply.
+      clock_in_raw:      original clock-in cell text, including any appended
+                         note (e.g. "9:28:00 AM/ Bonita"). ``None`` if blank.
+      clock_out_raw:     original clock-out cell text. ``None`` if blank.
+      clock_in_hours:    decimal hours form of the clock-in time, or ``None``
+                         if the cell was blank or unparseable.
+      clock_out_hours:   decimal hours form of the clock-out time, or ``None``.
+      gross_hours:       clock-out minus clock-in in hours, or ``None``.
+      lunch_deduction:   policy lunch deduction in hours, or ``None``.
+      net_hours:         gross minus lunch in hours, or ``None``.
+      long_shift:        whether net hours qualify as a long shift per policy.
+      in_note:           note portion of ``clock_in_raw`` (text after the time),
+                         uninterpreted. Time goes to calculation, note goes to
+                         context.
+      out_note:          note portion of ``clock_out_raw``, uninterpreted.
+      source_path:       absolute path of the roster workbook that produced this
+                         evidence record.
+    """
+
+    tech: str
+    date: str
+    project: str
+    clock_in_raw: Optional[str]
+    clock_out_raw: Optional[str]
+    clock_in_hours: Optional[float]
+    clock_out_hours: Optional[float]
+    gross_hours: Optional[float]
+    lunch_deduction: Optional[float]
+    net_hours: Optional[float]
+    long_shift: bool
+    in_note: str = ""
+    out_note: str = ""
+    source_path: str = ""
+
+
+def read_roster_log(path: str | Path) -> List[RosterEvidence]:
+    """Extract evidence rows from an Active Roster Log workbook.
+
+    Contract:
+      * Returns one ``RosterEvidence`` per (staff, date) pair with any punch
+        activity. Days with no punches at all are omitted.
+      * Note-bearing punches are preserved verbatim in ``clock_in_raw`` /
+        ``clock_out_raw`` and additionally split into ``in_note`` / ``out_note``
+        for downstream context. Time parsing follows ``triage.roster_parser``
+        rules: appended note text after the time is stripped from numeric
+        conversion but is not discarded.
+      * Lunch deduction and long-shift policy come from
+        ``triage.roster_parser._lunch_deduction``. This reader does not
+        re-implement that policy.
+      * Raises ``triage.roster_parser.RosterParseError`` if the workbook does
+        not match the expected wide-form layout.
+      * Does not classify issue types, does not decide project authority,
+        does not flag mismatches.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("read_roster_log is scaffolded; implementation pending")
+
+
+def split_note_bearing_punch(cell_text: str) -> tuple[str, str]:
+    """Split a roster punch cell into ``(time_text, note_text)``.
+
+    The time portion is whatever precedes the first ``/`` (or equivalent
+    separator). The note portion is the remainder, with surrounding whitespace
+    stripped. Either portion may be empty.
+
+    This utility is used by ``read_roster_log`` to preserve note context that
+    the underlying time parser strips. Pure-time cells return ``(cell_text, "")``.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("split_note_bearing_punch is scaffolded; implementation pending")

--- a/triage/nw_prj_target_classifier.py
+++ b/triage/nw_prj_target_classifier.py
@@ -1,0 +1,129 @@
+"""
+NW PRJ target classifier — owns all resolution and authority logic.
+
+Inputs are dumb evidence records from ``nw_prj_admin_scratch_reader`` and
+``nw_prj_roster_reader`` plus optional prior dashboard rows for carry-forward.
+This module decides:
+
+  * authority hierarchy per ``configs/nw_prj_dashboard_v6_schema.json``:
+    manual_admin_scratch > official_admin_workbook > roster_log > prior_dashboard
+  * Rich hours protection (admin full/long day is never downgraded by weak
+    roster evidence)
+  * partial-hour classification (PARTIAL_HOURS_REVIEW)
+  * note-bearing punch handling (NOTE_BEARING_PUNCH, time-to-calc / note-to-context)
+  * false-flag handling per ``configs/weekly_attendance_dashboard_values_v1.json``
+  * gray archive preservation (skipped/gray rows stay archived, never resurrected)
+  * submission blocker classification (Yes / No / Review)
+
+Readers never make these decisions. Resolution lives here.
+
+Status: scaffolded for feature/nw-prj-ingest-admin-roster-rows. Implementations
+raise NotImplementedError until the ingestion PR lands.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+from triage.nw_prj_admin_scratch_reader import AdminScratchEvidence
+from triage.nw_prj_dashboard_rows import DashboardRow
+from triage.nw_prj_roster_reader import RosterEvidence
+
+
+@dataclass
+class ClassifierInputs:
+    """All evidence feeding a single classification pass.
+
+    ``admin_scratch_rows`` carries the highest authority. ``official_admin_rows``
+    is consulted only when the scratch is silent for a (tech, date). Roster
+    evidence informs roster check / partial hours / note context. Prior rows
+    are used solely for carry-forward of manual status, gray archive
+    preservation, and Rich Guard memory.
+    """
+
+    admin_scratch_rows: List[AdminScratchEvidence] = field(default_factory=list)
+    official_admin_rows: List[AdminScratchEvidence] = field(default_factory=list)
+    roster_evidence: List[RosterEvidence] = field(default_factory=list)
+    prior_rows: List[DashboardRow] = field(default_factory=list)
+
+
+@dataclass
+class ClassifierOutput:
+    """Classification result, partitioned by destination dashboard sheet."""
+
+    active_rows: List[DashboardRow] = field(default_factory=list)
+    archive_rows: List[DashboardRow] = field(default_factory=list)
+    rich_guard_rows: List[DashboardRow] = field(default_factory=list)
+    false_flag_rows: List[DashboardRow] = field(default_factory=list)
+    submission_blockers: List[DashboardRow] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    failures: List[str] = field(default_factory=list)
+
+
+def classify(inputs: ClassifierInputs) -> ClassifierOutput:
+    """Produce dashboard rows from evidence + prior carry-forward.
+
+    Contract (binding once implemented):
+
+      * Authority hierarchy is enforced strictly. A scratch row for (tech, date)
+        overrides any official admin or roster value for that key. An override
+        beats default assignment.
+      * Rich hours protection: if resolved admin hours for a (tech, date) are
+        >= 8 and roster evidence is absent or weaker, an entry is emitted to
+        ``rich_guard_rows`` with reason ``PRESERVE_ADMIN_FULL_DAY`` and the
+        active row is not downgraded.
+      * Partial hours: when 0 < resolved hours < 8, the active row carries
+        reason ``PARTIAL_HOURS_REVIEW`` and Work Queue Status ``AMBER``.
+      * Note-bearing punches: roster evidence with non-empty ``in_note`` or
+        ``out_note`` produces (or annotates) a row with reason
+        ``NOTE_BEARING_PUNCH``. The note text is preserved in
+        ``Roster Check Notes``; the time portion is what feeds hours math.
+      * False-flag dispositions from the weekly taxonomy go to
+        ``false_flag_rows`` and never to ``active_rows``.
+      * Gray preservation: any prior row whose review status is in
+        ``skipped_gray`` remains in ``archive_rows`` and is not resurrected
+        even if fresh evidence exists for the same key. A ``gray_resurrection``
+        warning is emitted if fresh evidence conflicts.
+      * Submission blocker classification: ``Yes`` only when resolved evidence
+        proves an admin edit is required before submission; ``Review`` for
+        ambiguous; ``No`` otherwise. Rows with ``Yes`` are duplicated into
+        ``submission_blockers`` for fast indexing.
+      * Resolution never silently mutates roster or admin sources. This is a
+        pure function over evidence.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("classify is scaffolded; implementation pending")
+
+
+def resolve_hours_authority(
+    scratch: AdminScratchEvidence | None,
+    official: AdminScratchEvidence | None,
+    roster: RosterEvidence | None,
+) -> tuple[float | None, str]:
+    """Return ``(resolved_hours, authority_label)`` for a single (tech, date).
+
+    ``authority_label`` is one of:
+      ``manual_admin_scratch``, ``official_admin_workbook``, ``roster_log``,
+      or ``none`` when no evidence is present.
+
+    The first non-empty source in hierarchy order wins. This helper is the
+    only place authority order is encoded; ``classify`` calls it per key.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError(
+        "resolve_hours_authority is scaffolded; implementation pending"
+    )
+
+
+def is_rich_guard(resolved_hours: float | None, roster_hours: float | None) -> bool:
+    """Return True iff Rich Guard should preserve resolved admin hours.
+
+    Rule: resolved_hours >= 8 and (roster_hours is None or roster_hours <
+    resolved_hours). A True result must never cause the active row to be
+    downgraded by weak roster evidence.
+
+    Implementation is pending the ingestion PR.
+    """
+    raise NotImplementedError("is_rich_guard is scaffolded; implementation pending")


### PR DESCRIPTION
## Summary

Scaffolds the NW PRJ admin scratch reader, roster reader, and target classifier contracts needed to move the dashboard generator from prior-dashboard carry-forward toward fresh admin/roster evidence-driven row generation.

## Architecture

- Readers stay dumb.
- Readers extract evidence only.
- Classifier owns authority hierarchy, Rich Guard, partial-hour classification, false flags, gray/archive preservation, and submission blocker logic.
- Current generator remains carry-forward/skeleton until readers + classifier are implemented.

## Validation

Targeted suite:

- `tests/test_nw_prj_input_ingestion.py`
- `tests/test_nw_prj_target_classifier.py`
- `tests/test_nw_prj_dashboard.py`

Result:

- 21 passed
- 18 xfailed strict
- 0 failed

## Known unrelated main failures

Full suite still has pre-existing failures on `main`:

1. Windows strftime portability bug in `triage/billing_summary_generator.py:543`
   - `%-d` is POSIX-only
   - Windows equivalent is `%#d`
2. Missing private/local `attached_assets/*.docx` fixtures referenced by billing regression tests

Neither is changed in this PR.
