### PR TITLE
feat: One Marcus clean-render generator with Visual column

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -43,6 +43,7 @@ jobs:
             tests/test_nw_prj_neuron_track_hours_bonita.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
+            tests/test_one_marcus_generate.py \
             tests/test_sidecar_html_portal.py \
             tests/test_artifact_compare.py \
             tests/test_roster_log_compare.py \

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ python -m triage.one_marcus_recon.cli generate `
   --output "Outputs/one_marcus_recon/1M_Recon_READY.xlsx"
 ```
 
-**Relink** (OOXML patch — renames the `M-D-YYYY Part Numbers` tab, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`; preserves tables, drawings, styles, and sheet order):
+**Relink** (OOXML patch — renames any dated Part Numbers tab to stable `Part Numbers`, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`; preserves tables, drawings, styles, and sheet order):
 
 ```powershell
 python -m triage.one_marcus_recon.cli relink `

--- a/README.md
+++ b/README.md
@@ -137,16 +137,34 @@ Design configs (distinct roles):
 
 Repo hygiene: `python -m triage.gitignore_hygiene` fails if private binaries are tracked outside sanitized fixture paths.
 
-### 1 Marcus inventory recon (part-number relink)
+### 1 Marcus inventory recon (generate + relink)
 
-Surgically relink the dated Part Numbers tab and produce a Web Excel-safe recon candidate from a private workbook:
+Clean-render a full recon workbook from an integrated source spreadsheet, or surgically relink an existing workbook's dated Part Numbers tab:
 
 - Contract: [`docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md`](docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md)
 - Failure analysis: [`docs/ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md`](docs/ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md)
 - Success checkpoint: [`docs/ONE_MARCUS_RECON_SUCCESS_CHECKPOINT_2026_06_03.md`](docs/ONE_MARCUS_RECON_SUCCESS_CHECKPOINT_2026_06_03.md)
 - Executive protection (later lane): [`docs/ONE_MARCUS_EXECUTIVE_VISUAL_PANEL_PROTECTION.md`](docs/ONE_MARCUS_EXECUTIVE_VISUAL_PANEL_PROTECTION.md)
-- Run: `python -m triage.one_marcus_recon.cli --input "Candidates/inventory recon/<workbook>.xlsx" --date auto --output Outputs/one_marcus_recon_2026_06_01/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx`
-- Patches the OOXML package in place (renames the `M-D-YYYY Part Numbers` tab, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`) instead of reserializing; preserves tables, drawings, styles, and sheet order. Use `--dry-run` to report without writing, `--strict` to fail on ambiguous dates.
+- Artifact profile: [`configs/artifact_profiles/one_marcus_recon.json`](configs/artifact_profiles/one_marcus_recon.json)
+
+**Generate** (default delivery path — builds `Part Numbers` + `1M Recon Pivot Module` with executive `Visual` column):
+
+```powershell
+python -m triage.one_marcus_recon.cli generate `
+  --input "Candidates/inventory recon/1M_Recon_READY.xlsx" `
+  --output "Outputs/one_marcus_recon/1M_Recon_READY.xlsx"
+```
+
+**Relink** (OOXML patch — renames the `M-D-YYYY Part Numbers` tab, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`; preserves tables, drawings, styles, and sheet order):
+
+```powershell
+python -m triage.one_marcus_recon.cli relink `
+  --input "Candidates/inventory recon/<workbook>.xlsx" `
+  --date auto `
+  --output "Outputs/one_marcus_recon/<workbook>_WEBSAFE.xlsx"
+```
+
+Use `--dry-run` to report without writing, `--strict` to fail on ambiguous dates. Generate mode exits non-zero when package preflight or operational checks fail.
 
 ### Lifecycle folder rules (quick reference)
 

--- a/configs/artifact_profiles/one_marcus_recon.json
+++ b/configs/artifact_profiles/one_marcus_recon.json
@@ -1,0 +1,12 @@
+{
+  "name": "one_marcus_recon",
+  "description": "One Marcus inventory recon generator with executive Visual column",
+  "submission_safe": true,
+  "expected_sheets": ["Part Numbers", "1M Recon Pivot Module"],
+  "required_headers_by_sheet": {
+    "1M Recon Pivot Module": ["Inventory Rollup by Item", "Total Qty", "Visual"]
+  },
+  "forbidden_text": ["%20", "web excel-safe", "webexcel-safe"],
+  "compare_totals": false,
+  "fail_on_canonical_mismatch": false
+}

--- a/docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md
+++ b/docs/1MARCUS_RECON_PARTNUMBER_RELINK_CONTRACT.md
@@ -14,11 +14,19 @@ Related issue: #30
 
 The operator updates the 1 Marcus recon workbook and pivots after physical or spreadsheet reconciliation work.
 
-The updated workbook needs a dated consolidated part-number reference tab, usually named like:
+The updated workbook may contain a dated consolidated part-number reference tab from manual iteration, usually named like:
 
 ```text
 5-28-2026 Part Numbers
 ```
+
+Delivery workbooks must use the stable tab name:
+
+```text
+Part Numbers
+```
+
+Put dates in filenames, manifests, and visible pivot titles — not in the Part Numbers sheet tab name.
 
 The operator may remember to rename the workbook and tab title. If they forget, the repo should infer the intended date and repair the mismatch before client delivery.
 
@@ -65,28 +73,24 @@ If the date is not supplied, infer it in this order:
 The generated tab name must use:
 
 ```text
