### PR TITLE
ci: add artifact engine pytest workflow

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -1,0 +1,35 @@
+name: Artifact engine tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  artifact-engines:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install pytest openpyxl
+
+      - name: Import artifact engines
+        run: |
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.one_marcus_recon.cli; print('imports ok')"
+
+      - name: Run artifact engine tests
+        run: |
+          python -m pytest \
+            tests/test_cybernet_targets.py \
+            tests/test_nw_prj_neuron_track_hours.py \
+            tests/test_one_marcus_recon.py \
+            -q

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -19,8 +19,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          pip install pytest openpyxl
+          if [ -f requirements.txt ]; then
+            python -m pip install -r requirements.txt
+          else
+            python -m pip install openpyxl
+          fi
+          python -m pip install pytest
 
       - name: Import artifact engines
         run: |


### PR DESCRIPTION
## **User description**
## Summary

Adds a minimal GitHub Actions workflow at `.github/workflows/artifact-engines.yml` to protect the three proven artifact engines on `main` without making the repo red on unrelated legacy test failures.

The workflow runs on:

- Pull requests
- Pushes to `main`

It uses:

- `ubuntu-latest`
- Python `3.11`
- `requirements.txt` when present
- explicit installs for `pytest` and `openpyxl`

## Exact tests run

```bash
python -m pytest \
  tests/test_cybernet_targets.py \
  tests/test_nw_prj_neuron_track_hours.py \
  tests/test_one_marcus_recon.py \
  -q
```

## Import check

The workflow also runs:

```bash
python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.one_marcus_recon.cli; print('imports ok')"
```

## Local targeted test result

Not rerun in this connector-backed environment. This PR is intentionally limited to the known-green engine test set already proven locally before this CI sprint.

## Full-suite audit result

Full-suite pytest is intentionally not enabled in this workflow. The current known state is that clean `main` has pre-existing `test_invoice_parser.py` module-import failures unrelated to these three artifact engines.

## Private/generated file check

Confirmed branch diff contains only:

```text
.github/workflows/artifact-engines.yml
```

No private workbooks, generated workbook outputs, `Candidates/**`, or `Outputs/**` files are included.

## Known gaps

- Full repo CI is not enabled yet because invoice parser failures pre-exist.
- GitHub Actions now protects the three proven artifact engines only.
- PR #10 and PR #11 remain preserved for separate audit and were not modified in this sprint.


___

## **CodeAnt-AI Description**
Protect the three artifact engines with a dedicated CI check

### What Changed
- Added a GitHub Actions workflow that runs on pull requests and pushes to `main`
- The workflow verifies the three artifact engines still import correctly
- It runs the focused pytest set for `cybernet_targets`, `nw_prj_neuron_track_hours`, and `one_marcus_recon` on Python 3.11

### Impact
`✅ Fewer broken artifact engine releases`
`✅ Earlier detection of engine-specific test failures`
`✅ Safer merges to main`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
