### PR TITLE
docs: define 1 Marcus recon part-number relink sprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ Generate `Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx` locally from the priva
 - Run: `python -m triage.nw_prj_neuron_track_hours.cli --roster-log "<roster>.xlsx" --out-dir Outputs/nw_prj_neuron_track_hours_2026_06_01 --months 2026-04 2026-05 --websafe --zip`
 - Neuron scope uses Worked-Project per-date classification (not default team membership); totals: April 1048.19, May 697.83, total 1746.02, Go Live weekend 2 rows / 22h.
 
+### 1 Marcus inventory recon (part-number relink)
+
+Surgically relink the dated Part Numbers tab and produce a Web Excel-safe recon candidate from a private workbook:
+
+- Docs: [`docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md`](docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md)
+- Run: `python -m triage.one_marcus_recon.cli --input "Candidates/inventory recon/<workbook>.xlsx" --date auto --output Outputs/one_marcus_recon_2026_06_01/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx`
+- Patches the OOXML package in place (renames the `M-D-YYYY Part Numbers` tab, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`) instead of reserializing; preserves tables, drawings, styles, and sheet order. Use `--dry-run` to report without writing, `--strict` to fail on ambiguous dates.
+
 ### Lifecycle folder rules (quick reference)
 
 This repo uses lifecycle folders so the engine can keep artifacts organized:

--- a/docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md
+++ b/docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md
@@ -1,0 +1,213 @@
+# 1 Marcus Recon Part-Number Relink Contract
+
+## Purpose
+
+Automate the 1 Marcus inventory recon workbook cleanup that was proven manually on the 2026-05-28 Web Excel-safe artifact.
+
+The repo should generate a client-shareable recon workbook where the pivot/recon module is wired to the current dated Part Numbers tab, formulas point to the current tab, stale workbook references are removed, and Excel for Web does not trigger repair.
+
+This lane is inventory recon. Billing remains a valid repo capability, but this contract does not replace or rewrite billing logic.
+
+Related issue: #30
+
+## Business workflow
+
+The operator updates the 1 Marcus recon workbook and pivots after physical or spreadsheet reconciliation work.
+
+The updated workbook needs a dated consolidated part-number reference tab, usually named like:
+
+```text
+5-28-2026 Part Numbers
+```
+
+The operator may remember to rename the workbook and tab title. If they forget, the repo should infer the intended date and repair the mismatch before client delivery.
+
+## Inputs
+
+The first implementation should support local private inputs only. Do not commit real client workbooks.
+
+Expected input patterns:
+
+```text
+Candidates/
+  *1 Marcus*Recon*.xlsx
+  *Part Numbers*.xlsx        optional, if consolidated reference is separate
+```
+
+Suggested CLI shape:
+
+```bash
+python -m triage.one_marcus_recon.cli \
+  --input "Candidates/Tab-Linked 1 Marcus Compiled_Recon_Integrated_2026-05-28.xlsx" \
+  --date auto \
+  --output "Outputs/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx"
+```
+
+Optional flags:
+
+```text
+--part-number-tab "5-28-2026 Part Numbers"
+--pivot-tab "1M Recon Pivot Module"
+--dry-run
+--strict
+--report-json Outputs/1_Marcus_Recon_2026-05-28_preflight.json
+```
+
+## Date inference precedence
+
+If the date is not supplied, infer it in this order:
+
+1. Explicit CLI/config date.
+2. Workbook filename date.
+3. Existing latest dated Part Numbers tab.
+4. File modified timestamp as a last-resort fallback, with warning.
+
+The generated tab name must use:
+
+```text
+M-D-YYYY Part Numbers
+```
+
+Example:
+
+```text
+5-28-2026 Part Numbers
+```
+
+## Required behavior
+
+### Tab handling
+
+- Detect existing Part Numbers candidate tabs.
+- Rename the chosen source tab to the target dated tab.
+- Preserve all unrelated tabs, sheet order, visibility, tab colors, tables, drawings, styles, filters, validation, conditional formatting, print settings, and workbook metadata unless explicitly changed.
+- Never delete old tabs unless a cleanup flag explicitly says to do so.
+
+### Formula rewiring
+
+- Find formulas referencing older dated Part Numbers tabs.
+- Repoint them to the target dated tab.
+- Correctly quote sheet names with spaces and hyphens.
+- Localize formulas that point to stale external workbook references when the target tab exists locally.
+- Report formulas that still reference old dates after rewrite.
+- Report formulas that still reference external workbooks after rewrite.
+
+### Pivot/recon module wiring
+
+- The pivot/recon module must resolve from the current dated Part Numbers tab.
+- Helper logic should prefer stable part/model identifiers over loose descriptions.
+- Calculation labels should remain plain text or formula-clean values.
+- Do not use hyperlink formulas inside helper/calculation labels used by rollups or validation.
+- Presentation-only navigation links are allowed only where they cannot affect calculation logic.
+
+### Web Excel safety
+
+When formulas or workbook XML are patched:
+
+- Remove stale `calcChain.xml` so Excel for Web can rebuild formulas.
+- Remove unused `xl/externalLinks/*` package parts after formula localization.
+- Remove or repair dangling relationship references caused by external link cleanup.
+- Do not reserialize broad workbook structures when a surgical package/XML patch is sufficient.
+
+## Output package
+
+Expected outputs:
+
+```text
+Outputs/
+  1_Marcus_Recon_YYYY-MM-DD_WEBSAFE.xlsx
+  1_Marcus_Recon_YYYY-MM-DD_preflight.json
+  1_Marcus_Recon_YYYY-MM-DD_manifest.json
+  1_Marcus_Recon_YYYY-MM-DD_review_queue.csv
+  1_Marcus_Recon_YYYY-MM-DD_carryover.md
+  1_Marcus_Recon_YYYY-MM-DD_DELIVERY.zip
+```
+
+## Required report fields
+
+The JSON report should include:
+
+```text
+input_workbook
+output_workbook
+inferred_update_date
+final_part_number_tab
+pivot_tab
+renamed_tabs
+formula_cells_scanned
+formula_cells_patched
+stale_tab_references_removed
+remaining_stale_tab_references
+external_link_parts_removed
+remaining_external_links
+calc_chain_removed
+formula_error_scan
+webexcel_preflight_pass
+warnings
+```
+
+## Web Excel gates
+
+Before success, scan for:
+
+- `#REF!`
+- `#VALUE!`
+- `#NAME?`
+- `#DIV/0!`
+- `#N/A`
+- stale dated Part Numbers tab references
+- stale external workbook references
+- unnecessary `xl/externalLinks/` package parts
+- broken workbook relationships
+- broken worksheet relationships
+- stale `calcChain.xml` after formula rewrites
+- `inlineStr`
+- `ns0:`
+- `xmlns:ns0`
+- `_xlfn.`
+- `_xludf.`
+- `_xlpm`
+
+## Acceptance criteria
+
+1. Given a workbook containing stale references to `5-07-2026 Part Numbers`, the output rewrites formulas to `'5-28-2026 Part Numbers'` when the update date is 2026-05-28.
+2. Given stale external workbook references for part-number lookups, the output localizes formulas when the dated Part Numbers tab exists locally.
+3. Given formula rewrites, `calcChain.xml` is removed.
+4. Given localized formulas, unneeded `xl/externalLinks/*` parts are removed.
+5. The pivot/recon module resolves against the current dated Part Numbers tab.
+6. Unrelated tabs and workbook presentation structure are preserved.
+7. Dry run reports intended changes without writing a workbook.
+8. Ambiguous multiple date candidates produce a warning or strict-mode failure.
+9. The output passes Web Excel preflight.
+10. No private workbook data or generated client workbooks are committed.
+
+## Tests to add
+
+Use sanitized fixtures only.
+
+Suggested tests:
+
+```text
+test_infers_recon_update_date_from_filename
+test_renames_part_number_tab_to_target_date
+test_rewrites_formulas_from_old_part_number_tab
+test_localizes_external_part_number_formulas
+test_removes_external_link_parts_after_localization
+test_removes_calc_chain_after_formula_patch
+test_preserves_unrelated_tabs_and_sheet_order
+test_dry_run_reports_without_output_write
+test_warns_on_ambiguous_date_candidates
+test_webexcel_preflight_rejects_stale_refs_and_stopship_tokens
+```
+
+## Non-goals for first sprint
+
+- Do not build a general workbook framework before this concrete engine works.
+- Do not merge billing behavior into this recon lane.
+- Do not commit real 1 Marcus workbooks.
+- Do not delete tabs or hide evidence by default.
+- Do not claim Excel Web success without a package-level preflight at minimum.
+
+## Operator rule
+
+Automation should catch the boring mistake: the workbook date, Part Numbers tab title, formula references, and package metadata must agree before the file goes to a client.

--- a/docs/1MARCUS_RECON_SPRINT_LEDGER_2026-06-01.md
+++ b/docs/1MARCUS_RECON_SPRINT_LEDGER_2026-06-01.md
@@ -1,0 +1,134 @@
+# 1 Marcus Recon Sprint Ledger — 2026-06-01
+
+## Sprint target
+
+Build the repo lane for 1 Marcus inventory recon automation.
+
+The immediate goal is not a polished universal framework. The immediate goal is a narrow, testable engine that can take the updated 1 Marcus recon workbook, align the dated Part Numbers tab, rewire formulas, remove stale workbook ghosts, and produce a Web Excel-safe client candidate.
+
+## Current branch
+
+```text
+feat/1marcus-recon-partnumber-relink-engine-2026-06-01
+```
+
+Created from current `main` after PR #28 and PR #29 were merged.
+
+## Completed in this sprint checkpoint
+
+- Verified PR #28 is closed and merged.
+- Verified PR #29 is closed and merged.
+- Confirmed legacy open PRs still exist and should not be blindly merged.
+- Created clean inventory recon feature branch from merged `main`.
+- Added the 1 Marcus recon part-number relink contract.
+- Preserved billing as a valid repo capability while keeping this lane scoped to inventory recon.
+
+## Known open PR state
+
+These open PRs remain outside this sprint unless explicitly pulled in:
+
+| PR | Status | Current handling |
+| --- | --- | --- |
+| #26 | Open, not mergeable | Likely superseded in part by merged Cybernet/Neuron engines, but contains broader NW PRJ local artifact work. Needs audit before close or salvage. |
+| #23 | Open draft | Scaffold reader/classifier contracts. Likely superseded by later concrete engines. Needs close/comment after confirming no unique doctrine remains. |
+| #17 | Open draft | Artifact checkpoint payload/manifest lane. Contains encrypted payload references. Keep untouched unless artifact-retention decision is made. |
+| #14 | Open | Post-convergence validation docs. Useful historical audit, but old base. Needs rebase or close as superseded by later repo state. |
+| #11 | Open | Admin billing workbook inspector. Billing-adjacent. Do not close in inventory recon cleanup without explicit billing lane decision. |
+| #10 | Open | Note-tolerant roster punch parsing docs. Probably valuable doctrine, but old base and may be duplicated by merged engines. Needs doctrine audit. |
+
+## Known gaps
+
+1. No code module exists yet for `triage.one_marcus_recon`.
+2. No sanitized 1 Marcus recon fixture exists yet.
+3. No parser exists yet for detecting dated `M-D-YYYY Part Numbers` tabs.
+4. No formula-rewrite function exists yet for localizing old part-number references.
+5. No package-level cleanup exists yet for removing stale `xl/externalLinks/*` parts in this lane.
+6. No recon-specific Web Excel preflight wrapper exists yet.
+7. No dry-run report exists yet.
+8. No delivery ZIP/manifest/carryover sidecars exist yet for this lane.
+9. No CI workflow exists, so tests are still locally proven only unless a separate CI PR is added.
+10. Open legacy PRs remain and may confuse future merge order if not annotated or retired.
+
+## Risks
+
+| Risk | Why it matters | Mitigation target |
+| --- | --- | --- |
+| Workbook rewrite damage | High-level workbook libraries can damage Excel Web compatibility or visual fidelity. | Use preserve-first, surgical XML/package patching where possible. |
+| Stale external links | Excel Web may repair or reject workbook packages with unresolved external links. | Localize formulas, remove unused external link parts, scan relationships. |
+| Stale calc chain | Formula rewrites can leave invalid calcChain references. | Remove `calcChain.xml` after formula edits. |
+| Date ambiguity | Multiple dated Part Numbers tabs can cause the engine to choose the wrong reference. | Strict mode fails; normal mode warns and reports selected candidate. |
+| Loose item-description matching | Pivots can roll up under inconsistent names instead of stable part/model identifiers. | Prefer part/model fields in helper logic. |
+| Hyperlink formulas in calc labels | Prior artifact showed hyperlink formulas can interfere with validation/calculation labels. | Keep calculation labels formula-clean; allow links only in presentation-only cells. |
+| Private workbook leakage | Real recon/client files must not enter repo history. | Fixtures must be sanitized/minimal; Candidates and Outputs stay gitignored. |
+| Legacy PR collision | Old branches may touch same docs/helpers and conflict with new lane. | Keep new lane narrow; retire or annotate stale PRs separately. |
+
+## Targets
+
+### Target 1 — scaffolding
+
+Create package:
+
+```text
+triage/one_marcus_recon/
+  __init__.py
+  models.py
+  date_inference.py
+  formula_relink.py
+  package_cleanup.py
+  preflight.py
+  exporter.py
+  cli.py
+```
+
+### Target 2 — sanitized fixtures
+
+Create minimal test workbooks that simulate:
+
+- old dated Part Numbers tab
+- new intended date from filename
+- stale formula references
+- stale external workbook prefix
+- stale calcChain
+- unrelated tab preservation
+
+### Target 3 — relink engine
+
+Implement deterministic dry-run and write modes:
+
+```bash
+python -m triage.one_marcus_recon.cli --input Candidates/input.xlsx --date auto --dry-run
+python -m triage.one_marcus_recon.cli --input Candidates/input.xlsx --date 2026-05-28 --output Outputs/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx
+```
+
+### Target 4 — Web Excel preflight
+
+Produce JSON report with:
+
+- formula errors
+- stale dated references
+- external links
+- calc chain state
+- relationship scan
+- stop-ship token scan
+- tab preservation summary
+
+### Target 5 — PR hygiene
+
+Before opening implementation PR:
+
+- confirm branch has only intended files
+- confirm no generated workbook outputs are tracked
+- confirm no private `Candidates/` content is tracked
+- confirm old PRs are either untouched by design or clearly commented/closed in a separate cleanup PR
+
+## Next checkpoint definition of done
+
+A draft PR should exist for this branch with:
+
+- contract doc
+- sprint ledger
+- no private files
+- no generated workbook files
+- clear known gaps/risks/targets
+
+The implementation can then proceed in small commits without carrying a dirty repo into the next feature push.

--- a/tests/fixtures/one_marcus_recon/.gitignore
+++ b/tests/fixtures/one_marcus_recon/.gitignore
@@ -1,0 +1,2 @@
+*.xlsx
+__pycache__/

--- a/tests/fixtures/one_marcus_recon/fixtures.py
+++ b/tests/fixtures/one_marcus_recon/fixtures.py
@@ -1,0 +1,148 @@
+"""Sanitized fixtures for the 1 Marcus recon engine.
+
+No real client data. Workbooks are generated at test time and gitignored.
+"""
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+from openpyxl import Workbook
+
+_EXT_LINK_XML = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<externalLink xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<externalBook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"'
+    ' r:id="rId1"><sheetNames><sheetName val="5-07-2026 Part Numbers"/></sheetNames>'
+    "</externalBook></externalLink>"
+)
+_EXT_LINK_RELS = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+    '<Relationship Id="rId1"'
+    ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLinkPath"'
+    ' Target="file:///C:/old/PartNumbers_Source.xlsx" TargetMode="External"/></Relationships>'
+)
+_CALC_CHAIN = (
+    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+    '<calcChain xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+    '<c r="A1" i="1"/></calcChain>'
+)
+
+
+def _build_base(part_numbers_titles, *, with_external_formula: bool) -> bytes:
+    """Build a minimal valid workbook with openpyxl and return its bytes."""
+    wb = Workbook()
+    pivot = wb.active
+    pivot.title = "1M Recon Pivot Module"
+
+    first_pn = part_numbers_titles[0]
+    pivot["A1"] = "Recon totals"
+    pivot["A2"] = f"=SUMIFS('{first_pn}'!$T$2:$T$10,'{first_pn}'!$Z$2:$Z$10,\"Include\")"
+    pivot["A3"] = f"=COUNTIFS('{first_pn}'!$Z$2:$Z$10,\"Include\")"
+    if with_external_formula:
+        # Stored external-indexed reference Excel uses for external workbooks.
+        pivot["A4"] = f"=[1]'{first_pn}'!$A$1"
+
+    notes = wb.create_sheet("Notes")
+    notes["A1"] = "Unrelated tab; must be preserved."
+
+    for title in part_numbers_titles:
+        pn = wb.create_sheet(title)
+        pn["S1"] = "Site"
+        pn["T1"] = "Qty"
+        pn["Z1"] = "Decision"
+        pn["S2"] = "OR"
+        pn["T2"] = 5
+        pn["Z2"] = "Include"
+
+    readme = wb.create_sheet("README Integration")
+    readme["A1"] = "Recon integration notes."
+
+    buf = io.BytesIO()
+    wb.save(buf)
+    return buf.getvalue()
+
+
+def _inject_defects(data: bytes, *, add_external: bool, add_calc_chain: bool) -> bytes:
+    """Add external-link parts and/or calcChain to an openpyxl workbook."""
+    with zipfile.ZipFile(io.BytesIO(data), "r") as zin:
+        names = zin.namelist()
+        parts = {n: zin.read(n) for n in names}
+
+    if add_external:
+        parts["xl/externalLinks/externalLink1.xml"] = _EXT_LINK_XML.encode("utf-8")
+        parts["xl/externalLinks/_rels/externalLink1.xml.rels"] = _EXT_LINK_RELS.encode("utf-8")
+        ct = parts["[Content_Types].xml"].decode("utf-8")
+        if "externalLink" not in ct:
+            ct = ct.replace(
+                "</Types>",
+                '<Override PartName="/xl/externalLinks/externalLink1.xml"'
+                ' ContentType="application/vnd.openxmlformats-officedocument'
+                '.spreadsheetml.externalLink+xml"/></Types>',
+            )
+            parts["[Content_Types].xml"] = ct.encode("utf-8")
+        rels = parts["xl/_rels/workbook.xml.rels"].decode("utf-8")
+        rels = rels.replace(
+            "</Relationships>",
+            '<Relationship Id="rIdExt1"'
+            ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/externalLink"'
+            ' Target="externalLinks/externalLink1.xml"/></Relationships>',
+        )
+        parts["xl/_rels/workbook.xml.rels"] = rels.encode("utf-8")
+        wb = parts["xl/workbook.xml"].decode("utf-8")
+        if "<externalReferences" not in wb:
+            wb = wb.replace(
+                "</sheets>",
+                '</sheets><externalReferences><externalReference r:id="rIdExt1"/>'
+                "</externalReferences>",
+            )
+            parts["xl/workbook.xml"] = wb.encode("utf-8")
+
+    if add_calc_chain:
+        parts["xl/calcChain.xml"] = _CALC_CHAIN.encode("utf-8")
+        ct = parts["[Content_Types].xml"].decode("utf-8")
+        if "calcChain" not in ct:
+            ct = ct.replace(
+                "</Types>",
+                '<Override PartName="/xl/calcChain.xml"'
+                ' ContentType="application/vnd.openxmlformats-officedocument'
+                '.spreadsheetml.calcChain+xml"/></Types>',
+            )
+            parts["[Content_Types].xml"] = ct.encode("utf-8")
+        rels = parts["xl/_rels/workbook.xml.rels"].decode("utf-8")
+        if "calcChain" not in rels:
+            rels = rels.replace(
+                "</Relationships>",
+                '<Relationship Id="rIdCalc"'
+                ' Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/calcChain"'
+                ' Target="calcChain.xml"/></Relationships>',
+            )
+            parts["xl/_rels/workbook.xml.rels"] = rels.encode("utf-8")
+
+    order = list(parts.keys())
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zout:
+        for n in order:
+            zout.writestr(n, parts[n])
+    return buf.getvalue()
+
+
+def make_stale_recon(path: str) -> str:
+    """A recon workbook with a stale dated tab, external link, and calcChain."""
+    data = _build_base(["5-07-2026 Part Numbers"], with_external_formula=True)
+    data = _inject_defects(data, add_external=True, add_calc_chain=True)
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_bytes(data)
+    return path
+
+
+def make_ambiguous(path: str) -> str:
+    """A recon workbook with two dated Part Numbers tabs (no filename date)."""
+    data = _build_base(
+        ["5-07-2026 Part Numbers", "5-21-2026 Part Numbers"], with_external_formula=False
+    )
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
+    Path(path).write_bytes(data)
+    return path

--- a/tests/test_one_marcus_recon.py
+++ b/tests/test_one_marcus_recon.py
@@ -1,0 +1,150 @@
+"""Tests for the 1 Marcus recon part-number relink engine (sanitized fixtures)."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.one_marcus_recon import fixtures as fx
+from triage.one_marcus_recon import date_inference as di
+from triage.one_marcus_recon import formula_relink as fr
+from triage.one_marcus_recon import preflight as pf
+from triage.one_marcus_recon.exporter import run_recon
+from triage.one_marcus_recon.package_cleanup import Package
+
+TARGET_TAB = "5-28-2026 Part Numbers"
+REAL_WB = Path(
+    "Candidates/inventory recon/"
+    "WEBSAFE_Tab-Linked_1_Marcus_Compiled_Recon_Integrated_5-28-2026_PARTNUMBERS_LINKED_CANDIDATE_v2.xlsx"
+)
+
+
+def _names(path: str):
+    with zipfile.ZipFile(path) as z:
+        return z.namelist()
+
+
+def _all_text(path: str) -> str:
+    blob = []
+    with zipfile.ZipFile(path) as z:
+        for n in z.namelist():
+            if n.endswith(".xml") or n.endswith(".rels"):
+                blob.append(z.read(n).decode("utf-8", "ignore"))
+    return "".join(blob)
+
+
+@pytest.fixture
+def stale_input(tmp_path):
+    src = tmp_path / "1 Marcus Recon Integrated 5-28-2026.xlsx"
+    return fx.make_stale_recon(str(src))
+
+
+@pytest.fixture
+def output_path(tmp_path):
+    return str(tmp_path / "out" / "1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx")
+
+
+def test_infers_recon_update_date_from_filename(stale_input):
+    pkg = Package.from_path(stale_input)
+    names = fr.workbook_sheet_names(pkg.text("xl/workbook.xml"))
+    chosen, _cands, _warn = di.infer_update_date(stale_input, "auto", names)
+    assert chosen.date_iso == "2026-05-28"
+    assert chosen.source == "filename"
+    assert chosen.tab_label == TARGET_TAB
+
+
+def test_renames_part_number_tab_to_target_date(stale_input, output_path):
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto")
+    assert result.report.renamed_tabs == ["5-07-2026 Part Numbers -> 5-28-2026 Part Numbers"]
+    with zipfile.ZipFile(output_path) as z:
+        wb = z.read("xl/workbook.xml").decode("utf-8")
+    assert TARGET_TAB in wb
+    assert "5-07-2026 Part Numbers" not in wb
+
+
+def test_rewrites_formulas_from_old_part_number_tab(stale_input, output_path):
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto")
+    assert result.report.formula_cells_patched > 0
+    text = _all_text(output_path)
+    assert f"'{TARGET_TAB}'!" in text
+    assert "'5-07-2026 Part Numbers'!" not in text
+
+
+def test_localizes_external_part_number_formulas(stale_input, output_path):
+    run_recon(stale_input, output_path=output_path, cli_date="auto")
+    text = _all_text(output_path)
+    # The [1]'...'! external-indexed reference must be localized (prefix dropped).
+    assert "[1]'" not in text
+    assert f"'{TARGET_TAB}'!$A$1" in text
+
+
+def test_removes_external_link_parts_after_localization(stale_input, output_path):
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto")
+    assert any("externalLinks" in p for p in result.report.external_link_parts_removed)
+    assert not [n for n in _names(output_path) if n.startswith("xl/externalLinks/")]
+    assert "externalLink" not in _all_text(output_path)
+
+
+def test_removes_calc_chain_after_formula_patch(stale_input, output_path):
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto")
+    assert result.report.calc_chain_removed is True
+    assert "xl/calcChain.xml" not in _names(output_path)
+
+
+def test_preserves_unrelated_tabs_and_sheet_order(stale_input, output_path):
+    before = fr.workbook_sheet_names(Package.from_path(stale_input).text("xl/workbook.xml"))
+    run_recon(stale_input, output_path=output_path, cli_date="auto")
+    after = fr.workbook_sheet_names(Package.from_path(output_path).text("xl/workbook.xml"))
+    expected = [TARGET_TAB if n == "5-07-2026 Part Numbers" else n for n in before]
+    assert after == expected
+    assert "Notes" in after and "README Integration" in after
+
+
+def test_dry_run_reports_without_output_write(stale_input, output_path):
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto", dry_run=True)
+    assert result.report.dry_run is True
+    assert result.report.formula_cells_patched > 0
+    assert not Path(output_path).exists()
+    assert result.outputs == {}
+
+
+def test_warns_on_ambiguous_date_candidates(tmp_path):
+    src = fx.make_ambiguous(str(tmp_path / "1 Marcus Recon Integrated.xlsx"))
+    out = str(tmp_path / "amb_WEBSAFE.xlsx")
+    result = run_recon(src, output_path=out, cli_date="auto")
+    assert any("ambiguous" in w for w in result.report.warnings)
+    # Strict mode must hard-fail on the same ambiguity.
+    pkg = Package.from_path(src)
+    names = fr.workbook_sheet_names(pkg.text("xl/workbook.xml"))
+    with pytest.raises(di.AmbiguousDateError):
+        di.infer_update_date(src, "auto", names, strict=True)
+
+
+def test_webexcel_preflight_rejects_stale_refs_and_stopship_tokens(stale_input, output_path):
+    # The stale INPUT must fail preflight (calcChain + external links + stale refs).
+    pre_in = pf.run_preflight(stale_input, target_part_number_tab=TARGET_TAB)
+    assert pre_in.preflight_pass is False
+    assert pre_in.has_calc_chain and pre_in.external_link_parts
+    # The repaired OUTPUT must pass.
+    result = run_recon(stale_input, output_path=output_path, cli_date="auto")
+    assert result.report.webexcel_preflight_pass is True
+    pre_out = pf.run_preflight(output_path, target_part_number_tab=TARGET_TAB)
+    assert pre_out.preflight_pass is True
+    assert not pre_out.stale_dated_refs
+
+
+@pytest.mark.skipif(not REAL_WB.exists(), reason="private real workbook not present")
+def test_real_workbook_idempotent_regression(tmp_path):
+    out = str(tmp_path / "real_1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx")
+    before = fr.workbook_sheet_names(Package.from_path(str(REAL_WB)).text("xl/workbook.xml"))
+    result = run_recon(str(REAL_WB), output_path=out, cli_date="2026-05-28")
+    after = fr.workbook_sheet_names(Package.from_path(out).text("xl/workbook.xml"))
+    # Already-clean workbook: sheet set/order preserved, target tab intact.
+    assert after == before
+    assert TARGET_TAB in after
+    # Tables and drawing survive the surgical patch.
+    names = _names(out)
+    assert any(n.startswith("xl/tables/table") for n in names)
+    assert any(n.startswith("xl/drawings/drawing") for n in names)
+    assert result.report.webexcel_preflight_pass is True

--- a/triage/one_marcus_recon/__init__.py
+++ b/triage/one_marcus_recon/__init__.py
@@ -1,0 +1,13 @@
+"""1 Marcus inventory recon part-number relink engine.
+
+Surgically patches an existing 1 Marcus recon workbook package so the dated
+Part Numbers tab, formula references, and package metadata agree before client
+delivery, then emits a Web Excel-safe artifact plus sidecars.
+
+See docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md.
+"""
+from __future__ import annotations
+
+from .models import DateCandidate, ReconChange, ReconReport
+
+__all__ = ["DateCandidate", "ReconChange", "ReconReport"]

--- a/triage/one_marcus_recon/cli.py
+++ b/triage/one_marcus_recon/cli.py
@@ -1,0 +1,71 @@
+"""CLI for the 1 Marcus recon part-number relink engine.
+
+Example:
+    python -m triage.one_marcus_recon.cli \\
+        --input "Candidates/inventory recon/...CANDIDATE_v2.xlsx" \\
+        --date auto \\
+        --output "Outputs/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from .date_inference import AmbiguousDateError
+from .exporter import run_recon
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m triage.one_marcus_recon.cli",
+        description="Relink the dated Part Numbers tab and produce a Web Excel-safe recon workbook.",
+    )
+    p.add_argument("--input", required=True, help="Source recon workbook (.xlsx).")
+    p.add_argument("--date", default="auto", help="Update date (ISO/M-D-YYYY) or 'auto'.")
+    p.add_argument("--output", help="Output .xlsx path. Defaults under Outputs/.")
+    p.add_argument("--part-number-tab", help="Explicit source Part Numbers tab to rename.")
+    p.add_argument("--pivot-tab", help="Pivot/recon module tab name (reporting only).")
+    p.add_argument("--dry-run", action="store_true", help="Report intended changes; write nothing.")
+    p.add_argument("--strict", action="store_true", help="Fail on ambiguous date candidates.")
+    p.add_argument("--report-json", help="Write the recon report JSON to this path.")
+    return p
+
+
+def _default_output(input_path: str) -> str:
+    return str(Path("Outputs") / "1_Marcus_Recon_WEBSAFE.xlsx")
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    output = args.output or _default_output(args.input)
+
+    try:
+        result = run_recon(
+            args.input,
+            output_path=output,
+            cli_date=args.date,
+            part_number_tab=args.part_number_tab,
+            pivot_tab=args.pivot_tab,
+            dry_run=args.dry_run,
+            strict=args.strict,
+        )
+    except AmbiguousDateError as exc:
+        print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
+        return 2
+
+    report = result.report.to_dict()
+    print(json.dumps(report, indent=2))
+
+    if args.report_json:
+        Path(args.report_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.report_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if not result.report.webexcel_preflight_pass:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/triage/one_marcus_recon/date_inference.py
+++ b/triage/one_marcus_recon/date_inference.py
@@ -1,0 +1,142 @@
+"""Recon update-date inference.
+
+Precedence (contract):
+1. Explicit CLI/config date.
+2. Workbook filename date.
+3. Existing latest dated Part Numbers tab.
+4. File modified timestamp (last resort, warns).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from .models import DateCandidate
+
+# Matches "5-28-2026", "05-28-2026"; also tolerant of "5/28/2026".
+_MDY = re.compile(r"(?<!\d)(\d{1,2})[-/](\d{1,2})[-/](\d{4})(?!\d)")
+# Matches ISO "2026-05-28".
+_ISO = re.compile(r"(?<!\d)(\d{4})-(\d{1,2})-(\d{1,2})(?!\d)")
+# A dated Part Numbers tab title, e.g. "5-28-2026 Part Numbers".
+PART_NUMBERS_TAB = re.compile(
+    r"(?P<m>\d{1,2})-(?P<d>\d{1,2})-(?P<y>\d{4})\s+part\s+numbers", re.IGNORECASE
+)
+
+
+class AmbiguousDateError(ValueError):
+    """Raised in strict mode when multiple distinct dated tabs compete."""
+
+
+def _to_iso(month: int, day: int, year: int) -> Optional[str]:
+    try:
+        return _dt.date(year, month, day).isoformat()
+    except ValueError:
+        return None
+
+
+def parse_explicit(value: str) -> Optional[str]:
+    """Parse an explicit --date value (ISO or M-D-YYYY). 'auto'/'' -> None."""
+    if not value or value.strip().lower() == "auto":
+        return None
+    v = value.strip()
+    m = _ISO.search(v)
+    if m:
+        return _to_iso(int(m.group(2)), int(m.group(3)), int(m.group(1)))
+    m = _MDY.search(v)
+    if m:
+        return _to_iso(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    return None
+
+
+def date_from_filename(path: str) -> Optional[str]:
+    stem = Path(path).name
+    m = _ISO.search(stem)
+    if m:
+        iso = _to_iso(int(m.group(2)), int(m.group(3)), int(m.group(1)))
+        if iso:
+            return iso
+    m = _MDY.search(stem)
+    if m:
+        return _to_iso(int(m.group(1)), int(m.group(2)), int(m.group(3)))
+    return None
+
+
+def dated_part_number_tabs(sheet_names: List[str]) -> List[Tuple[str, str]]:
+    """Return [(sheet_name, iso_date)] for every dated Part Numbers tab."""
+    out: List[Tuple[str, str]] = []
+    for name in sheet_names:
+        m = PART_NUMBERS_TAB.search(name)
+        if not m:
+            continue
+        iso = _to_iso(int(m.group("m")), int(m.group("d")), int(m.group("y")))
+        if iso:
+            out.append((name, iso))
+    return out
+
+
+def infer_update_date(
+    input_path: str,
+    cli_date: str,
+    sheet_names: List[str],
+    *,
+    file_mtime: Optional[float] = None,
+    strict: bool = False,
+) -> Tuple[DateCandidate, List[DateCandidate], List[str]]:
+    """Resolve the update date.
+
+    Returns (chosen, all_candidates, warnings). Raises AmbiguousDateError in
+    strict mode when multiple distinct dated tabs exist and no explicit/filename
+    date disambiguates them.
+    """
+    warnings: List[str] = []
+    candidates: List[DateCandidate] = []
+
+    explicit = parse_explicit(cli_date)
+    if explicit:
+        candidates.append(DateCandidate(explicit, "cli", cli_date))
+
+    fname = date_from_filename(input_path)
+    if fname:
+        candidates.append(DateCandidate(fname, "filename", Path(input_path).name))
+
+    tabs = dated_part_number_tabs(sheet_names)
+    distinct_tab_dates = sorted({iso for _, iso in tabs})
+    for name, iso in sorted(tabs, key=lambda t: t[1]):
+        candidates.append(DateCandidate(iso, "tab", name))
+
+    # Ambiguity: more than one distinct dated Part Numbers tab and the operator
+    # gave no explicit/filename date to anchor the intended source.
+    ambiguous = len(distinct_tab_dates) > 1 and not (explicit or fname)
+    if len(distinct_tab_dates) > 1:
+        msg = (
+            "ambiguous date candidates: multiple dated Part Numbers tabs "
+            f"{distinct_tab_dates}"
+        )
+        if ambiguous and strict:
+            raise AmbiguousDateError(msg)
+        warnings.append(msg)
+
+    chosen: Optional[DateCandidate] = None
+    # Precedence: cli > filename > latest tab > mtime.
+    for src in ("cli", "filename"):
+        for c in candidates:
+            if c.source == src:
+                chosen = c
+                break
+        if chosen:
+            break
+    if chosen is None and distinct_tab_dates:
+        latest = distinct_tab_dates[-1]
+        chosen = next(c for c in candidates if c.source == "tab" and c.date_iso == latest)
+    if chosen is None:
+        ts = file_mtime if file_mtime is not None else Path(input_path).stat().st_mtime
+        iso = _dt.date.fromtimestamp(ts).isoformat()
+        chosen = DateCandidate(iso, "mtime", str(ts))
+        candidates.append(chosen)
+        warnings.append(
+            "update date inferred from file modified timestamp (last-resort fallback)"
+        )
+
+    return chosen, candidates, warnings

--- a/triage/one_marcus_recon/exporter.py
+++ b/triage/one_marcus_recon/exporter.py
@@ -1,0 +1,281 @@
+"""Orchestrates the recon relink pipeline and writes the delivery package."""
+from __future__ import annotations
+
+import csv
+import json
+import re
+import tempfile
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from triage.xlsx_utils import fix_inlinestr
+
+from . import date_inference as di
+from . import formula_relink as fr
+from . import preflight as pf
+from .models import ReconChange, ReconReport
+from .package_cleanup import (
+    Package,
+    broken_relationship_targets,
+    remove_calc_chain,
+    remove_external_links,
+)
+
+_DATED_PN = re.compile(r"^\s*\d{1,2}-\d{1,2}-\d{4}\s+part\s+numbers\s*$", re.IGNORECASE)
+
+
+@dataclass
+class ReconResult:
+    report: ReconReport
+    outputs: Dict[str, str] = field(default_factory=dict)
+
+
+def _sidecar_base(output_path: str) -> Path:
+    out = Path(output_path)
+    stem = out.stem
+    if stem.endswith("_WEBSAFE"):
+        stem = stem[: -len("_WEBSAFE")]
+    return out.with_name(stem)
+
+
+def run_recon(
+    input_path: str,
+    *,
+    output_path: str,
+    cli_date: str = "auto",
+    part_number_tab: Optional[str] = None,
+    pivot_tab: Optional[str] = None,
+    dry_run: bool = False,
+    strict: bool = False,
+) -> ReconResult:
+    report = ReconReport(input_workbook=str(Path(input_path).resolve()), dry_run=dry_run)
+
+    pkg = Package.from_path(input_path)
+    wb_xml = pkg.text("xl/workbook.xml")
+    sheet_names = fr.workbook_sheet_names(wb_xml)
+    report.pivot_tab = pivot_tab or (sheet_names[0] if sheet_names else "")
+
+    # --- date inference ---
+    chosen, candidates, warnings = di.infer_update_date(
+        input_path, cli_date, sheet_names, strict=strict
+    )
+    report.inferred_update_date = chosen.date_iso
+    report.date_source = chosen.source
+    report.date_candidates = [
+        {"date": c.date_iso, "source": c.source, "raw": c.raw} for c in candidates
+    ]
+    report.warnings.extend(warnings)
+    target_label = chosen.tab_label
+    report.final_part_number_tab = target_label
+
+    # --- pick + rename the source Part Numbers tab ---
+    source_tab = fr.choose_source_tab(
+        sheet_names,
+        explicit_tab=part_number_tab,
+        chosen_date_iso=chosen.date_iso,
+        target_label=target_label,
+    )
+    if source_tab:
+        wb_xml, renamed = fr.rename_tab(wb_xml, source_tab, target_label)
+        if renamed:
+            report.renamed_tabs.append(f"{source_tab} -> {target_label}")
+            report.add_change(
+                ReconChange("rename_tab", f"{source_tab} -> {target_label}", source_tab, 1)
+            )
+    else:
+        report.warnings.append("no Part Numbers candidate tab detected")
+
+    extra_source = source_tab if (source_tab and not _DATED_PN.match(source_tab)) else None
+
+    # --- rewrite formulas across worksheets ---
+    total_scanned = total_patched = total_localized = 0
+    remaining_ext: List[str] = []
+    for ws in pkg.worksheet_parts():
+        text = pkg.text(ws)
+        new_text, scanned, patched, localized, ext = fr.rewrite_sheet_formulas(
+            text, target_label, extra_source
+        )
+        total_scanned += scanned
+        total_patched += patched
+        total_localized += localized
+        remaining_ext.extend(ext)
+        if new_text != text:
+            pkg.set_text(ws, new_text)
+    # Defined names can also carry references.
+    wb_xml = re.sub(
+        r"(<definedName\b[^>]*>)(.*?)(</definedName>)",
+        lambda m: m.group(1)
+        + fr._rewrite_refs_in_text(m.group(2), target_label, extra_source)[0]
+        + m.group(3),
+        wb_xml,
+        flags=re.DOTALL,
+    )
+    pkg.set_text("xl/workbook.xml", wb_xml)
+
+    report.formula_cells_scanned = total_scanned
+    report.formula_cells_patched = total_patched
+    report.stale_tab_references_removed = total_patched
+    if total_patched:
+        report.add_change(
+            ReconChange("rewrite_formula", f"repointed to '{target_label}'", count=total_patched)
+        )
+    if total_localized:
+        report.add_change(
+            ReconChange("localize_external", "dropped external index prefix", count=total_localized)
+        )
+
+    # --- package cleanup ---
+    if remove_calc_chain(pkg):
+        report.calc_chain_removed = True
+        report.add_change(ReconChange("remove_part", "xl/calcChain.xml"))
+
+    # Only strip external link parts when nothing still references them.
+    if remaining_ext:
+        report.remaining_external_links = sorted(set(remaining_ext))
+        report.warnings.append(
+            "external references remain after rewrite; external link parts preserved"
+        )
+    else:
+        removed = remove_external_links(pkg)
+        if removed:
+            report.external_link_parts_removed = removed
+            for n in removed:
+                report.add_change(ReconChange("remove_part", n))
+
+    # --- write patched workbook (or temp for dry-run preflight) ---
+    base = _sidecar_base(output_path)
+    out_dir = base.parent
+    if not dry_run:
+        pkg.write(output_path)
+        report.output_workbook = str(Path(output_path).resolve())
+        scan_path = output_path
+        cleanup_tmp = None
+    else:
+        tmp = tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False)
+        tmp.write(pkg.to_bytes())
+        tmp.close()
+        scan_path = tmp.name
+        cleanup_tmp = tmp.name
+
+    # Web Excel safety: eliminate any inlineStr tokens (surgical zip patch).
+    fix_inlinestr(scan_path)
+
+    # --- preflight ---
+    pre = pf.run_preflight(scan_path, target_part_number_tab=target_label)
+    report.webexcel_preflight_pass = pre.preflight_pass
+    report.formula_error_scan = pre.error_value_failures
+    report.remaining_stale_tab_references = pre.stale_dated_refs
+    if pre.token_failures:
+        report.warnings.append(f"stop-ship tokens: {pre.token_failures}")
+    if pre.broken_relationships:
+        report.warnings.append(f"broken relationships: {pre.broken_relationships}")
+    report.remaining_external_links = sorted(
+        set(report.remaining_external_links) | set(pre.external_link_parts)
+    )
+
+    result = ReconResult(report=report)
+    if dry_run:
+        if cleanup_tmp:
+            Path(cleanup_tmp).unlink(missing_ok=True)
+        return result
+
+    # --- sidecars ---
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pre_path = out_dir / f"{base.name}_preflight.json"
+    manifest_path = out_dir / f"{base.name}_manifest.json"
+    review_path = out_dir / f"{base.name}_review_queue.csv"
+    carry_path = out_dir / f"{base.name}_carryover.md"
+    zip_path = out_dir / f"{base.name}_DELIVERY.zip"
+
+    pre_path.write_text(json.dumps(pre.to_dict(), indent=2), encoding="utf-8")
+    manifest = {
+        "input_workbook": report.input_workbook,
+        "output_workbook": report.output_workbook,
+        "inferred_update_date": report.inferred_update_date,
+        "date_source": report.date_source,
+        "final_part_number_tab": report.final_part_number_tab,
+        "pivot_tab": report.pivot_tab,
+        "renamed_tabs": report.renamed_tabs,
+        "formula_cells_scanned": report.formula_cells_scanned,
+        "formula_cells_patched": report.formula_cells_patched,
+        "external_link_parts_removed": report.external_link_parts_removed,
+        "calc_chain_removed": report.calc_chain_removed,
+        "webexcel_preflight_pass": report.webexcel_preflight_pass,
+        "sidecars": {
+            "preflight": str(pre_path.resolve()),
+            "review_queue": str(review_path.resolve()),
+            "carryover": str(carry_path.resolve()),
+            "delivery_zip": str(zip_path.resolve()),
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    _write_review_queue(review_path, report, pre)
+    _write_carryover(carry_path, report, pre)
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.write(output_path, Path(output_path).name)
+        z.write(pre_path, pre_path.name)
+        z.write(manifest_path, manifest_path.name)
+        z.write(review_path, review_path.name)
+        z.write(carry_path, carry_path.name)
+
+    result.outputs = {
+        "workbook": str(Path(output_path).resolve()),
+        "preflight": str(pre_path.resolve()),
+        "manifest": str(manifest_path.resolve()),
+        "review_queue": str(review_path.resolve()),
+        "carryover": str(carry_path.resolve()),
+        "delivery_zip": str(zip_path.resolve()),
+    }
+    return result
+
+
+def _write_review_queue(path: Path, report: ReconReport, pre: pf.ReconPreflight) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(["category", "detail"])
+        for ref in report.remaining_stale_tab_references:
+            w.writerow(["stale_dated_reference", ref])
+        for ext in report.remaining_external_links:
+            w.writerow(["remaining_external_link", ext])
+        for err in report.formula_error_scan:
+            w.writerow(["formula_error", err])
+        for tok in pre.token_failures:
+            w.writerow(["stop_ship_token", tok])
+        for rel in pre.broken_relationships:
+            w.writerow(["broken_relationship", rel])
+        for warn in report.warnings:
+            w.writerow(["warning", warn])
+
+
+def _write_carryover(path: Path, report: ReconReport, pre: pf.ReconPreflight) -> None:
+    lines = [
+        f"# 1 Marcus Recon Carryover — {report.inferred_update_date}",
+        "",
+        f"- Input: `{Path(report.input_workbook).name}`",
+        f"- Output: `{Path(report.output_workbook).name if report.output_workbook else '(dry-run)'}`",
+        f"- Update date: {report.inferred_update_date} (source: {report.date_source})",
+        f"- Target Part Numbers tab: `{report.final_part_number_tab}`",
+        f"- Pivot tab: `{report.pivot_tab}`",
+        f"- Preflight pass: **{report.webexcel_preflight_pass}**",
+        "",
+        "## Changes applied",
+        "",
+        f"- Renamed tabs: {report.renamed_tabs or 'none'}",
+        f"- Formula cells scanned: {report.formula_cells_scanned}",
+        f"- Formula references repointed: {report.formula_cells_patched}",
+        f"- External link parts removed: {report.external_link_parts_removed or 'none'}",
+        f"- calcChain removed: {report.calc_chain_removed}",
+        "",
+        "## Review queue",
+        "",
+        f"- Remaining stale dated refs: {report.remaining_stale_tab_references or 'none'}",
+        f"- Remaining external links: {report.remaining_external_links or 'none'}",
+        f"- Formula errors: {report.formula_error_scan or 'none'}",
+        f"- Warnings: {report.warnings or 'none'}",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")

--- a/triage/one_marcus_recon/formula_relink.py
+++ b/triage/one_marcus_recon/formula_relink.py
@@ -1,0 +1,169 @@
+"""Tab detection/rename and formula reference rewiring.
+
+Operates on decoded XML text of package parts. The engine never reserializes
+the workbook through a high-level library; it edits the OOXML in place so
+tables, drawings, styles, filters, and validation are preserved.
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional, Tuple
+
+# Ordered <sheet .../> tags inside xl/workbook.xml.
+_SHEET_TAG = re.compile(r"<sheet\b[^>]*/>|<sheet\b[^>]*>")
+_NAME_ATTR = re.compile(r'name="([^"]*)"')
+
+# A dated Part Numbers reference inside a formula, optionally external-indexed:
+#   'M-D-YYYY Part Numbers'!     or    [1]'M-D-YYYY Part Numbers'!
+_DATED_REF = re.compile(
+    r"(?:\[(?P<idx>\d+)\])?'(?P<name>\d{1,2}-\d{1,2}-\d{4} Part Numbers)'!"
+)
+# Detects an undated "Part Numbers" candidate tab title.
+_UNDATED_PN = re.compile(r"^\s*part\s+numbers\b", re.IGNORECASE)
+_DATED_PN = re.compile(r"^\s*\d{1,2}-\d{1,2}-\d{4}\s+part\s+numbers\s*$", re.IGNORECASE)
+
+
+def workbook_sheet_names(workbook_xml: str) -> List[str]:
+    """Return sheet display names in tab order."""
+    names: List[str] = []
+    for m in _SHEET_TAG.finditer(workbook_xml):
+        nm = _NAME_ATTR.search(m.group(0))
+        if nm:
+            names.append(nm.group(1))
+    return names
+
+
+def detect_part_number_tabs(sheet_names: List[str]) -> List[str]:
+    """Return all Part Numbers candidate tabs (dated first, then undated)."""
+    dated = [n for n in sheet_names if _DATED_PN.match(n)]
+    undated = [n for n in sheet_names if _UNDATED_PN.match(n) and n not in dated]
+    return dated + undated
+
+
+def choose_source_tab(
+    sheet_names: List[str],
+    *,
+    explicit_tab: Optional[str],
+    chosen_date_iso: str,
+    target_label: str,
+) -> Optional[str]:
+    """Pick the tab to rename to ``target_label``."""
+    if explicit_tab and explicit_tab in sheet_names:
+        return explicit_tab
+    candidates = detect_part_number_tabs(sheet_names)
+    if not candidates:
+        return None
+    if target_label in candidates and len(candidates) == 1:
+        return target_label
+    # Prefer the dated tab whose date matches the chosen update date.
+    y, m, d = chosen_date_iso.split("-")
+    want = f"{int(m)}-{int(d)}-{int(y)} Part Numbers"
+    if want in candidates:
+        return want
+    # Otherwise prefer the single dated candidate, else the latest dated, else
+    # the first undated candidate.
+    dated = [n for n in candidates if _DATED_PN.match(n)]
+    if dated:
+        return sorted(dated)[-1]
+    return candidates[0]
+
+
+def rename_tab(workbook_xml: str, old: str, new: str) -> Tuple[str, bool]:
+    """Rename a sheet's display name in xl/workbook.xml. Returns (xml, changed)."""
+    if old == new:
+        return workbook_xml, False
+
+    changed = False
+
+    def _sub(m: re.Match) -> str:
+        nonlocal changed
+        tag = m.group(0)
+        nm = _NAME_ATTR.search(tag)
+        if nm and nm.group(1) == old:
+            changed = True
+            return tag[: nm.start(1)] + new + tag[nm.end(1) :]
+        return tag
+
+    return _SHEET_TAG.sub(_sub, workbook_xml), changed
+
+
+def _rewrite_refs_in_text(
+    text: str, target_label: str, extra_source: Optional[str]
+) -> Tuple[str, int, int, List[str]]:
+    """Rewrite dated/external Part Numbers refs to the local target tab.
+
+    Returns (new_text, patched_count, localized_count, remaining_external_idx).
+    """
+    patched = 0
+    localized = 0
+    remaining_ext: List[str] = []
+
+    def _sub(m: re.Match) -> str:
+        nonlocal patched, localized
+        idx = m.group("idx")
+        replacement = f"'{target_label}'!"
+        if m.group(0) != replacement:
+            patched += 1
+        if idx is not None:
+            localized += 1
+        return replacement
+
+    text = _DATED_REF.sub(_sub, text)
+
+    # An explicitly chosen, non-dated source tab (e.g. plain "Part Numbers").
+    if extra_source and extra_source != target_label:
+        esc = re.escape(extra_source)
+        pat = re.compile(r"(?:\[(?P<idx>\d+)\])?'" + esc + r"'!")
+
+        def _sub2(m: re.Match) -> str:
+            nonlocal patched, localized
+            if m.group("idx") is not None:
+                localized += 1
+            patched += 1
+            return f"'{target_label}'!"
+
+        text = pat.sub(_sub2, text)
+
+    # Any remaining external-indexed references (could not be localized here).
+    for m in re.finditer(r"\[(\d+)\]'?[^'!]*'?!", text):
+        remaining_ext.append(m.group(0))
+
+    return text, patched, localized, remaining_ext
+
+
+def rewrite_sheet_formulas(
+    sheet_xml: str, target_label: str, extra_source: Optional[str]
+) -> Tuple[str, int, int, int, List[str]]:
+    """Rewrite refs inside every <f>…</f> of a worksheet.
+
+    Returns (new_xml, scanned, patched, localized, remaining_external).
+    """
+    scanned = 0
+    patched_total = 0
+    localized_total = 0
+    remaining_ext: List[str] = []
+
+    def _sub(m: re.Match) -> str:
+        nonlocal scanned, patched_total, localized_total
+        scanned += 1
+        head, body, tail = m.group(1), m.group(2), m.group(3)
+        new_body, patched, localized, ext = _rewrite_refs_in_text(
+            body, target_label, extra_source
+        )
+        patched_total += patched
+        localized_total += localized
+        remaining_ext.extend(ext)
+        return head + new_body + tail
+
+    new_xml = re.sub(r"(<f[^>]*>)(.*?)(</f>)", _sub, sheet_xml, flags=re.DOTALL)
+    return new_xml, scanned, patched_total, localized_total, remaining_ext
+
+
+def find_stale_dated_refs(text: str, target_label: str) -> List[str]:
+    """Return distinct dated Part Numbers refs whose date != target."""
+    target_inner = target_label
+    stale = set()
+    for m in _DATED_REF.finditer(text):
+        if m.group("name") != target_inner:
+            stale.add(m.group(0))
+    return sorted(stale)

--- a/triage/one_marcus_recon/models.py
+++ b/triage/one_marcus_recon/models.py
@@ -1,0 +1,64 @@
+"""Data models for the 1 Marcus recon relink engine."""
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class DateCandidate:
+    """A possible recon update date and where it came from."""
+
+    date_iso: str
+    source: str  # "cli" | "filename" | "tab" | "mtime"
+    raw: str = ""
+
+    @property
+    def tab_label(self) -> str:
+        """Render the M-D-YYYY Part Numbers tab title (no zero padding)."""
+        y, m, d = self.date_iso.split("-")
+        return f"{int(m)}-{int(d)}-{int(y)} Part Numbers"
+
+
+@dataclass
+class ReconChange:
+    """A single applied (or proposed, in dry-run) change."""
+
+    kind: str  # "rename_tab" | "rewrite_formula" | "localize_external" | "remove_part"
+    detail: str
+    sheet: str = ""
+    count: int = 0
+
+
+@dataclass
+class ReconReport:
+    """Full recon report; serialized to the *_preflight.json sidecar."""
+
+    input_workbook: str = ""
+    output_workbook: str = ""
+    inferred_update_date: str = ""
+    date_source: str = ""
+    final_part_number_tab: str = ""
+    pivot_tab: str = ""
+    renamed_tabs: List[str] = field(default_factory=list)
+    formula_cells_scanned: int = 0
+    formula_cells_patched: int = 0
+    stale_tab_references_removed: int = 0
+    remaining_stale_tab_references: List[str] = field(default_factory=list)
+    external_link_parts_removed: List[str] = field(default_factory=list)
+    remaining_external_links: List[str] = field(default_factory=list)
+    calc_chain_removed: bool = False
+    formula_error_scan: List[str] = field(default_factory=list)
+    webexcel_preflight_pass: bool = False
+    date_candidates: List[Dict] = field(default_factory=list)
+    changes: List[Dict] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    dry_run: bool = False
+
+    def add_change(self, change: ReconChange) -> None:
+        self.changes.append(dataclasses.asdict(change))
+
+    def to_dict(self) -> Dict:
+        return dataclasses.asdict(self)

--- a/triage/one_marcus_recon/package_cleanup.py
+++ b/triage/one_marcus_recon/package_cleanup.py
@@ -1,0 +1,160 @@
+"""Package-level surgical cleanup for Web Excel safety.
+
+- Drop stale ``xl/calcChain.xml`` so Excel for Web rebuilds formulas.
+- Strip unused ``xl/externalLinks/*`` parts after formula localization.
+- Repair the relationship and content-type references those removals dangle.
+"""
+from __future__ import annotations
+
+import io
+import re
+import zipfile
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+
+class Package:
+    """Mutable, order-preserving view over an OOXML (xlsx) ZIP package."""
+
+    def __init__(self, names: List[str], parts: Dict[str, bytes]):
+        self.names = list(names)
+        self.parts = dict(parts)
+
+    @classmethod
+    def from_path(cls, path: str) -> "Package":
+        with zipfile.ZipFile(path, "r") as z:
+            names = z.namelist()
+            parts = {n: z.read(n) for n in names}
+        return cls(names, parts)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> "Package":
+        with zipfile.ZipFile(io.BytesIO(data), "r") as z:
+            names = z.namelist()
+            parts = {n: z.read(n) for n in names}
+        return cls(names, parts)
+
+    def text(self, name: str) -> str:
+        return self.parts[name].decode("utf-8", errors="ignore")
+
+    def set_text(self, name: str, value: str) -> None:
+        self.parts[name] = value.encode("utf-8")
+
+    def has(self, name: str) -> bool:
+        return name in self.parts
+
+    def remove(self, name: str) -> bool:
+        if name in self.parts:
+            del self.parts[name]
+            self.names = [n for n in self.names if n != name]
+            return True
+        return False
+
+    def worksheet_parts(self) -> List[str]:
+        return [
+            n
+            for n in self.names
+            if n.startswith("xl/worksheets/sheet") and n.endswith(".xml")
+        ]
+
+    def to_bytes(self) -> bytes:
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+            for n in self.names:
+                z.writestr(n, self.parts[n])
+        return buf.getvalue()
+
+    def write(self, path: str) -> None:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(self.to_bytes())
+
+
+def remove_calc_chain(pkg: Package) -> bool:
+    """Remove calcChain.xml and its content-type override + workbook rel."""
+    removed = pkg.remove("xl/calcChain.xml")
+    if not removed:
+        return False
+
+    ct_name = "[Content_Types].xml"
+    if pkg.has(ct_name):
+        ct = pkg.text(ct_name)
+        ct = re.sub(r'<Override\b[^>]*calcChain\.xml[^>]*/>', "", ct)
+        pkg.set_text(ct_name, ct)
+
+    rels_name = "xl/_rels/workbook.xml.rels"
+    if pkg.has(rels_name):
+        rels = pkg.text(rels_name)
+        rels = re.sub(r'<Relationship\b[^>]*Target="[^"]*calcChain\.xml"[^>]*/>', "", rels)
+        pkg.set_text(rels_name, rels)
+    return True
+
+
+def remove_external_links(pkg: Package) -> List[str]:
+    """Remove xl/externalLinks/* parts and repair dangling references."""
+    ext_parts = [n for n in pkg.names if n.startswith("xl/externalLinks/")]
+    if not ext_parts:
+        return []
+
+    for n in ext_parts:
+        pkg.remove(n)
+
+    # Content types: drop externalLink overrides.
+    ct_name = "[Content_Types].xml"
+    if pkg.has(ct_name):
+        ct = pkg.text(ct_name)
+        ct = re.sub(r'<Override\b[^>]*externalLink[^>]*/>', "", ct)
+        pkg.set_text(ct_name, ct)
+
+    # Workbook rels: drop relationships targeting externalLinks/*, and collect
+    # the rIds so we can strip <externalReference r:id=...> from workbook.xml.
+    rels_name = "xl/_rels/workbook.xml.rels"
+    dropped_rids: List[str] = []
+    if pkg.has(rels_name):
+        rels = pkg.text(rels_name)
+
+        def _drop(m: re.Match) -> str:
+            frag = m.group(0)
+            if "externalLink" in frag:
+                rid = re.search(r'Id="([^"]+)"', frag)
+                if rid:
+                    dropped_rids.append(rid.group(1))
+                return ""
+            return frag
+
+        rels = re.sub(r"<Relationship\b[^>]*/>", _drop, rels)
+        pkg.set_text(rels_name, rels)
+
+    # Workbook.xml: remove externalReference entries (and empty container).
+    wb_name = "xl/workbook.xml"
+    if pkg.has(wb_name):
+        wb = pkg.text(wb_name)
+        for rid in dropped_rids:
+            wb = re.sub(
+                r'<externalReference\b[^>]*r:id="' + re.escape(rid) + r'"[^>]*/>',
+                "",
+                wb,
+            )
+        # Drop any leftover externalReference tags, then empty wrapper.
+        wb = re.sub(r"<externalReference\b[^>]*/>", "", wb)
+        wb = re.sub(r"<externalReferences\b[^>]*>\s*</externalReferences>", "", wb)
+        wb = re.sub(r"<externalReferences\b[^>]*/>", "", wb)
+        pkg.set_text(wb_name, wb)
+
+    return ext_parts
+
+
+def broken_relationship_targets(pkg: Package) -> List[str]:
+    """Return workbook relationship targets that no longer resolve to a part."""
+    rels_name = "xl/_rels/workbook.xml.rels"
+    if not pkg.has(rels_name):
+        return []
+    rels = pkg.text(rels_name)
+    broken: List[str] = []
+    for t in re.findall(r'Target="([^"]+)"', rels):
+        if t.startswith("http") or t.startswith("/"):
+            continue
+        norm = ("xl/" + t).replace("xl/./", "xl/")
+        norm = re.sub(r"xl/\.\./", "", norm)
+        if norm not in pkg.parts and t not in pkg.parts:
+            broken.append(t)
+    return broken

--- a/triage/one_marcus_recon/preflight.py
+++ b/triage/one_marcus_recon/preflight.py
@@ -1,0 +1,128 @@
+"""Recon-specific Web Excel preflight.
+
+Self-contained (no shared repo preflight import) so the engine merges cleanly.
+Scans the raw OOXML package for repair-risk tokens, formula errors, stale dated
+Part Numbers references, lingering external links, and broken relationships.
+"""
+from __future__ import annotations
+
+import dataclasses
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+STOP_SHIP_TOKENS = [
+    "inlineStr",
+    "ns0:",
+    "xmlns:ns0",
+    "_xlfn.",
+    "_xludf.",
+    "_xlpm",
+]
+ERROR_VALUE_TOKENS = ["#REF!", "#VALUE!", "#NAME?", "#DIV/0!", "#N/A", "#NULL!"]
+_DATED_PN_REF = re.compile(r"'(\d{1,2}-\d{1,2}-\d{4} Part Numbers)'!")
+
+
+@dataclass
+class ReconPreflight:
+    artifact_name: str
+    path: str
+    exists: bool = False
+    size_bytes: int = 0
+    preflight_pass: bool = False
+    zip_valid: bool = False
+    target_part_number_tab: str = ""
+    has_calc_chain: bool = False
+    external_link_parts: List[str] = field(default_factory=list)
+    stale_dated_refs: List[str] = field(default_factory=list)
+    token_failures: List[str] = field(default_factory=list)
+    error_value_failures: List[str] = field(default_factory=list)
+    broken_relationships: List[str] = field(default_factory=list)
+    sheet_count: int = 0
+    errors: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict:
+        return dataclasses.asdict(self)
+
+
+def run_preflight(path: str, target_part_number_tab: str = "") -> ReconPreflight:
+    p = Path(path)
+    res = ReconPreflight(
+        artifact_name=p.name,
+        path=str(p.resolve()),
+        target_part_number_tab=target_part_number_tab,
+    )
+    if not p.exists():
+        res.errors.append("file_not_found")
+        return res
+    res.exists = True
+    res.size_bytes = p.stat().st_size
+
+    try:
+        with zipfile.ZipFile(path, "r") as z:
+            res.zip_valid = z.testzip() is None
+            names = z.namelist()
+
+            res.has_calc_chain = "xl/calcChain.xml" in names
+            res.external_link_parts = [n for n in names if n.startswith("xl/externalLinks/")]
+
+            wb_xml = ""
+            all_text = ""
+            for part in names:
+                if not (part.endswith(".xml") or part.endswith(".rels")):
+                    continue
+                text = z.read(part).decode("utf-8", errors="ignore")
+                all_text += text
+                if part == "xl/workbook.xml":
+                    wb_xml = text
+
+            res.sheet_count = len(re.findall(r"<sheet\b[^>]*>", wb_xml))
+
+            # Stale dated Part Numbers references != target.
+            stale = set()
+            for m in _DATED_PN_REF.finditer(all_text):
+                if not target_part_number_tab or m.group(1) != target_part_number_tab:
+                    stale.add(m.group(0))
+            res.stale_dated_refs = sorted(stale)
+
+            for tok in STOP_SHIP_TOKENS:
+                if tok in all_text:
+                    res.token_failures.append(tok)
+            for tok in ERROR_VALUE_TOKENS:
+                if tok in all_text:
+                    res.error_value_failures.append(tok)
+
+            res.broken_relationships = _broken_rels(z, names)
+    except zipfile.BadZipFile:
+        res.errors.append("bad_zip")
+        return res
+
+    res.preflight_pass = (
+        res.zip_valid
+        and not res.has_calc_chain
+        and not res.external_link_parts
+        and not res.stale_dated_refs
+        and not res.token_failures
+        and not res.error_value_failures
+        and not res.broken_relationships
+        and not res.errors
+    )
+    return res
+
+
+def _broken_rels(z: zipfile.ZipFile, names: List[str]) -> List[str]:
+    rels_path = "xl/_rels/workbook.xml.rels"
+    if rels_path not in names:
+        return []
+    rels = z.read(rels_path).decode("utf-8", errors="ignore")
+    broken: List[str] = []
+    for t in re.findall(r'Target="([^"]+)"', rels):
+        if t.startswith("http") or t.startswith("/"):
+            continue
+        norm = ("xl/" + t).replace("xl/./", "xl/")
+        norm = re.sub(r"xl/\.\./", "", norm)
+        if norm not in names and t not in names:
+            broken.append(t)
+    return broken


### PR DESCRIPTION
## Summary

Defines the inventory recon automation sprint for the 1 Marcus workbook lane.

This PR is intentionally documentation-first so the next implementation can land cleanly without dragging private workbooks, generated outputs, or unrelated billing/NW PRJ branches into the feature.

## Scope

- Inventory recon automation only.
- Dated Part Numbers tab relinking.
- Pivot/recon module wiring to the current dated tab.
- Formula rewrite/localization rules.
- Web Excel-safe package cleanup rules.
- Known gaps, risks, and targets for implementation.

Billing remains a valid repo capability, but this PR does not overwrite or demote billing behavior.

## Added

- `docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md`
- `docs/1MARCUS_RECON_SPRINT_LEDGER_2026-06-01.md`

## Known gaps recorded

- No `triage.one_marcus_recon` package yet.
- No sanitized 1 Marcus fixture yet.
- No date inference, formula relink, external link cleanup, or recon-specific Web Excel preflight yet.
- No dry-run/manifest/sidecar package yet.
- Legacy PRs remain open and need separate audit/retirement handling.

## Test plan

Documentation-only checkpoint.

Manual validation:

- No private workbook data committed.
- No generated `Outputs/` files committed.
- No `Candidates/` content committed.
- Branch created from current `main` after PR #28 and PR #29 merges.

## Related

- Closes no implementation issue yet.
- Implements the planning checkpoint for #30.