-M-D-YYYY Part Numbers
+Part Numbers
 ```
 
-Example:
-
-```text
-5-28-2026 Part Numbers
-```
+Dated tab names (e.g. `5-28-2026 Part Numbers`) are source-only candidates detected during date inference. Relink and generate modes rename or emit the stable `Part Numbers` tab.
 
 ## Required behavior
 
 ### Tab handling
 
-- Detect existing Part Numbers candidate tabs.
-- Rename the chosen source tab to the target dated tab.
+- Detect existing Part Numbers candidate tabs (dated or undated).
+- Rename the chosen source tab to the stable `Part Numbers` tab.
 - Preserve all unrelated tabs, sheet order, visibility, tab colors, tables, drawings, styles, filters, validation, conditional formatting, print settings, and workbook metadata unless explicitly changed.
 - Never delete old tabs unless a cleanup flag explicitly says to do so.
 
 ### Formula rewiring
 
 - Find formulas referencing older dated Part Numbers tabs.
-- Repoint them to the target dated tab.
+- Repoint them to the stable `Part Numbers` tab.
 - Correctly quote sheet names with spaces and hyphens.
 - Localize formulas that point to stale external workbook references when the target tab exists locally.
 - Report formulas that still reference old dates after rewrite.

--- a/tests/fixtures/one_marcus_recon/fixtures.py
+++ b/tests/fixtures/one_marcus_recon/fixtures.py
@@ -146,3 +146,37 @@ def make_ambiguous(path: str) -> str:
     Path(path).parent.mkdir(parents=True, exist_ok=True)
     Path(path).write_bytes(data)
     return path
+
+
+def make_integrated_source(path: str) -> str:
+    """Integrated workbook with Part Numbers helpers but no executive Visual column."""
+    wb = Workbook()
+    pivot = wb.active
+    pivot.title = "1M Recon Pivot Module"
+    pivot["A1"] = "Placeholder executive tab"
+    pivot["A12"] = "Inventory Rollup by Item"
+    pivot["B12"] = "Total Qty"
+    # Deliberately missing Visual column on input.
+
+    pn = wb.create_sheet("5-28-2026 Part Numbers")
+    pn.append(
+        [
+            "Date Added",
+            "Item Type",
+            "Item Model/Brand",
+            "Part / Model Number",
+            "Category",
+            "Description",
+            "Quantity",
+        ]
+        + [None] * 11
+        + ["PivotPartKey", "QtyNum", None, None, None, None, None, "IncludeFlag"]
+    )
+    pn.append([None, "TypeA", None, "PN-001", None, None, 5] + [None] * 11 + ["Alpha", 5, None, None, None, None, None, "Include"])
+    pn.append([None, "TypeB", None, "PN-002", None, None, 3] + [None] * 11 + ["Beta", 3, None, None, None, None, None, "Include"])
+    pn.append([None, "TypeA", None, "PN-003", None, None, 2] + [None] * 11 + ["Alpha", 2, None, None, None, None, None, "Include"])
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    wb.save(str(out))
+    return str(out)

--- a/tests/test_one_marcus_generate.py
+++ b/tests/test_one_marcus_generate.py
@@ -1,6 +1,7 @@
 """Tests for the One Marcus clean-render generator."""
 from __future__ import annotations
 
+import re
 import zipfile
 from pathlib import Path
 
@@ -8,11 +9,13 @@ import openpyxl
 import pytest
 
 from tests.fixtures.one_marcus_recon import fixtures as fx
+from triage.one_marcus_recon.config import PART_NUMBERS_SHEET
 from triage.one_marcus_recon.exporter import run_generate
 from triage.one_marcus_recon.operational_checks import run_operational_checks
 from triage.one_marcus_recon.style_pass import apply_style_pass
 
 READY_WB = Path("Candidates/inventory recon/1M_Recon_READY.xlsx")
+_DATED_PN_SHEET = re.compile(r"^\d{1,2}-\d{1,2}-\d{4} Part Numbers$")
 
 
 @pytest.fixture
@@ -33,11 +36,13 @@ def test_generate_creates_required_sheets(integrated_source, tmp_path):
     out = tmp_path / "out.xlsx"
     result = run_generate(integrated_source, output_path=str(out))
     assert result.report.mode == "generate"
+    assert result.report.final_part_number_tab == PART_NUMBERS_SHEET
     assert result.report.operational_pass
     with zipfile.ZipFile(out) as z:
         wb = z.read("xl/workbook.xml").decode("utf-8")
-    assert "Part Numbers" in wb
+    assert f'name="{PART_NUMBERS_SHEET}"' in wb or 'name="Part Numbers"' in wb
     assert "1M Recon Pivot Module" in wb
+    assert not re.search(r'\d{1,2}-\d{1,2}-\d{4} Part Numbers', wb)
 
 
 def test_visual_column_after_total_qty(generated_output):
@@ -80,10 +85,25 @@ def test_operational_checks_fail_without_visual(tmp_path, integrated_source):
     assert not ops.operational_pass
 
 
+def test_generate_has_no_dated_part_numbers_tab(generated_output):
+    wb = openpyxl.load_workbook(generated_output, read_only=True)
+    try:
+        assert PART_NUMBERS_SHEET in wb.sheetnames
+        assert not any(_DATED_PN_SHEET.match(n) for n in wb.sheetnames)
+    finally:
+        wb.close()
+
+
 @pytest.mark.skipif(not READY_WB.exists(), reason="private operator reference workbook not present")
 def test_generate_from_operator_reference(tmp_path):
     out = tmp_path / "1M_Recon_READY_generated.xlsx"
     result = run_generate(str(READY_WB), output_path=str(out))
     assert result.report.webexcel_preflight_pass
     assert result.report.operational_pass
+    assert result.report.final_part_number_tab == PART_NUMBERS_SHEET
     assert result.report.rollup_key_count >= 1
+    wb = openpyxl.load_workbook(out, read_only=True)
+    try:
+        assert not any(_DATED_PN_SHEET.match(n) for n in wb.sheetnames)
+    finally:
+        wb.close()

--- a/tests/test_one_marcus_generate.py
+++ b/tests/test_one_marcus_generate.py
@@ -1,0 +1,89 @@
+"""Tests for the One Marcus clean-render generator."""
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from tests.fixtures.one_marcus_recon import fixtures as fx
+from triage.one_marcus_recon.exporter import run_generate
+from triage.one_marcus_recon.operational_checks import run_operational_checks
+from triage.one_marcus_recon.style_pass import apply_style_pass
+
+READY_WB = Path("Candidates/inventory recon/1M_Recon_READY.xlsx")
+
+
+@pytest.fixture
+def integrated_source(tmp_path):
+    return fx.make_integrated_source(str(tmp_path / "integrated_source.xlsx"))
+
+
+@pytest.fixture
+def generated_output(integrated_source, tmp_path):
+    out = tmp_path / "1M_Recon_READY.xlsx"
+    result = run_generate(integrated_source, output_path=str(out))
+    assert result.report.webexcel_preflight_pass
+    assert result.report.operational_pass
+    return str(out)
+
+
+def test_generate_creates_required_sheets(integrated_source, tmp_path):
+    out = tmp_path / "out.xlsx"
+    result = run_generate(integrated_source, output_path=str(out))
+    assert result.report.mode == "generate"
+    assert result.report.operational_pass
+    with zipfile.ZipFile(out) as z:
+        wb = z.read("xl/workbook.xml").decode("utf-8")
+    assert "Part Numbers" in wb
+    assert "1M Recon Pivot Module" in wb
+
+
+def test_visual_column_after_total_qty(generated_output):
+    wb = openpyxl.load_workbook(generated_output, data_only=False, read_only=True)
+    try:
+        pivot = wb["1M Recon Pivot Module"]
+        headers = [pivot.cell(12, c).value for c in range(1, 8)]
+        assert headers[0] == "Inventory Rollup by Item"
+        assert headers[1] == "Total Qty"
+        assert headers[2] == "Visual"
+        formula = pivot.cell(13, 3).value
+        assert isinstance(formula, str) and "REPT" in formula.upper()
+    finally:
+        wb.close()
+
+
+def test_no_forbidden_workbook_text(generated_output):
+    ops = run_operational_checks(generated_output)
+    forbidden = [f for f in ops.failures if "websafe" in f or "%20" in f]
+    assert not forbidden
+
+
+def test_style_pass_preserves_formulas(generated_output, tmp_path):
+    copy = tmp_path / "styled.xlsx"
+    copy.write_bytes(Path(generated_output).read_bytes())
+    before, after = apply_style_pass(str(copy))
+    assert before == after
+
+
+def test_operational_checks_fail_without_visual(tmp_path, integrated_source):
+    out = tmp_path / "bad.xlsx"
+    run_generate(integrated_source, output_path=str(out))
+    wb = openpyxl.load_workbook(out)
+    ws = wb["1M Recon Pivot Module"]
+    ws.cell(12, 3, "NotVisual")
+    ws.cell(13, 3, "")
+    wb.save(out)
+    wb.close()
+    ops = run_operational_checks(str(out))
+    assert not ops.operational_pass
+
+
+@pytest.mark.skipif(not READY_WB.exists(), reason="private operator reference workbook not present")
+def test_generate_from_operator_reference(tmp_path):
+    out = tmp_path / "1M_Recon_READY_generated.xlsx"
+    result = run_generate(str(READY_WB), output_path=str(out))
+    assert result.report.webexcel_preflight_pass
+    assert result.report.operational_pass
+    assert result.report.rollup_key_count >= 1

--- a/tests/test_one_marcus_recon.py
+++ b/tests/test_one_marcus_recon.py
@@ -1,6 +1,7 @@
 """Tests for the 1 Marcus recon part-number relink engine (sanitized fixtures)."""
 from __future__ import annotations
 
+import re
 import zipfile
 from pathlib import Path
 
@@ -10,10 +11,13 @@ from tests.fixtures.one_marcus_recon import fixtures as fx
 from triage.one_marcus_recon import date_inference as di
 from triage.one_marcus_recon import formula_relink as fr
 from triage.one_marcus_recon import preflight as pf
+from triage.one_marcus_recon.config import PART_NUMBERS_SHEET
 from triage.one_marcus_recon.exporter import run_recon
 from triage.one_marcus_recon.package_cleanup import Package
 
-TARGET_TAB = "5-28-2026 Part Numbers"
+STABLE_TAB = PART_NUMBERS_SHEET
+DATED_INFERRED_TAB = "5-28-2026 Part Numbers"
+_DATED_PN_SHEET = re.compile(r"^\d{1,2}-\d{1,2}-\d{4} Part Numbers$")
 REAL_WB = Path(
     "Candidates/inventory recon/"
     "WEBSAFE_Tab-Linked_1_Marcus_Compiled_Recon_Integrated_5-28-2026_PARTNUMBERS_LINKED_CANDIDATE_v2.xlsx"
@@ -34,6 +38,10 @@ def _all_text(path: str) -> str:
     return "".join(blob)
 
 
+def _assert_no_dated_part_numbers_tabs(sheet_names: list[str]) -> None:
+    assert not any(_DATED_PN_SHEET.match(n) for n in sheet_names)
+
+
 @pytest.fixture
 def stale_input(tmp_path):
     src = tmp_path / "1 Marcus Recon Integrated 5-28-2026.xlsx"
@@ -51,23 +59,25 @@ def test_infers_recon_update_date_from_filename(stale_input):
     chosen, _cands, _warn = di.infer_update_date(stale_input, "auto", names)
     assert chosen.date_iso == "2026-05-28"
     assert chosen.source == "filename"
-    assert chosen.tab_label == TARGET_TAB
+    assert chosen.tab_label == DATED_INFERRED_TAB
 
 
-def test_renames_part_number_tab_to_target_date(stale_input, output_path):
+def test_renames_part_number_tab_to_stable_name(stale_input, output_path):
     result = run_recon(stale_input, output_path=output_path, cli_date="auto")
-    assert result.report.renamed_tabs == ["5-07-2026 Part Numbers -> 5-28-2026 Part Numbers"]
+    assert result.report.final_part_number_tab == STABLE_TAB
+    assert result.report.renamed_tabs == [f"5-07-2026 Part Numbers -> {STABLE_TAB}"]
     with zipfile.ZipFile(output_path) as z:
         wb = z.read("xl/workbook.xml").decode("utf-8")
-    assert TARGET_TAB in wb
+    assert f'name="{STABLE_TAB}"' in wb or f"name='{STABLE_TAB}'" in wb
     assert "5-07-2026 Part Numbers" not in wb
+    _assert_no_dated_part_numbers_tabs(fr.workbook_sheet_names(wb))
 
 
 def test_rewrites_formulas_from_old_part_number_tab(stale_input, output_path):
     result = run_recon(stale_input, output_path=output_path, cli_date="auto")
     assert result.report.formula_cells_patched > 0
     text = _all_text(output_path)
-    assert f"'{TARGET_TAB}'!" in text
+    assert f"'{STABLE_TAB}'!" in text
     assert "'5-07-2026 Part Numbers'!" not in text
 
 
@@ -76,7 +86,7 @@ def test_localizes_external_part_number_formulas(stale_input, output_path):
     text = _all_text(output_path)
     # The [1]'...'! external-indexed reference must be localized (prefix dropped).
     assert "[1]'" not in text
-    assert f"'{TARGET_TAB}'!$A$1" in text
+    assert f"'{STABLE_TAB}'!$A$1" in text
 
 
 def test_removes_external_link_parts_after_localization(stale_input, output_path):
@@ -96,7 +106,7 @@ def test_preserves_unrelated_tabs_and_sheet_order(stale_input, output_path):
     before = fr.workbook_sheet_names(Package.from_path(stale_input).text("xl/workbook.xml"))
     run_recon(stale_input, output_path=output_path, cli_date="auto")
     after = fr.workbook_sheet_names(Package.from_path(output_path).text("xl/workbook.xml"))
-    expected = [TARGET_TAB if n == "5-07-2026 Part Numbers" else n for n in before]
+    expected = [STABLE_TAB if n == "5-07-2026 Part Numbers" else n for n in before]
     assert after == expected
     assert "Notes" in after and "README Integration" in after
 
@@ -123,13 +133,13 @@ def test_warns_on_ambiguous_date_candidates(tmp_path):
 
 def test_webexcel_preflight_rejects_stale_refs_and_stopship_tokens(stale_input, output_path):
     # The stale INPUT must fail preflight (calcChain + external links + stale refs).
-    pre_in = pf.run_preflight(stale_input, target_part_number_tab=TARGET_TAB)
+    pre_in = pf.run_preflight(stale_input, target_part_number_tab=STABLE_TAB)
     assert pre_in.preflight_pass is False
     assert pre_in.has_calc_chain and pre_in.external_link_parts
     # The repaired OUTPUT must pass.
     result = run_recon(stale_input, output_path=output_path, cli_date="auto")
     assert result.report.webexcel_preflight_pass is True
-    pre_out = pf.run_preflight(output_path, target_part_number_tab=TARGET_TAB)
+    pre_out = pf.run_preflight(output_path, target_part_number_tab=STABLE_TAB)
     assert pre_out.preflight_pass is True
     assert not pre_out.stale_dated_refs
 
@@ -140,11 +150,13 @@ def test_real_workbook_idempotent_regression(tmp_path):
     before = fr.workbook_sheet_names(Package.from_path(str(REAL_WB)).text("xl/workbook.xml"))
     result = run_recon(str(REAL_WB), output_path=out, cli_date="2026-05-28")
     after = fr.workbook_sheet_names(Package.from_path(out).text("xl/workbook.xml"))
-    # Already-clean workbook: sheet set/order preserved, target tab intact.
-    assert after == before
-    assert TARGET_TAB in after
+    expected = [STABLE_TAB if _DATED_PN_SHEET.match(n) else n for n in before]
+    assert after == expected
+    assert STABLE_TAB in after
+    _assert_no_dated_part_numbers_tabs(after)
     # Tables and drawing survive the surgical patch.
     names = _names(out)
     assert any(n.startswith("xl/tables/table") for n in names)
     assert any(n.startswith("xl/drawings/drawing") for n in names)
     assert result.report.webexcel_preflight_pass is True
+    assert result.report.final_part_number_tab == STABLE_TAB

--- a/triage/one_marcus_recon/cli.py
+++ b/triage/one_marcus_recon/cli.py
@@ -1,7 +1,11 @@
-"""CLI for the 1 Marcus recon part-number relink engine.
+"""CLI for the 1 Marcus recon engine (generate + relink modes).
 
-Example:
-    python -m triage.one_marcus_recon.cli \\
+Examples:
+    python -m triage.one_marcus_recon.cli generate \\
+        --input "Candidates/inventory recon/1M_Recon_READY.xlsx" \\
+        --output "Outputs/one_marcus_recon/1M_Recon_READY.xlsx"
+
+    python -m triage.one_marcus_recon.cli relink \\
         --input "Candidates/inventory recon/...CANDIDATE_v2.xlsx" \\
         --date auto \\
         --output "Outputs/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx"
@@ -14,46 +18,81 @@ import sys
 from pathlib import Path
 
 from .date_inference import AmbiguousDateError
-from .exporter import run_recon
+from .exporter import run_generate, run_recon
+
+
+def _add_shared_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--input", required=True, help="Source integrated recon workbook (.xlsx).")
+    p.add_argument("--date", default="auto", help="Update date (ISO/M-D-YYYY) or 'auto'.")
+    p.add_argument("--output", help="Output .xlsx path. Defaults under Outputs/.")
+    p.add_argument("--part-number-tab", help="Explicit source Part Numbers tab.")
+    p.add_argument("--dry-run", action="store_true", help="Report intended changes; write nothing.")
+    p.add_argument("--strict", action="store_true", help="Fail on ambiguous date candidates.")
+    p.add_argument("--report-json", help="Write the recon report JSON to this path.")
 
 
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="python -m triage.one_marcus_recon.cli",
-        description="Relink the dated Part Numbers tab and produce a Web Excel-safe recon workbook.",
+        description="Generate or relink One Marcus inventory recon workbooks.",
     )
-    p.add_argument("--input", required=True, help="Source recon workbook (.xlsx).")
-    p.add_argument("--date", default="auto", help="Update date (ISO/M-D-YYYY) or 'auto'.")
-    p.add_argument("--output", help="Output .xlsx path. Defaults under Outputs/.")
-    p.add_argument("--part-number-tab", help="Explicit source Part Numbers tab to rename.")
-    p.add_argument("--pivot-tab", help="Pivot/recon module tab name (reporting only).")
-    p.add_argument("--dry-run", action="store_true", help="Report intended changes; write nothing.")
-    p.add_argument("--strict", action="store_true", help="Fail on ambiguous date candidates.")
-    p.add_argument("--report-json", help="Write the recon report JSON to this path.")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    gen = sub.add_parser(
+        "generate",
+        help="Clean-render Part Numbers + executive pivot with Visual column (default path).",
+    )
+    _add_shared_args(gen)
+
+    relink = sub.add_parser(
+        "relink",
+        help="Surgical Part Numbers tab relink on an existing integrated workbook.",
+    )
+    _add_shared_args(relink)
+    relink.add_argument("--pivot-tab", help="Pivot/recon module tab name (reporting only).")
     return p
 
 
-def _default_output(input_path: str) -> str:
+def _default_generate_output(_input_path: str) -> str:
+    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_READY.xlsx")
+
+
+def _default_relink_output(_input_path: str) -> str:
     return str(Path("Outputs") / "1_Marcus_Recon_WEBSAFE.xlsx")
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
-    output = args.output or _default_output(args.input)
 
-    try:
-        result = run_recon(
-            args.input,
-            output_path=output,
-            cli_date=args.date,
-            part_number_tab=args.part_number_tab,
-            pivot_tab=args.pivot_tab,
-            dry_run=args.dry_run,
-            strict=args.strict,
-        )
-    except AmbiguousDateError as exc:
-        print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
-        return 2
+    if args.command == "generate":
+        output = args.output or _default_generate_output(args.input)
+        try:
+            result = run_generate(
+                args.input,
+                output_path=output,
+                cli_date=args.date,
+                part_number_tab=args.part_number_tab,
+                dry_run=args.dry_run,
+                strict=args.strict,
+            )
+        except AmbiguousDateError as exc:
+            print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
+            return 2
+    else:
+        output = args.output or _default_relink_output(args.input)
+        try:
+            result = run_recon(
+                args.input,
+                output_path=output,
+                cli_date=args.date,
+                part_number_tab=args.part_number_tab,
+                pivot_tab=getattr(args, "pivot_tab", None),
+                dry_run=args.dry_run,
+                strict=args.strict,
+            )
+        except AmbiguousDateError as exc:
+            print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
+            return 2
 
     report = result.report.to_dict()
     print(json.dumps(report, indent=2))
@@ -61,6 +100,11 @@ def main(argv=None) -> int:
     if args.report_json:
         Path(args.report_json).parent.mkdir(parents=True, exist_ok=True)
         Path(args.report_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if args.command == "generate":
+        if not result.report.webexcel_preflight_pass or not result.report.operational_pass:
+            return 1
+        return 0
 
     if not result.report.webexcel_preflight_pass:
         return 1

--- a/triage/one_marcus_recon/config.py
+++ b/triage/one_marcus_recon/config.py
@@ -1,0 +1,68 @@
+"""Config loaders and layout constants for the One Marcus recon generator."""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from triage.spreadsheet_style import style_config
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_INVENTORY_VISUAL_PATH = _REPO_ROOT / "configs" / "inventory_visual_aid_chart_v1.json"
+
+EXPECTED_SHEETS: Tuple[str, ...] = ("Part Numbers", "1M Recon Pivot Module")
+PIVOT_SHEET = "1M Recon Pivot Module"
+PART_NUMBERS_SHEET = "Part Numbers"
+
+TECH_COL_START = 1  # A
+TECH_COL_END = 18  # R
+HELPER_COL_START = 19  # S
+HELPER_COL_END = 29  # AC
+
+PN_HEADER_ROW = 1
+PN_DATA_START = 2
+PN_DATA_END = 500
+
+ROLLUP_HEADER_ROW = 12
+ROLLUP_DATA_START = 13
+ROLLUP_DATA_END = 190
+
+# Part Numbers helper column indices (1-based).
+COL_PIVOT_KEY = 19  # S PivotPartKey
+COL_QTY_NUM = 20  # T QtyNum
+COL_INCLUDE = 26  # Z IncludeFlag
+
+FORBIDDEN_WORKBOOK_TEXT = (
+    "%20",
+    "web excel-safe",
+    "webexcel-safe",
+    "websafe",
+    "excel for web safe",
+)
+
+ROLLUP_HEADERS: Tuple[str, ...] = (
+    "Inventory Rollup by Item",
+    "Total Qty",
+    "Visual",
+    "Lines",
+    "Redeployable",
+    "Hold Qty",
+    "Verify Qty",
+    "Cleanup Lines",
+)
+
+
+@lru_cache(maxsize=1)
+def load_inventory_visual_config() -> Dict[str, Any]:
+    with _INVENTORY_VISUAL_PATH.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def visual_font_color() -> str:
+    cfg = load_inventory_visual_config()
+    return str(cfg.get("executive_visual_field", {}).get("font_color", "FF2563EB"))
+
+
+def load_style_config() -> Dict[str, Any]:
+    return style_config()

--- a/triage/one_marcus_recon/exporter.py
+++ b/triage/one_marcus_recon/exporter.py
@@ -15,6 +15,7 @@ from triage.xlsx_utils import fix_inlinestr
 from . import date_inference as di
 from . import formula_relink as fr
 from . import preflight as pf
+from .config import PART_NUMBERS_SHEET
 from .generator import build_workbook, load_snapshot
 from .models import ReconChange, ReconReport
 from .operational_checks import run_operational_checks
@@ -71,7 +72,7 @@ def run_recon(
         {"date": c.date_iso, "source": c.source, "raw": c.raw} for c in candidates
     ]
     report.warnings.extend(warnings)
-    target_label = chosen.tab_label
+    target_label = PART_NUMBERS_SHEET
     report.final_part_number_tab = target_label
 
     # --- pick + rename the source Part Numbers tab ---

--- a/triage/one_marcus_recon/exporter.py
+++ b/triage/one_marcus_recon/exporter.py
@@ -15,13 +15,17 @@ from triage.xlsx_utils import fix_inlinestr
 from . import date_inference as di
 from . import formula_relink as fr
 from . import preflight as pf
+from .generator import build_workbook, load_snapshot
 from .models import ReconChange, ReconReport
+from .operational_checks import run_operational_checks
 from .package_cleanup import (
     Package,
     broken_relationship_targets,
     remove_calc_chain,
     remove_external_links,
 )
+
+from .style_pass import apply_style_pass
 
 _DATED_PN = re.compile(r"^\s*\d{1,2}-\d{1,2}-\d{4}\s+part\s+numbers\s*$", re.IGNORECASE)
 
@@ -50,7 +54,7 @@ def run_recon(
     dry_run: bool = False,
     strict: bool = False,
 ) -> ReconResult:
-    report = ReconReport(input_workbook=str(Path(input_path).resolve()), dry_run=dry_run)
+    report = ReconReport(input_workbook=str(Path(input_path).resolve()), dry_run=dry_run, mode="relink")
 
     pkg = Package.from_path(input_path)
     wb_xml = pkg.text("xl/workbook.xml")
@@ -245,6 +249,180 @@ def run_recon(
         "html_portal": str(portal_path.resolve()),
     }
     return result
+
+
+def run_generate(
+    input_path: str,
+    *,
+    output_path: str,
+    cli_date: str = "auto",
+    part_number_tab: Optional[str] = None,
+    dry_run: bool = False,
+    strict: bool = False,
+) -> ReconResult:
+    """Clean-render a full recon workbook from an integrated source spreadsheet."""
+    report = ReconReport(
+        input_workbook=str(Path(input_path).resolve()),
+        dry_run=dry_run,
+        mode="generate",
+        pivot_tab="1M Recon Pivot Module",
+    )
+    snapshot = load_snapshot(
+        input_path,
+        cli_date=cli_date,
+        part_number_tab=part_number_tab,
+        strict=strict,
+    )
+    report.inferred_update_date = snapshot.inferred_date
+    report.date_source = snapshot.date_source
+    report.final_part_number_tab = "Part Numbers"
+    report.rollup_key_count = len(snapshot.rollup_keys)
+    report.warnings.extend(snapshot.warnings)
+    if not snapshot.rollup_keys:
+        report.warnings.append("no rollup keys found in included Part Numbers rows")
+
+    if dry_run:
+        report.add_change(
+            ReconChange(
+                "generate",
+                f"would render {len(snapshot.rollup_keys)} rollup keys to {output_path}",
+                count=len(snapshot.rollup_keys),
+            )
+        )
+        return ReconResult(report=report)
+
+    build_workbook(snapshot, output_path, source_path=input_path)
+    apply_style_pass(output_path)
+    fix_inlinestr(output_path)
+    report.output_workbook = str(Path(output_path).resolve())
+
+    pre = pf.run_preflight(output_path, target_part_number_tab="Part Numbers")
+    report.webexcel_preflight_pass = pre.preflight_pass
+    report.formula_error_scan = pre.error_value_failures
+    report.remaining_stale_tab_references = pre.stale_dated_refs
+
+    ops = run_operational_checks(output_path)
+    report.operational_pass = ops.operational_pass
+    report.operational_failures = list(ops.failures)
+
+    result = ReconResult(report=report)
+    base = _sidecar_base(output_path)
+    out_dir = base.parent
+    out_dir.mkdir(parents=True, exist_ok=True)
+    pre_path = out_dir / f"{base.name}_preflight.json"
+    manifest_path = out_dir / f"{base.name}_manifest.json"
+    review_path = out_dir / f"{base.name}_review_queue.csv"
+    carry_path = out_dir / f"{base.name}_carryover.md"
+    zip_path = out_dir / f"{base.name}_DELIVERY.zip"
+    ops_path = out_dir / f"{base.name}_operational.json"
+
+    pre_payload = pre.to_dict()
+    pre_payload["operational"] = ops.to_dict()
+    pre_path.write_text(json.dumps(pre_payload, indent=2), encoding="utf-8")
+    ops_path.write_text(json.dumps(ops.to_dict(), indent=2), encoding="utf-8")
+
+    manifest = {
+        "mode": "generate",
+        "input_workbook": report.input_workbook,
+        "output_workbook": report.output_workbook,
+        "inferred_update_date": report.inferred_update_date,
+        "date_source": report.date_source,
+        "final_part_number_tab": report.final_part_number_tab,
+        "pivot_tab": report.pivot_tab,
+        "rollup_key_count": len(snapshot.rollup_keys),
+        "webexcel_preflight_pass": report.webexcel_preflight_pass,
+        "operational_pass": report.operational_pass,
+        "operational_failures": report.operational_failures,
+        "sidecars": {
+            "preflight": str(pre_path.resolve()),
+            "operational": str(ops_path.resolve()),
+            "review_queue": str(review_path.resolve()),
+            "carryover": str(carry_path.resolve()),
+            "delivery_zip": str(zip_path.resolve()),
+        },
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    _write_review_queue_generate(review_path, report, pre, ops)
+    _write_carryover_generate(carry_path, report, pre, ops)
+
+    from triage.sidecar_html.adapters import one_marcus_sections
+    from triage.sidecar_html.portal import build_run_portal
+
+    portal_path = build_run_portal(
+        out_dir,
+        title="1 Marcus Recon — Generate Review",
+        subtitle=report.input_workbook,
+        sections=one_marcus_sections(manifest),
+    )
+    manifest["html_portal"] = str(portal_path)
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.write(output_path, Path(output_path).name)
+        z.write(pre_path, pre_path.name)
+        z.write(ops_path, ops_path.name)
+        z.write(manifest_path, manifest_path.name)
+        z.write(review_path, review_path.name)
+        z.write(carry_path, carry_path.name)
+        z.write(portal_path, portal_path.name)
+
+    result.outputs = {
+        "workbook": str(Path(output_path).resolve()),
+        "preflight": str(pre_path.resolve()),
+        "operational": str(ops_path.resolve()),
+        "manifest": str(manifest_path.resolve()),
+        "review_queue": str(review_path.resolve()),
+        "carryover": str(carry_path.resolve()),
+        "delivery_zip": str(zip_path.resolve()),
+        "html_portal": str(portal_path.resolve()),
+    }
+    return result
+
+
+def _write_review_queue_generate(
+    path: Path,
+    report: ReconReport,
+    pre: pf.ReconPreflight,
+    ops,
+) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.writer(fh)
+        w.writerow(["category", "detail"])
+        for fail in ops.failures:
+            w.writerow(["operational_failure", fail])
+        for err in report.formula_error_scan:
+            w.writerow(["formula_error", err])
+        for tok in pre.token_failures:
+            w.writerow(["stop_ship_token", tok])
+        for warn in report.warnings:
+            w.writerow(["warning", warn])
+
+
+def _write_carryover_generate(
+    path: Path,
+    report: ReconReport,
+    pre: pf.ReconPreflight,
+    ops,
+) -> None:
+    lines = [
+        f"# 1 Marcus Recon Generate — {report.inferred_update_date}",
+        "",
+        f"- Input: `{Path(report.input_workbook).name}`",
+        f"- Output: `{Path(report.output_workbook).name}`",
+        f"- Part Numbers tab: `{report.final_part_number_tab}`",
+        f"- Package preflight: **{report.webexcel_preflight_pass}**",
+        f"- Operational pass: **{report.operational_pass}**",
+        "",
+        "## Operational failures",
+        "",
+    ]
+    if ops.failures:
+        lines.extend(f"- {f}" for f in ops.failures)
+    else:
+        lines.append("- none")
+    lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
 
 
 def _write_review_queue(path: Path, report: ReconReport, pre: pf.ReconPreflight) -> None:

--- a/triage/one_marcus_recon/generator.py
+++ b/triage/one_marcus_recon/generator.py
@@ -10,6 +10,7 @@ from openpyxl.styles import Font
 
 from triage.xlsx_utils import fix_inlinestr
 
+from . import formula_relink as fr
 from .config import (
     PART_NUMBERS_SHEET,
     PN_DATA_END,
@@ -35,8 +36,11 @@ def _copy_part_numbers_sheet(source_path: str, source_tab: str, target_ws, outpu
                 dst = target_ws.cell(r, c, src.value)
                 if src.number_format and src.number_format != "General":
                     dst.number_format = src.number_format
-                if src.data_type == "f" and isinstance(dst.value, str) and source_tab != output_tab:
-                    dst.value = dst.value.replace(f"'{source_tab}'!", f"'{output_tab}'!")
+                if src.data_type == "f" and isinstance(dst.value, str):
+                    new_val, _patched, _loc, _ext = fr._rewrite_refs_in_text(
+                        dst.value, output_tab, source_tab if source_tab != output_tab else None
+                    )
+                    dst.value = new_val
         return max_row
     finally:
         wb.close()

--- a/triage/one_marcus_recon/generator.py
+++ b/triage/one_marcus_recon/generator.py
@@ -1,0 +1,99 @@
+"""Clean-render workbook generator for One Marcus inventory recon."""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import List, Optional
+
+import openpyxl
+from openpyxl.styles import Font
+
+from triage.xlsx_utils import fix_inlinestr
+
+from .config import (
+    PART_NUMBERS_SHEET,
+    PN_DATA_END,
+    PIVOT_SHEET,
+    ROLLUP_DATA_START,
+    ROLLUP_HEADER_ROW,
+    visual_font_color,
+)
+from .reader import PartNumbersSnapshot, read_integrated_workbook
+from .visual_field import write_rollup_table
+
+
+def _copy_part_numbers_sheet(source_path: str, source_tab: str, target_ws, output_tab: str) -> int:
+    """Copy Part Numbers sheet content; rewrite tab refs in formulas. Returns last data row."""
+    wb = openpyxl.load_workbook(source_path, data_only=False)
+    try:
+        ws = wb[source_tab]
+        max_col = max(ws.max_column or 1, 29)
+        max_row = min(ws.max_row or 1, PN_DATA_END)
+        for r in range(1, max_row + 1):
+            for c in range(1, max_col + 1):
+                src = ws.cell(r, c)
+                dst = target_ws.cell(r, c, src.value)
+                if src.number_format and src.number_format != "General":
+                    dst.number_format = src.number_format
+                if src.data_type == "f" and isinstance(dst.value, str) and source_tab != output_tab:
+                    dst.value = dst.value.replace(f"'{source_tab}'!", f"'{output_tab}'!")
+        return max_row
+    finally:
+        wb.close()
+
+
+def _write_pivot_shell(ws, snapshot: PartNumbersSnapshot, pn_last_row: int) -> None:
+    m, d, y = snapshot.inferred_date.split("-")
+    ws["A1"] = f"1M Recon — {int(m)}/{int(d)}/{y}"
+    ws["A2"] = "Executive inventory review. Update source rows on Part Numbers."
+    ws["A3"] = "Visual bars show relative stock quantity in the executive rollup."
+    ws["A10"] = "Leadership view: quantity rollup and operational posture."
+    write_rollup_table(
+        ws,
+        snapshot.rollup_keys,
+        pn_tab=PART_NUMBERS_SHEET,
+        pn_last_row=pn_last_row,
+    )
+    visual_color = visual_font_color()
+    last_row = ROLLUP_DATA_START + max(len(snapshot.rollup_keys), 1) - 1
+    if snapshot.rollup_keys:
+        last_row = ROLLUP_DATA_START + len(snapshot.rollup_keys) - 1
+        for row in range(ROLLUP_DATA_START, last_row + 1):
+            ws.cell(row, 3).font = Font(color=visual_color[2:] if visual_color.startswith("FF") else visual_color)
+
+
+def build_workbook(
+    snapshot: PartNumbersSnapshot,
+    out_path: str,
+    *,
+    source_path: Optional[str] = None,
+) -> str:
+    """Generate a two-sheet recon workbook from a Part Numbers snapshot."""
+    src = source_path or snapshot.source_path
+    out_wb = openpyxl.Workbook()
+    out_wb.remove(out_wb.active)
+    pivot_ws = out_wb.create_sheet(PIVOT_SHEET, 0)
+    pn_ws = out_wb.create_sheet(PART_NUMBERS_SHEET, 1)
+    pn_last_row = _copy_part_numbers_sheet(src, snapshot.source_tab, pn_ws, PART_NUMBERS_SHEET)
+    _write_pivot_shell(pivot_ws, snapshot, pn_last_row)
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out_wb.save(str(out))
+    out_wb.close()
+    fix_inlinestr(str(out))
+    return str(out.resolve())
+
+
+def load_snapshot(
+    input_path: str,
+    *,
+    cli_date: str = "auto",
+    part_number_tab: Optional[str] = None,
+    strict: bool = False,
+) -> PartNumbersSnapshot:
+    return read_integrated_workbook(
+        input_path,
+        cli_date=cli_date,
+        part_number_tab=part_number_tab,
+        strict=strict,
+    )

--- a/triage/one_marcus_recon/models.py
+++ b/triage/one_marcus_recon/models.py
@@ -56,6 +56,10 @@ class ReconReport:
     warnings: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
     dry_run: bool = False
+    mode: str = "relink"  # "relink" | "generate"
+    operational_pass: bool = False
+    operational_failures: List[str] = field(default_factory=list)
+    rollup_key_count: int = 0
 
     def add_change(self, change: ReconChange) -> None:
         self.changes.append(dataclasses.asdict(change))

--- a/triage/one_marcus_recon/operational_checks.py
+++ b/triage/one_marcus_recon/operational_checks.py
@@ -45,6 +45,11 @@ def _scan_forbidden_text(path: str) -> List[str]:
     return hits
 
 
+_DATED_PN_TAB = re.compile(
+    r"^\s*\d{1,2}-\d{1,2}-\d{4}\s+part\s+numbers\s*$", re.IGNORECASE
+)
+
+
 def run_operational_checks(path: str, *, min_visual_rows: int = 1) -> OperationalCheckResult:
     """Validate executive operational surface per success checkpoint + visual config."""
     res = OperationalCheckResult(path=str(Path(path).resolve()))
@@ -64,6 +69,10 @@ def run_operational_checks(path: str, *, min_visual_rows: int = 1) -> Operationa
         for sheet in EXPECTED_SHEETS:
             if sheet not in wb.sheetnames:
                 res.failures.append(f"missing_sheet:{sheet}")
+
+        for name in wb.sheetnames:
+            if _DATED_PN_TAB.match(name):
+                res.failures.append(f"dated_part_numbers_tab:{name}")
 
         if PIVOT_SHEET not in wb.sheetnames or PART_NUMBERS_SHEET not in wb.sheetnames:
             res.operational_pass = False

--- a/triage/one_marcus_recon/operational_checks.py
+++ b/triage/one_marcus_recon/operational_checks.py
@@ -1,0 +1,104 @@
+"""Operational surface checks for generated One Marcus recon workbooks."""
+from __future__ import annotations
+
+import dataclasses
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+import openpyxl
+
+from .config import (
+    EXPECTED_SHEETS,
+    FORBIDDEN_WORKBOOK_TEXT,
+    PART_NUMBERS_SHEET,
+    PIVOT_SHEET,
+    ROLLUP_DATA_START,
+    ROLLUP_HEADER_ROW,
+    load_inventory_visual_config,
+)
+
+
+@dataclass
+class OperationalCheckResult:
+    path: str
+    operational_pass: bool = False
+    failures: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict:
+        return dataclasses.asdict(self)
+
+
+def _scan_forbidden_text(path: str) -> List[str]:
+    hits: List[str] = []
+    with zipfile.ZipFile(path, "r") as z:
+        for name in z.namelist():
+            if not name.endswith(".xml"):
+                continue
+            text = z.read(name).decode("utf-8", errors="ignore").lower()
+            for token in FORBIDDEN_WORKBOOK_TEXT:
+                if token in text:
+                    hits.append(f"{token} in {name}")
+    return hits
+
+
+def run_operational_checks(path: str, *, min_visual_rows: int = 1) -> OperationalCheckResult:
+    """Validate executive operational surface per success checkpoint + visual config."""
+    res = OperationalCheckResult(path=str(Path(path).resolve()))
+    cfg = load_inventory_visual_config()
+    visual_cfg = cfg.get("executive_visual_field", {})
+    expected_visual_header = str(visual_cfg.get("header", "Visual"))
+
+    if not Path(path).is_file():
+        res.failures.append("workbook_missing")
+        return res
+
+    forbidden = _scan_forbidden_text(path)
+    res.failures.extend(forbidden)
+
+    wb = openpyxl.load_workbook(path, data_only=False, read_only=True)
+    try:
+        for sheet in EXPECTED_SHEETS:
+            if sheet not in wb.sheetnames:
+                res.failures.append(f"missing_sheet:{sheet}")
+
+        if PIVOT_SHEET not in wb.sheetnames or PART_NUMBERS_SHEET not in wb.sheetnames:
+            res.operational_pass = False
+            return res
+
+        pivot = wb[PIVOT_SHEET]
+        headers = [pivot.cell(ROLLUP_HEADER_ROW, c).value for c in range(1, 8)]
+        header_text = [str(h or "").strip() for h in headers]
+        if "Total Qty" not in header_text:
+            res.failures.append("missing_header:Total Qty")
+        if expected_visual_header not in header_text:
+            res.failures.append(f"missing_header:{expected_visual_header}")
+            visual_idx = -1
+        else:
+            visual_idx = header_text.index(expected_visual_header)
+            qty_idx = header_text.index("Total Qty") if "Total Qty" in header_text else -1
+            if qty_idx >= 0 and visual_idx != qty_idx + 1:
+                res.failures.append("visual_not_after_total_qty")
+
+        if visual_idx >= 0:
+            visual_rows = 0
+            for row in range(ROLLUP_DATA_START, ROLLUP_DATA_START + 200):
+                key = pivot.cell(row, 1).value
+                if key is None or str(key).strip() == "":
+                    break
+                visual_cell = pivot.cell(row, visual_idx + 1)
+                formula = visual_cell.value
+                if isinstance(formula, str) and "REPT" in formula.upper():
+                    visual_rows += 1
+                elif formula not in (None, ""):
+                    visual_rows += 1
+            if visual_rows < min_visual_rows:
+                res.failures.append(f"visual_rows_below_minimum:{visual_rows}<{min_visual_rows}")
+    finally:
+        wb.close()
+
+    res.operational_pass = not res.failures
+    return res

--- a/triage/one_marcus_recon/reader.py
+++ b/triage/one_marcus_recon/reader.py
@@ -1,0 +1,146 @@
+"""Read Part Numbers data from an integrated recon workbook."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+import openpyxl
+from openpyxl.utils import get_column_letter
+
+from . import date_inference as di
+from . import formula_relink as fr
+from .config import (
+    COL_INCLUDE,
+    COL_PIVOT_KEY,
+    COL_QTY_NUM,
+    PART_NUMBERS_SHEET,
+    PN_DATA_END,
+    PN_DATA_START,
+    PN_HEADER_ROW,
+)
+
+
+@dataclass
+class PartNumbersSnapshot:
+    source_path: str
+    source_tab: str
+    output_tab: str = PART_NUMBERS_SHEET
+    inferred_date: str = ""
+    date_source: str = ""
+    headers: List[Any] = field(default_factory=list)
+    rows: List[Tuple[Any, ...]] = field(default_factory=list)
+    rollup_keys: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+
+def _cell_value(cell) -> Any:
+    val = cell.value
+    if isinstance(val, str):
+        return val.strip()
+    return val
+
+
+def _derive_key(row_values: dict[int, Any]) -> str:
+    for col in (COL_PIVOT_KEY, 4, 6, 2):  # S, D part, F desc, B type
+        val = row_values.get(col)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return ""
+
+
+def _is_included(row_values: dict[int, Any]) -> bool:
+    flag = row_values.get(COL_INCLUDE)
+    if flag is None:
+        return True
+    return str(flag).strip().lower() == "include"
+
+
+def read_integrated_workbook(
+    path: str,
+    *,
+    cli_date: str = "auto",
+    part_number_tab: Optional[str] = None,
+    strict: bool = False,
+) -> PartNumbersSnapshot:
+    """Extract Part Numbers rows and rollup keys from an integrated workbook."""
+    p = Path(path)
+    wb = openpyxl.load_workbook(str(p), data_only=True, read_only=True)
+    try:
+        sheet_names = list(wb.sheetnames)
+        chosen, _candidates, warnings = di.infer_update_date(
+            str(p), cli_date, sheet_names, strict=strict
+        )
+        tab = fr.choose_source_tab(
+            sheet_names,
+            explicit_tab=part_number_tab,
+            chosen_date_iso=chosen.date_iso,
+            target_label=chosen.tab_label,
+        )
+        if not tab:
+            raise ValueError("no Part Numbers candidate tab found in workbook")
+        ws = wb[tab]
+        max_col = max(ws.max_column or 1, 29)
+        headers = [
+            _cell_value(ws.cell(PN_HEADER_ROW, c))
+            for c in range(1, max_col + 1)
+        ]
+        rows: List[Tuple[Any, ...]] = []
+        rollup_keys: List[str] = []
+        seen_keys: set[str] = set()
+        for r in range(PN_DATA_START, min((ws.max_row or PN_DATA_START) + 1, PN_DATA_END + 1)):
+            row_map = {
+                c: _cell_value(ws.cell(r, c))
+                for c in range(1, max_col + 1)
+            }
+            if not any(v not in (None, "") for v in row_map.values()):
+                continue
+            row_tuple = tuple(row_map.get(c) for c in range(1, max_col + 1))
+            rows.append(row_tuple)
+            if _is_included(row_map):
+                key = _derive_key(row_map)
+                if key and key not in seen_keys:
+                    seen_keys.add(key)
+                    rollup_keys.append(key)
+        return PartNumbersSnapshot(
+            source_path=str(p.resolve()),
+            source_tab=tab,
+            inferred_date=chosen.date_iso,
+            date_source=chosen.source,
+            headers=headers,
+            rows=rows,
+            rollup_keys=rollup_keys,
+            warnings=list(warnings),
+        )
+    finally:
+        wb.close()
+
+
+def copy_row_formulas_from_source(
+    source_path: str,
+    source_tab: str,
+    target_ws,
+    *,
+    target_tab_name: str,
+) -> None:
+    """Copy Part Numbers cell values/formulas from source into target worksheet."""
+    wb = openpyxl.load_workbook(source_path, data_only=False, read_only=False)
+    try:
+        ws = wb[source_tab]
+        max_col = max(ws.max_column or 1, 29)
+        max_row = min(ws.max_row or 1, PN_DATA_END)
+        for r in range(1, max_row + 1):
+            for c in range(1, max_col + 1):
+                src = ws.cell(r, c)
+                dst = target_ws.cell(r, c)
+                dst.value = src.value
+                if src.has_style:
+                    dst._style = src._style
+        # Rewrite dated tab references in formulas to stable output tab name.
+        if source_tab != target_tab_name:
+            for row in target_ws.iter_rows(min_row=1, max_row=max_row, min_col=1, max_col=max_col):
+                for cell in row:
+                    if cell.data_type == "f" and isinstance(cell.value, str):
+                        cell.value = cell.value.replace(f"'{source_tab}'!", f"'{target_tab_name}'!")
+    finally:
+        wb.close()

--- a/triage/one_marcus_recon/style_pass.py
+++ b/triage/one_marcus_recon/style_pass.py
@@ -1,0 +1,59 @@
+"""Formula-safe styling pass for generated One Marcus workbooks."""
+from __future__ import annotations
+
+import hashlib
+import json
+import zipfile
+from pathlib import Path
+from typing import Dict, Tuple
+
+import openpyxl
+
+from triage.spreadsheet_style import apply_openpyxl_tab_colors, openpyxl_style_primitives
+
+from .config import PART_NUMBERS_SHEET, PIVOT_SHEET, ROLLUP_HEADER_ROW
+
+
+def _formula_fingerprint(path: str) -> str:
+    """Hash of all formula strings in workbook (stable compare aid)."""
+    wb = openpyxl.load_workbook(path, data_only=False, read_only=True)
+    formulas = []
+    try:
+        for name in wb.sheetnames:
+            ws = wb[name]
+            for row in ws.iter_rows():
+                for cell in row:
+                    if cell.data_type == "f" and cell.value is not None:
+                        formulas.append(f"{name}!{cell.coordinate}={cell.value}")
+    finally:
+        wb.close()
+    payload = json.dumps(sorted(formulas), separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def apply_style_pass(path: str) -> Tuple[str, str]:
+    """Apply tab colors and executive header styling. Returns before/after formula hashes."""
+    before = _formula_fingerprint(path)
+    wb = openpyxl.load_workbook(path)
+    apply_openpyxl_tab_colors(wb)
+    styles = openpyxl_style_primitives()
+    if PIVOT_SHEET in wb.sheetnames:
+        pivot = wb[PIVOT_SHEET]
+        for col in range(1, 9):
+            cell = pivot.cell(ROLLUP_HEADER_ROW, col)
+            cell.fill = styles["table_header_fill"]
+            cell.font = styles["header_font"]
+        pivot["A1"].font = styles["title_font"]
+    if PART_NUMBERS_SHEET in wb.sheetnames:
+        pn = wb[PART_NUMBERS_SHEET]
+        for col in range(1, pn.max_column + 1):
+            cell = pn.cell(1, col)
+            if cell.value:
+                cell.fill = styles["table_header_fill"]
+                cell.font = styles["header_font"]
+    wb.save(path)
+    wb.close()
+    after = _formula_fingerprint(path)
+    if before != after:
+        raise RuntimeError("style pass altered workbook formulas")
+    return before, after

--- a/triage/one_marcus_recon/visual_field.py
+++ b/triage/one_marcus_recon/visual_field.py
@@ -1,0 +1,52 @@
+"""Executive rollup and Visual field formula builders."""
+from __future__ import annotations
+
+from typing import List
+
+from .config import PART_NUMBERS_SHEET, ROLLUP_DATA_START, ROLLUP_HEADER_ROW, ROLLUP_HEADERS
+
+
+def visual_formula(row: int, first_data_row: int, last_data_row: int) -> str:
+    """In-cell REPT bar scaled to the rollup qty column."""
+    return (
+        f'=IF(B{row}>0,REPT("\u2588",MAX(1,ROUND(B{row}/MAX($B${first_data_row}:$B${last_data_row})*18,0))),"")'
+    )
+
+
+def total_qty_formula(row: int, key_cell: str, pn_tab: str, pn_last_row: int) -> str:
+    return (
+        f'=SUMIFS(\'{pn_tab}\'!$T$2:$T${pn_last_row},'
+        f'\'{pn_tab}\'!$Z$2:$Z${pn_last_row},"Include",'
+        f'\'{pn_tab}\'!$S$2:$S${pn_last_row},{key_cell})'
+    )
+
+
+def line_count_formula(row: int, key_cell: str, pn_tab: str, pn_last_row: int) -> str:
+    return (
+        f'=COUNTIFS(\'{pn_tab}\'!$Z$2:$Z${pn_last_row},"Include",'
+        f'\'{pn_tab}\'!$S$2:$S${pn_last_row},{key_cell})'
+    )
+
+
+def write_rollup_table(
+    ws,
+    keys: List[str],
+    *,
+    pn_tab: str = PART_NUMBERS_SHEET,
+    pn_last_row: int = 500,
+) -> int:
+    """Write rollup headers and data rows; return last data row index."""
+    for col, title in enumerate(ROLLUP_HEADERS, start=1):
+        ws.cell(ROLLUP_HEADER_ROW, col, title)
+    if not keys:
+        return ROLLUP_DATA_START - 1
+    first = ROLLUP_DATA_START
+    last = ROLLUP_DATA_START + len(keys) - 1
+    for i, key in enumerate(keys):
+        row = ROLLUP_DATA_START + i
+        ws.cell(row, 1, key)
+        key_ref = f"A{row}"
+        ws.cell(row, 2, total_qty_formula(row, key_ref, pn_tab, pn_last_row))
+        ws.cell(row, 3, visual_formula(row, first, last))
+        ws.cell(row, 4, line_count_formula(row, key_ref, pn_tab, pn_last_row))
+    return last


### PR DESCRIPTION
## **User description**
## Summary
- Adds \generate\ mode to the One Marcus recon engine: reads an integrated workbook, renders stable \Part Numbers\ + \1M Recon Pivot Module\ tabs with executive REPT Visual formulas, applies formula-safe styling and inlineStr fix, and gates on package preflight plus operational checks.
- Keeps existing \elink\ OOXML patch mode as a separate subcommand.
- Adds sanitized fixtures, \	ests/test_one_marcus_generate.py\, CI wiring, artifact profile, and README CLI docs.

## Known gaps / risks
- MVP pivot shell is simplified vs full operator KPI block; no optional Top-N chart or sheet protection yet.
- Operator Excel-for-Web validation still required outside CI.
- Historical \ttached_assets/\ bytes remain in git history (tip is clean).

## Test plan
- [x] \python -m pytest tests/test_one_marcus_recon.py tests/test_one_marcus_generate.py -q\ (17 passed)
- [x] Full artifact engine suite (115 passed, 1 skipped)
- [x] \python -m triage.gitignore_hygiene\`n- [x] Local generate against \Candidates/inventory recon/1M_Recon_READY.xlsx\ (65 rollup keys, preflight + operational pass)

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add a generate mode for One Marcus recon workbooks with an executive Visual column**

### What Changed
- Added a new generate flow that builds a clean two-sheet workbook from an integrated source, including `Part Numbers` and `1M Recon Pivot Module`
- The executive rollup now includes a `Visual` column with bar-style output next to `Total Qty`
- Generate mode runs package checks and operational checks, then fails when the workbook does not meet the required output shape
- The existing relink flow stays available as a separate command for patching an existing workbook
- Added fixture coverage, artifact profile support, and README examples for both workflows

### Impact
`✅ Faster creation of final recon workbooks`
`✅ Fewer missing Visual column issues`
`✅ Clearer workbook validation before delivery`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
