### PR TITLE
Fix hidden-sheet semantic hash in artifact fingerprint

### DIFF
--- a/docs/ARTIFACT_FINGERPRINT_AND_COMPARE.md
+++ b/docs/ARTIFACT_FINGERPRINT_AND_COMPARE.md
@@ -17,6 +17,8 @@ Raw SHA proves byte identity. Canonical package SHA removes volatile OOXML noise
 
 Visible semantic SHA proves visible sheet names, cell values, formulas, number formats, tables, chart count, frozen panes, and autofilter refs — without filesystem path noise. Use the all-sheet semantic hash only when hidden-sheet drift is itself the thing you want to compare.
 
+Operational/required-field comparison remains separate from hashing: profiles, package preflight, and semantic integrity gates enforce required tabs, native tables, sentinel fields, Web Excel stop-ship tokens, and manual proof requirements.
+
 ## CLI
 
 ```powershell

--- a/docs/ARTIFACT_FINGERPRINT_AND_COMPARE.md
+++ b/docs/ARTIFACT_FINGERPRINT_AND_COMPARE.md
@@ -10,9 +10,12 @@ Generated submission workbooks are compared to **manually blessed** references u
 |-------|--------|-------------------------|
 | Raw file | `raw_sha256` | No (warning only) |
 | Canonical package | `canonical_package_sha256` | No (warning; profile may opt in) |
-| Semantic workbook | `semantic_sha256` | Yes, unless approved delta |
+| Visible semantic workbook | `semantic_sha256` | Yes, unless approved delta |
+| All-sheet semantic workbook | `all_sheets_semantic_sha256` | No (diagnostic / explicit-use only) |
 
-Raw SHA proves byte identity. Semantic SHA proves sheet names, cell values, formulas, number formats, tables, chart count, frozen panes, and autofilter refs — without filesystem path noise.
+Raw SHA proves byte identity. Canonical package SHA removes volatile OOXML noise. The default semantic SHA now covers only **visible** worksheets so hidden/reference scratch tabs do not poison user-visible artifact comparison. `all_sheets_semantic_sha256` is still exposed for explicit investigations when you intentionally want hidden sheets to count.
+
+Visible semantic SHA proves visible sheet names, cell values, formulas, number formats, tables, chart count, frozen panes, and autofilter refs — without filesystem path noise. Use the all-sheet semantic hash only when hidden-sheet drift is itself the thing you want to compare.
 
 ## CLI
 

--- a/tests/test_artifact_compare.py
+++ b/tests/test_artifact_compare.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
 import zipfile
 from pathlib import Path
 
@@ -78,6 +79,19 @@ def _make_corpse_xlsx(path: Path) -> None:
     path.write_bytes(buf.getvalue())
 
 
+def _add_hidden_reference_sheet(path: Path, marker: str, *, state: str = "hidden") -> None:
+    from triage.xlsx_utils import fix_inlinestr
+
+    wb = openpyxl.load_workbook(str(path))
+    ws = wb.create_sheet("Reference Scratch")
+    ws.sheet_state = state
+    ws["A1"] = "Reference Scratch"
+    ws["B2"] = marker
+    wb.save(str(path))
+    wb.close()
+    fix_inlinestr(str(path))
+
+
 def test_raw_differs_semantic_matches(april_workbook, tmp_path):
     ref_path, neuron_tab = april_workbook
     cand_path = tmp_path / "meta_mutated.xlsx"
@@ -92,6 +106,37 @@ def test_raw_differs_semantic_matches(april_workbook, tmp_path):
     assert report["semantic_sha_match"] is True
     assert report["compare_pass"] is True
     assert "raw_sha256_mismatch" in report["profile_warnings"]
+
+
+def test_hidden_sheet_diff_does_not_poison_visible_semantic_hash(april_workbook, tmp_path):
+    ref_path, neuron_tab = april_workbook
+    ref_with_hidden = tmp_path / "ref_hidden.xlsx"
+    cand_with_hidden = tmp_path / "cand_hidden.xlsx"
+    shutil.copy2(ref_path, ref_with_hidden)
+    shutil.copy2(ref_path, cand_with_hidden)
+
+    _add_hidden_reference_sheet(ref_with_hidden, "alpha")
+    _add_hidden_reference_sheet(cand_with_hidden, "bravo")
+
+    assert semantic_sha256(ref_with_hidden) == semantic_sha256(cand_with_hidden)
+    assert semantic_sha256(ref_with_hidden, include_hidden=True) != semantic_sha256(
+        cand_with_hidden,
+        include_hidden=True,
+    )
+
+    ref_fp = fingerprint_file(ref_with_hidden)
+    cand_fp = fingerprint_file(cand_with_hidden)
+    assert ref_fp.semantic_sha256 == cand_fp.semantic_sha256
+    assert ref_fp.all_sheets_semantic_sha256 != cand_fp.all_sheets_semantic_sha256
+
+    report = compare_artifacts(
+        str(ref_with_hidden), str(cand_with_hidden), "admin_billing_summary",
+        expect_neuron_tab=neuron_tab,
+    )
+    assert report["semantic_sha_match"] is True
+    assert report["all_sheets_semantic_sha_match"] is False
+    assert report["semantic_compare"] == "PASS"
+    assert report["compare_pass"] is True
 
 
 def test_column_corpse_fails_semantic_compare(april_workbook, tmp_path):
@@ -188,6 +233,7 @@ def test_fingerprint_roundtrip_keys(april_workbook):
     fp = fingerprint_file(ref_path)
     d = fp.to_dict()
     assert "raw_sha256" in d and "canonical_package_sha256" in d and "semantic_sha256" in d
+    assert "all_sheets_semantic_sha256" in d
 
 
 def test_load_profiles():

--- a/triage/artifact_compare.py
+++ b/triage/artifact_compare.py
@@ -121,6 +121,9 @@ def compare_artifacts(
     raw_match = ref_fp.raw_sha256 == cand_fp.raw_sha256
     canonical_match = ref_fp.canonical_package_sha256 == cand_fp.canonical_package_sha256
     semantic_match = ref_fp.semantic_sha256 == cand_fp.semantic_sha256
+    all_sheets_semantic_match = (
+        ref_fp.all_sheets_semantic_sha256 == cand_fp.all_sheets_semantic_sha256
+    )
 
     profile_failures = list(cand_checks.failures)
     profile_warnings: list[str] = list(cand_checks.warnings)
@@ -170,6 +173,7 @@ def compare_artifacts(
         "raw_sha_match": raw_match,
         "canonical_package_match": canonical_match,
         "semantic_sha_match": semantic_match,
+        "all_sheets_semantic_sha_match": all_sheets_semantic_match,
         "excel_for_web_manual_check": preflight.get(
             "excel_for_web_manual_check", "NOT_PROVEN"
         ),

--- a/triage/artifact_fingerprint.py
+++ b/triage/artifact_fingerprint.py
@@ -12,15 +12,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+import posixpath
 import re
 import zipfile
 from dataclasses import dataclass, field
 from datetime import date, datetime, time
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
-from triage.xlsx_utils import read_bytes, read_text, sheet_name_map, table_parts
+from triage.xlsx_utils import get_attr, read_bytes, read_text, sheet_name_map, table_parts
 
 _VOLATILE_PARTS = frozenset({
     "docProps/core.xml",
@@ -95,9 +96,62 @@ def _sheet_xml_features(z: zipfile.ZipFile, sheet_part: str) -> Dict[str, Any]:
     }
 
 
-def _table_features(z: zipfile.ZipFile) -> List[Dict[str, str]]:
+def _rels_part_for(source_part: str) -> str:
+    return posixpath.join(
+        posixpath.dirname(source_part),
+        "_rels",
+        posixpath.basename(source_part) + ".rels",
+    )
+
+
+def _resolve_rel_target(source_part: str, target: str) -> str:
+    t = (target or "").strip().replace("\\", "/")
+    while t.startswith("/"):
+        t = t[1:]
+    if t.startswith("xl/"):
+        return t
+    return posixpath.normpath(posixpath.join(posixpath.dirname(source_part), t))
+
+
+def _related_parts(
+    z: zipfile.ZipFile,
+    source_part: str,
+    *,
+    rel_type_tail: str = "",
+    target_prefix: str = "",
+) -> List[str]:
+    try:
+        rels = read_text(z, _rels_part_for(source_part))
+    except KeyError:
+        return []
+
+    found: set[str] = set()
+    for m in re.finditer(r"<Relationship\b[^>]*>", rels):
+        frag = m.group(0)
+        rel_type = get_attr(frag, "Type") or ""
+        target = get_attr(frag, "Target") or ""
+        resolved = _resolve_rel_target(source_part, target)
+        if rel_type_tail and not rel_type.endswith(rel_type_tail):
+            continue
+        if target_prefix and not resolved.startswith(target_prefix):
+            continue
+        found.add(resolved)
+    return sorted(found)
+
+
+def _table_features(z: zipfile.ZipFile, sheet_parts: List[str] | None = None) -> List[Dict[str, str]]:
     out: List[Dict[str, str]] = []
-    for part in table_parts(z):
+    table_part_names = table_parts(z) if sheet_parts is None else sorted({
+        table_part
+        for sheet_part in sheet_parts
+        for table_part in _related_parts(
+            z,
+            sheet_part,
+            rel_type_tail="/table",
+            target_prefix="xl/tables/",
+        )
+    })
+    for part in table_part_names:
         try:
             text = read_text(z, part)
         except KeyError:
@@ -112,27 +166,40 @@ def _table_features(z: zipfile.ZipFile) -> List[Dict[str, str]]:
     return sorted(out, key=lambda x: (x["name"], x["ref"]))
 
 
-def _chart_count(z: zipfile.ZipFile) -> int:
-    return sum(1 for n in z.namelist() if n.startswith("xl/charts/chart") and n.endswith(".xml"))
+def _chart_count(z: zipfile.ZipFile, sheet_parts: List[str] | None = None) -> int:
+    if sheet_parts is None:
+        return sum(1 for n in z.namelist() if n.startswith("xl/charts/chart") and n.endswith(".xml"))
+
+    drawing_parts = {
+        drawing_part
+        for sheet_part in sheet_parts
+        for drawing_part in _related_parts(
+            z,
+            sheet_part,
+            rel_type_tail="/drawing",
+            target_prefix="xl/drawings/",
+        )
+    }
+    chart_parts = {
+        chart_part
+        for drawing_part in drawing_parts
+        for chart_part in _related_parts(
+            z,
+            drawing_part,
+            rel_type_tail="/chart",
+            target_prefix="xl/charts/",
+        )
+    }
+    return len(chart_parts)
 
 
-def _semantic_workbook_model(path: str | Path) -> Dict[str, Any]:
+def _semantic_workbook_model(path: str | Path, *, include_hidden: bool = False) -> Dict[str, Any]:
     """Build canonical semantic document (before hashing).
 
     Omits filesystem path so copies and metadata-only ZIP edits hash identically.
     """
     p = Path(path)
     model: Dict[str, Any] = {"sheets": []}
-
-    with zipfile.ZipFile(p, "r") as z:
-        part_to_name = sheet_name_map(z)
-        sheet_parts_sorted = sorted(
-            part_to_name.items(),
-            key=lambda kv: kv[1],
-        )
-        model["sheet_order"] = [name for _, name in sheet_parts_sorted]
-        model["table_features"] = _table_features(z)
-        model["chart_count"] = _chart_count(z)
 
     try:
         import openpyxl
@@ -142,11 +209,31 @@ def _semantic_workbook_model(path: str | Path) -> Dict[str, Any]:
 
     wb = openpyxl.load_workbook(str(p), data_only=False, read_only=True)
     try:
+        included_sheet_names: List[str] = []
+        for sheet_name in wb.sheetnames:
+            ws = wb[sheet_name]
+            if not include_hidden and getattr(ws, "sheet_state", "visible") in {"hidden", "veryHidden"}:
+                continue
+            included_sheet_names.append(sheet_name)
+        included_name_set = set(included_sheet_names)
+
         sheets_out: List[Dict[str, Any]] = []
         with zipfile.ZipFile(p, "r") as z:
             part_to_name = sheet_name_map(z)
+            sheet_parts_sorted = sorted(
+                (
+                    (part, name)
+                    for part, name in part_to_name.items()
+                    if name in included_name_set
+                ),
+                key=lambda kv: kv[1],
+            )
+            included_sheet_parts = [part for part, _ in sheet_parts_sorted]
+            model["sheet_order"] = [name for _, name in sheet_parts_sorted]
+            model["table_features"] = _table_features(z, included_sheet_parts)
+            model["chart_count"] = _chart_count(z, included_sheet_parts)
             name_to_part = {v: k for k, v in part_to_name.items()}
-            for sheet_name in wb.sheetnames:
+            for sheet_name in included_sheet_names:
                 ws = wb[sheet_name]
                 cells: Dict[str, Any] = {}
                 for row in ws.iter_rows(
@@ -183,16 +270,23 @@ def _semantic_workbook_model(path: str | Path) -> Dict[str, Any]:
     return model
 
 
-def semantic_sha256(path: str | Path) -> str:
-    """Hash canonical semantic workbook JSON."""
-    model = _semantic_workbook_model(path)
+def _semantic_model_sha256(model: Dict[str, Any]) -> str:
     payload = json.dumps(model, sort_keys=True, separators=(",", ":"), default=str)
     return _sha256_bytes(payload.encode("utf-8"))
 
 
-def per_sheet_semantic_detail(path: str | Path) -> Dict[str, Any]:
+def semantic_sha256(path: str | Path, *, include_hidden: bool = False) -> str:
+    """Hash canonical semantic workbook JSON.
+
+    By default only visible worksheets contribute to the semantic hash.
+    Set ``include_hidden=True`` for an explicit all-sheets semantic hash.
+    """
+    return _semantic_model_sha256(_semantic_workbook_model(path, include_hidden=include_hidden))
+
+
+def per_sheet_semantic_detail(path: str | Path, *, include_hidden: bool = False) -> Dict[str, Any]:
     """Per-sheet breakdown for compare reports (not used for pass/fail hash)."""
-    model = _semantic_workbook_model(path)
+    model = _semantic_workbook_model(path, include_hidden=include_hidden)
     sheets: Dict[str, Any] = {}
     for sh in model.get("sheets") or []:
         name = sh.get("name", "")
@@ -214,6 +308,7 @@ class ArtifactFingerprint:
     raw_sha256: str
     canonical_package_sha256: str
     semantic_sha256: str
+    all_sheets_semantic_sha256: str
     sheet_order: List[str] = field(default_factory=list)
     sheets: Dict[str, Any] = field(default_factory=dict)
     chart_count: int = 0
@@ -225,6 +320,7 @@ class ArtifactFingerprint:
             "raw_sha256": self.raw_sha256,
             "canonical_package_sha256": self.canonical_package_sha256,
             "semantic_sha256": self.semantic_sha256,
+            "all_sheets_semantic_sha256": self.all_sheets_semantic_sha256,
             "sheet_order": list(self.sheet_order),
             "chart_count": self.chart_count,
             "table_count": self.table_count,
@@ -235,9 +331,10 @@ class ArtifactFingerprint:
 def fingerprint_file(path: str | Path) -> ArtifactFingerprint:
     """Compute all three fingerprint layers for one workbook."""
     p = Path(path)
-    model = _semantic_workbook_model(p)
-    sem_payload = json.dumps(model, sort_keys=True, separators=(",", ":"), default=str)
-    sem_hash = _sha256_bytes(sem_payload.encode("utf-8"))
+    model = _semantic_workbook_model(p, include_hidden=False)
+    all_sheets_model = _semantic_workbook_model(p, include_hidden=True)
+    sem_hash = _semantic_model_sha256(model)
+    all_sheets_sem_hash = _semantic_model_sha256(all_sheets_model)
     sheets_detail: Dict[str, Any] = {}
     for sh in model.get("sheets") or []:
         name = sh.get("name", "")
@@ -254,6 +351,7 @@ def fingerprint_file(path: str | Path) -> ArtifactFingerprint:
         raw_sha256=raw_sha256(p),
         canonical_package_sha256=canonical_package_sha256(p),
         semantic_sha256=sem_hash,
+        all_sheets_semantic_sha256=all_sheets_sem_hash,
         sheet_order=list(model.get("sheet_order") or []),
         sheets=sheets_detail,
         chart_count=int(model.get("chart_count") or 0),


### PR DESCRIPTION
## **User description**
## Summary
- default artifact semantic hashing now ignores hidden and veryHidden worksheets
- add explicit all-sheets semantic hash for investigations that intentionally include hidden sheets
- expose all-sheets semantic match in artifact comparison reports
- add regression coverage for hidden/reference sheets and update fingerprint/compare docs

## Validation
- python -m pytest tests/test_artifact_compare.py -q -k hidden_sheet
- python -m pytest tests/test_artifact_compare.py -q

## Notes
- Stacked intentionally on PR #35 branch: feat/neuron-track-hours-bonita-generator-2026-06-02
- Does not duplicate fingerprint/compare modules onto origin/main
- Does not merge, rebase, force-push, delete branches, or close PRs


___

## **CodeAnt-AI Description**
**Ignore hidden worksheets in the default workbook comparison hash**

### What Changed
- Hidden and very hidden sheets no longer change the default semantic hash used for artifact comparison
- A separate all-sheet semantic hash is now exposed for cases where hidden/reference sheets should be included
- Comparison reports now show whether the all-sheet hash matches, without affecting the main pass/fail result
- Added coverage for workbooks with hidden reference sheets and updated the fingerprint docs to explain the new behavior

### Impact
`✅ Fewer false mismatches from hidden scratch tabs`
`✅ Clearer artifact comparison for reference sheets`
`✅ Easier investigation when hidden-sheet drift matters`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
