### PR TITLE
Add artifact formatting profiles for billing outputs

### DIFF
--- a/configs/artifact_profiles/admin_billing_summary.json
+++ b/configs/artifact_profiles/admin_billing_summary.json
@@ -1,0 +1,27 @@
+{
+  "name": "admin_billing_summary",
+  "submission_safe": true,
+  "sheets": [
+    "Start Here",
+    "Executive Dashboard",
+    "Monthly Summary",
+    "Project Summary",
+    "Tech Summary",
+    "Tech Project Summary"
+  ],
+  "required_headers": ["Month", "Tech", "Project", "Hours", "Net Hours"],
+  "forbidden_text": [
+    "Column1",
+    "Column2",
+    "confidence",
+    "heuristic",
+    "raw note",
+    "private note",
+    "exception machinery",
+    "AI generated"
+  ],
+  "frozen_panes": "A5",
+  "autofilter": true,
+  "title_row_height": 26,
+  "header_row_height": 22
+}

--- a/configs/artifact_profiles/bonita_neuron_track_hours.json
+++ b/configs/artifact_profiles/bonita_neuron_track_hours.json
@@ -1,0 +1,21 @@
+{
+  "name": "bonita_neuron_track_hours",
+  "submission_safe": true,
+  "sheets": ["Apr 26", "May 26"],
+  "required_headers": ["DATE", "TECH", "START", "END", "TOTAL", "PROJECT", "ASSIGNMENT"],
+  "forbidden_text": [
+    "Bonita-friendly",
+    "confidence",
+    "heuristic",
+    "review queue",
+    "assignment_rule",
+    "assignment_confidence",
+    "internal audit",
+    "Column1",
+    "Column2"
+  ],
+  "frozen_panes": "A3",
+  "autofilter": true,
+  "title_row_height": 24,
+  "header_row_height": 22
+}

--- a/docs/ARTIFACT_FORMAT_PROFILE_CONTRACT.md
+++ b/docs/ARTIFACT_FORMAT_PROFILE_CONTRACT.md
@@ -1,0 +1,61 @@
+# Artifact Format Profile Contract
+
+## Purpose
+
+The repo must be able to reproduce the formatting posture of approved generated artifacts without committing private workbooks.
+
+Formatting profiles define the expected workbook shape, visible headers, submission-safety boundaries, and forbidden internal language for each artifact family.
+
+## Why this exists
+
+Recent manually accepted outputs had a better formatting standard than older repo-generated workbooks. The repo should emulate that standard through code and profiles rather than requiring repeated chat instructions.
+
+## Core rules
+
+- Submission artifacts are clean and narrow.
+- Internal review, confidence, rule names, and exception details stay in internal artifacts or sidecars.
+- Client/submission trackers must not contain `Bonita-friendly`, heuristic/confidence language, raw note explanations, or `ColumnN` corpse headers.
+- Workbooks should use stable, Excel-for-Web-compatible features: values, tables, charts where needed, frozen panes, filters, readable widths, and no macros or external links.
+- Profiles are committed; private approved reference workbooks remain gitignored.
+
+## Profile files
+
+```text
+configs/artifact_profiles/bonita_neuron_track_hours.json
+configs/artifact_profiles/admin_billing_summary.json
+```
+
+## Helper module
+
+```text
+triage/artifact_format_profiles.py
+```
+
+The helper provides:
+
+- `load_profile(path)`
+- `apply_submission_sheet_format(ws, header_row, ...)`
+- `assert_no_forbidden_submission_text(values, forbidden)`
+
+## Submission-safe expectations
+
+### Bonita Neuron Track Hours
+
+- Exactly two visible sheets: `Apr 26`, `May 26`
+- Two-line tracker header
+- Required visible fields: date/day, tech, start, end, total, project, assignment
+- Assignment values are task categories from `triage/neuron_work_context_rules.py`
+- No notes, confidence, rule names, or internal review explanations in the workbook
+
+### Admin Billing Summary
+
+- Clear front-facing dashboard/summary structure
+- Monthly, project, tech, and tech-project summary tabs
+- Review and exception detail only in internal variants
+- Charts and tables should be native Excel structures, not pasted screenshots
+
+## Future implementation targets
+
+- Existing exporters should load these profiles instead of hardcoding style choices.
+- Semantic gates should use profile `required_headers`, `sheets`, and `forbidden_text`.
+- Artifact comparison should use these profiles when comparing candidate outputs to approved reference workbooks.

