### PR TITLE
Add approved artifact comparison scaffold

### DIFF
--- a/docs/ARTIFACT_REFERENCE_COMPARE_CONTRACT.md
+++ b/docs/ARTIFACT_REFERENCE_COMPARE_CONTRACT.md
@@ -1,0 +1,69 @@
+# Artifact Reference Compare Contract
+
+## Purpose
+
+Generated workbooks should be compared against approved reference artifacts without committing private workbook files to the repo.
+
+The comparison must support three layers:
+
+1. Raw file SHA-256 for exact byte identity.
+2. Canonical package hash for normalized XLSX package comparison.
+3. Semantic workbook hash for visible workbook meaning.
+
+Raw SHA mismatch is usually a warning. Semantic mismatch is a stop-ship condition unless an approved delta is supplied.
+
+## Approved references
+
+Approved reference workbooks belong outside git, for example:
+
+```text
+References/approved/
+```
+
+The folder may contain private workbooks locally, but those files must remain ignored. Commit profiles and comparison code only.
+
+## Required compare behavior
+
+A generated workbook should fail comparison when:
+
+- required sheets are missing
+- required headers are missing
+- visible title/sentinel cells are blank
+- shared strings collapse into generic ColumnN labels
+- known tech/project labels disappear
+- Neuron or billing totals change unexpectedly
+- semantic hash differs and no approved delta exists
+
+Warnings are acceptable for:
+
+- raw byte hash mismatch
+- workbook creator metadata changes
+- ZIP timestamp changes
+- harmless relationship ID changes
+
+## CLI target
+
+```powershell
+python -m triage.artifact_compare --reference <approved.xlsx> --candidate <generated.xlsx> --profile <profile.json> --out <compare.json>
+```
+
+## Output fields
+
+```json
+{
+  "raw_sha_match": false,
+  "canonical_package_match": true,
+  "semantic_match": true,
+  "comparison_status": "PASS"
+}
+```
+
+## Relationship to format profiles
+
+Comparison should consume profiles from:
+
+```text
+configs/artifact_profiles/
+```
+
+The profile supplies expected sheets, headers, and forbidden text. This keeps artifact expectations durable without committing private files.

--- a/triage/artifact_compare.py
+++ b/triage/artifact_compare.py
@@ -1,0 +1,79 @@
+"""Compare generated XLSX artifacts against approved references.
+
+This is intentionally lightweight. It provides a first repo-native comparison
+surface without committing private approved workbooks.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+
+def raw_sha256(path: str | Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def workbook_visible_payload(path: str | Path) -> dict[str, Any]:
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path, data_only=False, read_only=True)
+    try:
+        sheets = []
+        for ws in wb.worksheets:
+            rows = []
+            for row in ws.iter_rows(values_only=True):
+                values = [str(value) if value is not None else "" for value in row]
+                if any(values):
+                    rows.append(values)
+            sheets.append({"title": ws.title, "rows": rows})
+        return {"sheet_order": wb.sheetnames, "sheets": sheets}
+    finally:
+        wb.close()
+
+
+def semantic_sha256(path: str | Path) -> str:
+    payload = workbook_visible_payload(path)
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def compare_workbooks(reference: str | Path, candidate: str | Path) -> dict[str, Any]:
+    ref_raw = raw_sha256(reference)
+    cand_raw = raw_sha256(candidate)
+    ref_semantic = semantic_sha256(reference)
+    cand_semantic = semantic_sha256(candidate)
+    semantic_match = ref_semantic == cand_semantic
+    return {
+        "reference": str(reference),
+        "candidate": str(candidate),
+        "raw_sha_match": ref_raw == cand_raw,
+        "semantic_match": semantic_match,
+        "comparison_status": "PASS" if semantic_match else "FAIL",
+        "reference_raw_sha256": ref_raw,
+        "candidate_raw_sha256": cand_raw,
+        "reference_semantic_sha256": ref_semantic,
+        "candidate_semantic_sha256": cand_semantic,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compare generated workbook against approved reference")
+    parser.add_argument("--reference", required=True)
+    parser.add_argument("--candidate", required=True)
+    parser.add_argument("--out", required=True)
+    parser.add_argument("--profile", default="")
+    args = parser.parse_args(argv)
+
+    result = compare_workbooks(args.reference, args.candidate)
+    if args.profile:
+        result["profile"] = args.profile
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(result, indent=2), encoding="utf-8")
+    return 0 if result["comparison_status"] == "PASS" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## **User description**
## Summary

Adds the first repo-native approved-reference comparison scaffold for generated workbook artifacts.

## Changes

- Adds docs/ARTIFACT_REFERENCE_COMPARE_CONTRACT.md
- Adds triage/artifact_compare.py

## Purpose

This lets the repo compare generated XLSX artifacts against approved local references without committing private workbooks. Raw SHA is reported, but the first stop-ship signal is semantic workbook comparison.

## CLI

python -m triage.artifact_compare --reference <approved.xlsx> --candidate <generated.xlsx> --out <compare.json>

## Notes

This is intentionally minimal. Follow-up work should expand canonical package hashing, profile-aware sentinel checks, chart/table comparison, and sidecar portal wiring.

## Stack

Base branch is PR 36 branch: feat/artifact-format-profiles-2026-06-03.


___

## **CodeAnt-AI Description**
**Compare generated workbooks against approved references and fail when the workbook meaning changes**

### What Changed
- Added a command that compares a generated XLSX file with an approved reference and writes a JSON result
- The comparison now reports both exact file matching and workbook-meaning matching, and returns a failing exit code when the semantic comparison does not match
- Added guidance for where approved reference workbooks should live, what differences are acceptable, and which workbook changes should stop the release

### Impact
`✅ Faster workbook review`
`✅ Fewer false alarms from harmless file changes`
`✅ Clearer stop-ship signals for workbook changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