--- a/triage/artifact_format_profiles.py
+++ b/triage/artifact_format_profiles.py
@@ -1,0 +1,124 @@
+"""Reusable workbook formatting/profile helpers for submission artifacts.
+
+The goal is to preserve the formatting posture of the approved generated outputs
+without committing private workbook artifacts. Engines should load a profile and
+apply the same simple, Web-Excel-friendly conventions every time:
+
+- readable title and header rows
+- frozen panes and autofilters
+- conservative column widths
+- values-only submission workbooks
+- internal review/audit content kept out of client-facing tabs
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+import json
+
+HEADER_FILL = "1F4E78"
+HEADER_FONT = "FFFFFF"
+SUBTITLE_FILL = "EAF1F8"
+TITLE_FONT_SIZE = 14
+HEADER_FONT_SIZE = 11
+BODY_FONT_SIZE = 10
+DEFAULT_ROW_HEIGHT = 18
+TITLE_ROW_HEIGHT = 24
+HEADER_ROW_HEIGHT = 22
+
+
+@dataclass(frozen=True)
+class ArtifactFormatProfile:
+    """Workbook format/profile contract loaded from JSON."""
+
+    name: str
+    sheets: tuple[str, ...]
+    submission_safe: bool
+    forbidden_text: tuple[str, ...]
+    required_headers: tuple[str, ...]
+    frozen_panes: str = "A3"
+    autofilter: bool = True
+    title_row_height: int = TITLE_ROW_HEIGHT
+    header_row_height: int = HEADER_ROW_HEIGHT
+
+
+def load_profile(path: str | Path) -> ArtifactFormatProfile:
+    """Load an artifact format profile from JSON."""
+
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    return ArtifactFormatProfile(
+        name=payload["name"],
+        sheets=tuple(payload.get("sheets", [])),
+        submission_safe=bool(payload.get("submission_safe", False)),
+        forbidden_text=tuple(payload.get("forbidden_text", [])),
+        required_headers=tuple(payload.get("required_headers", [])),
+        frozen_panes=payload.get("frozen_panes", "A3"),
+        autofilter=bool(payload.get("autofilter", True)),
+        title_row_height=int(payload.get("title_row_height", TITLE_ROW_HEIGHT)),
+        header_row_height=int(payload.get("header_row_height", HEADER_ROW_HEIGHT)),
+    )
+
+
+def apply_submission_sheet_format(
+    ws: Any,
+    header_row: int,
+    last_row: int | None = None,
+    freeze_cell: str | None = None,
+    enable_filter: bool = True,
+) -> None:
+    """Apply the repo-standard submission sheet formatting to an openpyxl sheet.
+
+    This intentionally avoids fragile features. No pivots, no macros, no external
+    links, no volatile formulas. It is designed for Excel desktop and Excel for
+    Web compatibility.
+    """
+
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
+
+    header_fill = PatternFill("solid", fgColor=HEADER_FILL)
+    header_font = Font(bold=True, color=HEADER_FONT, size=HEADER_FONT_SIZE)
+    body_font = Font(size=BODY_FONT_SIZE)
+
+    ws.freeze_panes = freeze_cell or ws.cell(header_row + 1, 1).coordinate
+    ws.row_dimensions[header_row].height = HEADER_ROW_HEIGHT
+
+    max_col = max(1, ws.max_column)
+    max_row = max(header_row, last_row or ws.max_row)
+
+    for cell in ws[header_row]:
+        if cell.column <= max_col:
+            cell.fill = header_fill
+            cell.font = header_font
+            cell.alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+
+    for row in ws.iter_rows(min_row=header_row + 1, max_row=max_row):
+        for cell in row:
+            cell.font = body_font
+            cell.alignment = Alignment(vertical="top", wrap_text=False)
+
+    for col_idx in range(1, max_col + 1):
+        letter = get_column_letter(col_idx)
+        max_len = 10
+        for cell in ws[letter]:
+            if cell.value not in (None, ""):
+                max_len = max(max_len, min(len(str(cell.value)), 45))
+        ws.column_dimensions[letter].width = max_len + 2
+
+    if enable_filter:
+        last_col = get_column_letter(max_col)
+        ws.auto_filter.ref = f"A{header_row}:{last_col}{max_row}"
+
+
+def assert_no_forbidden_submission_text(values: Iterable[object], forbidden: Iterable[str]) -> None:
+    """Fail if internal/review-only text leaks into a submission workbook."""
+
+    forbidden_lower = [token.lower() for token in forbidden]
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).lower()
+        hit = next((token for token in forbidden_lower if token and token in text), None)
+        if hit:
+            raise ValueError(f"forbidden submission text leaked: {hit}")


### PR DESCRIPTION
## Summary

Adds a reusable artifact formatting/profile layer so the repo can reproduce accepted billing output structure without committing private workbook artifacts.

## Changes

- Adds triage/artifact_format_profiles.py
- Adds configs/artifact_profiles/bonita_neuron_track_hours.json
- Adds configs/artifact_profiles/admin_billing_summary.json
- Adds docs/ARTIFACT_FORMAT_PROFILE_CONTRACT.md

## Purpose

This captures the expected submission posture in code and config: clean submission workbooks, internal audit separation, readable headers, frozen panes, filters, forbidden text guardrails, and explicit sheet/header contracts.

## Test plan

Not run through connector. Recommended local target: python -m pytest tests/test_nw_prj_neuron_track_hours_bonita.py tests/test_admin_billing_summary.py -q

## Stack

Base branch is PR 35 branch: feat/neuron-track-hours-bonita-generator-2026-06-02.
