### PR TITLE
fix: One Marcus source immutability and baseline compare gate

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -44,6 +44,7 @@ jobs:
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \
+            tests/test_one_marcus_immutability.py \
             tests/test_sidecar_html_portal.py \
             tests/test_artifact_compare.py \
             tests/test_roster_log_compare.py \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,15 @@ Friday is the reporting batch marker. Work performed Monday through Friday maps 
 - Admin-facing output stays narrow and clean.
 - Internal task-tracker context may be richer, but it must not leak into admin submission artifacts.
 - Backfill into the roster log must be proposed, reviewed, and approved before mutation.
+
+## Operator source immutability
+
+**Candidates/** and **Active/** are read-only operator inputs (backup/emulator files).
+
+- Never write, overwrite, or copy engine output into these paths.
+- Never set `--output` equal to `--input`.
+- All generated workbooks, sidecars, and forensic reports go under **Outputs/**.
+- Overwrites elsewhere require timestamped backup under `Outputs/backups/`.
+- Delivery requires baseline fingerprint compare against the declared source; fail if sheets are deleted.
+
+See [`docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md) for the incident that motivated this rule.

--- a/README.md
+++ b/README.md
@@ -147,22 +147,24 @@ Clean-render a full recon workbook from an integrated source spreadsheet, or sur
 - Executive protection (later lane): [`docs/ONE_MARCUS_EXECUTIVE_VISUAL_PANEL_PROTECTION.md`](docs/ONE_MARCUS_EXECUTIVE_VISUAL_PANEL_PROTECTION.md)
 - Artifact profile: [`configs/artifact_profiles/one_marcus_recon.json`](configs/artifact_profiles/one_marcus_recon.json)
 
-**Generate** (default delivery path — builds `Part Numbers` + `1M Recon Pivot Module` with executive `Visual` column):
+**Generate** (sanitized 2-sheet fixtures only — **not** integrated READY workbooks with multiple tabs):
 
 ```powershell
 python -m triage.one_marcus_recon.cli generate `
-  --input "Candidates/inventory recon/1M_Recon_READY.xlsx" `
-  --output "Outputs/one_marcus_recon/1M_Recon_READY.xlsx"
+  --input "tests/fixtures/.../integrated_source.xlsx" `
+  --output "Outputs/one_marcus_recon/generated.xlsx"
 ```
 
-**Relink** (OOXML patch — renames any dated Part Numbers tab to stable `Part Numbers`, repoints formulas, localizes external refs, drops `calcChain.xml`, strips unused `xl/externalLinks/*`; preserves tables, drawings, styles, and sheet order):
+**Relink** (correct path for operator integrated workbooks — renames dated Part Numbers tab to stable `Part Numbers`, repoints formulas, **preserves all other sheets**):
 
 ```powershell
 python -m triage.one_marcus_recon.cli relink `
-  --input "Candidates/inventory recon/<workbook>.xlsx" `
-  --date auto `
-  --output "Outputs/one_marcus_recon/<workbook>_WEBSAFE.xlsx"
+  --input "Candidates/inventory recon/<baseline>.xlsx" `
+  --output "Outputs/one_marcus_recon/1M_Recon_READY_relink.xlsx" `
+  --date auto
 ```
+
+Do **not** write output into `Candidates/` or overwrite the source file. See [`docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md).
 
 Use `--dry-run` to report without writing, `--strict` to fail on ambiguous dates. Generate mode exits non-zero when package preflight or operational checks fail.
 

--- a/configs/artifact_profiles/one_marcus_recon.json
+++ b/configs/artifact_profiles/one_marcus_recon.json
@@ -8,5 +8,6 @@
   },
   "forbidden_text": ["%20", "web excel-safe", "webexcel-safe"],
   "compare_totals": false,
-  "fail_on_canonical_mismatch": false
+  "fail_on_canonical_mismatch": false,
+  "require_sheet_preservation": true
 }

--- a/docs/ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md
+++ b/docs/ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md
@@ -133,6 +133,12 @@ Excel artifacts fail across multiple layers:
 
 The app should model those layers separately. Passing one layer must not imply the others passed.
 
+### 7. Source overwrite / sheet amputation
+
+An agent copied **generate-mode** output (a new 2-sheet openpyxl workbook) over the operator handoff file in `Candidates/`. The integrated source had **7 sheets**; the generator **deleted 5** and gutted pivot content while still passing narrow package preflight.
+
+**Never write engine output into `Candidates/` or `Active/`.** Never use `generate` on integrated READY workbooks. See [`ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md).
+
 ## Doctrine
 
 Do not call an artifact successful because it is merely valid.

--- a/docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md
+++ b/docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md
@@ -1,0 +1,57 @@
+# One Marcus Source Overwrite Incident — 2026-06-04
+
+## Summary
+
+An agent run **overwrote** the operator handoff workbook in `Candidates/inventory recon/1M_Recon_READY.xlsx` by copying a **generate-mode** output onto the source path. The operator restored the working file manually.
+
+**This must never happen again.**
+
+## Timeline
+
+1. Operator had a working integrated workbook (~7 sheets, ~69 KB) validated in Excel for Web.
+2. Agent ran `generate` mode, which uses **openpyxl** to build a **new 2-sheet workbook** ([`generator.py`](../triage/one_marcus_recon/generator.py)).
+3. Agent ran `Copy-Item` to replace `Candidates/inventory recon/1M_Recon_READY.xlsx` with generator output.
+4. Operator lost the integrated workbook on disk; restored from backup as `Try Again Asshole - 1M_Recon_READY.xlsx`.
+
+## Damage (forensic compare)
+
+| Artifact | Sheets | Size | Notes |
+|----------|--------|------|-------|
+| Working baseline | **7** | 69,298 B | Full integrated READY workbook |
+| Generator output (`Cursor_broke_this_one_…`) | **2** | 56,940 B | 5 sheets **deleted**; pivot gutted (1533 → 272 cells) |
+| Excel-repaired broken file | **2** | 39,024 B | Further degraded |
+
+Package preflight **passed** on the broken 2-sheet stub — gates were too narrow and did not compare against the source baseline.
+
+## Root causes
+
+1. **Wrong engine lane**: `generate` is for sanitized 2-sheet fixtures, not integrated READY workbooks.
+2. **Source path treated as output**: violated read-only `Candidates/` doctrine.
+3. **No backup** before overwrite.
+4. **No fingerprint / sheet-preservation gate** before claiming success.
+
+## Hard rules for agents
+
+1. **`Candidates/` and `Active/` are read-only inputs.** All engine output goes under `Outputs/`.
+2. **Never set `--output` equal to `--input`.** Never `Copy-Item` delivery output into `Candidates/` or `Active/`.
+3. **Integrated multi-sheet workbooks use `relink` (OOXML graft), not `generate`.**
+4. **Before delivery pass**: run baseline compare; **fail if any non-Part-Numbers sheet is deleted**.
+5. **Overwrite requires backup** under `Outputs/backups/backup_<timestamp>/` ([`repo_apply.py`](../triage/repo_apply.py) pattern).
+
+## Recovery path
+
+```powershell
+python -m triage.one_marcus_recon.cli relink `
+  --input "Candidates/inventory recon/Try Again Asshole - 1M_Recon_READY.xlsx" `
+  --output "Outputs/one_marcus_recon/1M_Recon_READY_relink.xlsx" `
+  --date auto
+```
+
+Then compare output vs baseline (expect tab rename drift only, **zero sheet deletions**).
+
+Forensic report: `Outputs/one_marcus_recon/incident_2026-06-04/incident_compare.json`
+
+## Related docs
+
+- [`ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md`](ONE_MARCUS_RECON_FAILURE_ANALYSIS_2026_06_03.md) — failure mode #7
+- [`AGENTS.md`](../AGENTS.md) — operator source immutability section

--- a/tests/fixtures/one_marcus_recon/fixtures.py
+++ b/tests/fixtures/one_marcus_recon/fixtures.py
@@ -158,7 +158,7 @@ def make_integrated_source(path: str) -> str:
     pivot["B12"] = "Total Qty"
     # Deliberately missing Visual column on input.
 
-    pn = wb.create_sheet("5-28-2026 Part Numbers")
+    pn = wb.create_sheet("Part Numbers")
     pn.append(
         [
             "Date Added",

--- a/tests/test_one_marcus_immutability.py
+++ b/tests/test_one_marcus_immutability.py
@@ -1,0 +1,93 @@
+"""Tests for One Marcus source immutability guards."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.fixtures.one_marcus_recon import fixtures as fx
+from triage.one_marcus_recon.baseline_gate import run_baseline_gate
+from triage.one_marcus_recon.exporter import run_generate, run_recon
+from triage.one_marcus_recon.integrated_guard import IntegratedWorkbookError, assert_generate_allowed
+from triage.one_marcus_recon.path_guard import SourcePathWriteForbiddenError, assert_output_path_allowed
+
+
+def test_rejects_output_under_candidates():
+    repo = Path(__file__).resolve().parents[1]
+    inp = str(repo / "Candidates" / "inventory recon" / "in.xlsx")
+    out = str(repo / "Candidates" / "inventory recon" / "out.xlsx")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(inp, out)
+
+
+def test_rejects_output_equals_input(tmp_path):
+    p = tmp_path / "book.xlsx"
+    p.write_bytes(b"x")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(str(p), str(p))
+
+
+def test_generate_refuses_multi_sheet_integrated(tmp_path):
+    src = fx.make_stale_recon(str(tmp_path / "integrated.xlsx"))
+    with pytest.raises(IntegratedWorkbookError):
+        assert_generate_allowed(src)
+
+
+def test_generate_allowed_on_two_sheet_fixture(tmp_path):
+    src = fx.make_integrated_source(str(tmp_path / "mini.xlsx"))
+    names = assert_generate_allowed(src)
+    assert len(names) == 2
+
+
+def test_relink_preserves_sheet_count(stale_input, tmp_path):
+    from triage.one_marcus_recon import formula_relink as fr
+    from triage.one_marcus_recon.package_cleanup import Package
+
+    out = str(tmp_path / "out" / "relink.xlsx")
+    before = fr.workbook_sheet_names(Package.from_path(stale_input).text("xl/workbook.xml"))
+    result = run_recon(stale_input, output_path=out, cli_date="auto")
+    after = fr.workbook_sheet_names(Package.from_path(out).text("xl/workbook.xml"))
+    assert len(after) == len(before)
+    assert result.report.baseline_compare_pass is True
+
+
+def test_baseline_gate_fails_when_sheets_deleted(tmp_path):
+    base = fx.make_stale_recon(str(tmp_path / "base.xlsx"))
+    # Two-sheet stub simulates generator amputation.
+    stub = fx.make_integrated_source(str(tmp_path / "stub.xlsx"))
+    gate = run_baseline_gate(base, stub)
+    assert gate.sheets_deleted
+    assert gate.baseline_compare_pass is False
+
+
+def test_cli_rejects_candidates_output():
+    repo = Path(__file__).resolve().parents[1]
+    inp = str(repo / "Outputs" / "_test_guard_in.xlsx")
+    out = str(repo / "Candidates" / "inventory recon" / "_test_guard_out.xlsx")
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "triage.one_marcus_recon.cli",
+            "relink",
+            "--input",
+            inp,
+            "--output",
+            out,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=str(repo),
+    )
+    assert proc.returncode == 2
+    payload = json.loads(proc.stdout)
+    assert payload["error"] == "source_path_write_forbidden"
+
+
+@pytest.fixture
+def stale_input(tmp_path):
+    src = tmp_path / "1 Marcus Recon Integrated 5-28-2026.xlsx"
+    return fx.make_stale_recon(str(src))

--- a/tests/test_one_marcus_recon.py
+++ b/tests/test_one_marcus_recon.py
@@ -65,6 +65,7 @@ def test_infers_recon_update_date_from_filename(stale_input):
 def test_renames_part_number_tab_to_stable_name(stale_input, output_path):
     result = run_recon(stale_input, output_path=output_path, cli_date="auto")
     assert result.report.final_part_number_tab == STABLE_TAB
+    assert result.report.baseline_compare_pass is True
     assert result.report.renamed_tabs == [f"5-07-2026 Part Numbers -> {STABLE_TAB}"]
     with zipfile.ZipFile(output_path) as z:
         wb = z.read("xl/workbook.xml").decode("utf-8")

--- a/triage/one_marcus_recon/baseline_gate.py
+++ b/triage/one_marcus_recon/baseline_gate.py
@@ -1,0 +1,106 @@
+"""Baseline fingerprint gate — delivery must not delete sheets from the source workbook."""
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List
+
+from triage.artifact_compare import compare_artifacts
+from triage.artifact_fingerprint import fingerprint_file
+
+from .config import PART_NUMBERS_SHEET
+
+_DATED_PN_TAB = re.compile(r"^\d{1,2}-\d{1,2}-\d{4} Part Numbers$")
+
+
+@dataclass
+class BaselineGateResult:
+    baseline_path: str
+    candidate_path: str
+    baseline_compare_pass: bool = False
+    failures: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+    baseline_raw_sha256: str = ""
+    baseline_semantic_sha256: str = ""
+    candidate_raw_sha256: str = ""
+    candidate_semantic_sha256: str = ""
+    sheets_deleted: List[str] = field(default_factory=list)
+    sheet_deltas: List[Dict[str, Any]] = field(default_factory=list)
+    compare_report: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return dataclasses.asdict(self)
+
+
+def run_baseline_gate(
+    baseline_path: str,
+    candidate_path: str,
+    *,
+    profile: str = "one_marcus_recon",
+    require_sheet_preservation: bool = True,
+) -> BaselineGateResult:
+    """Compare candidate delivery against the source baseline; fail on sheet deletion."""
+    res = BaselineGateResult(
+        baseline_path=str(Path(baseline_path).resolve()),
+        candidate_path=str(Path(candidate_path).resolve()),
+    )
+    ref_fp = fingerprint_file(baseline_path)
+    cand_fp = fingerprint_file(candidate_path)
+    res.baseline_raw_sha256 = ref_fp.raw_sha256
+    res.baseline_semantic_sha256 = ref_fp.semantic_sha256
+    res.candidate_raw_sha256 = cand_fp.raw_sha256
+    res.candidate_semantic_sha256 = cand_fp.semantic_sha256
+
+    deleted = []
+    for s in ref_fp.sheet_order:
+        if s in cand_fp.sheet_order:
+            continue
+        if _DATED_PN_TAB.match(s) and PART_NUMBERS_SHEET in cand_fp.sheet_order:
+            continue
+        deleted.append(s)
+    res.sheets_deleted = deleted
+    if require_sheet_preservation and deleted:
+        res.failures.append(f"sheets_deleted:{deleted}")
+
+    if require_sheet_preservation:
+        allowed_floor = len(ref_fp.sheet_order)
+        for s in ref_fp.sheet_order:
+            if _DATED_PN_TAB.match(s) and PART_NUMBERS_SHEET in cand_fp.sheet_order:
+                allowed_floor -= 1
+        if len(cand_fp.sheet_order) < allowed_floor:
+            res.failures.append(
+                f"sheet_count_decreased:{len(ref_fp.sheet_order)}->{len(cand_fp.sheet_order)}"
+            )
+
+    ref_sheets = ref_fp.sheets or {}
+    cand_sheets = cand_fp.sheets or {}
+    for name in ref_fp.sheet_order:
+        rs = ref_sheets.get(name, {})
+        cs = cand_sheets.get(name, {})
+        if name not in cand_sheets:
+            continue
+        if rs.get("cell_value_hash") != cs.get("cell_value_hash"):
+            res.sheet_deltas.append(
+                {
+                    "sheet": name,
+                    "baseline_cells": rs.get("cell_count"),
+                    "candidate_cells": cs.get("cell_count"),
+                }
+            )
+
+    compare = compare_artifacts(baseline_path, candidate_path, profile)
+    res.compare_report = compare
+    for fail in compare.get("profile_failures") or []:
+        if "semantic_sha256_mismatch" in str(fail):
+            res.warnings.append(f"profile:{fail}")
+        elif fail not in res.failures:
+            res.failures.append(f"profile:{fail}")
+    for warn in compare.get("profile_warnings") or []:
+        if warn not in res.warnings:
+            res.warnings.append(warn)
+
+    # Tab rename + formula repoint is expected; sheet deletion is not.
+    res.baseline_compare_pass = not res.failures
+    return res

--- a/triage/one_marcus_recon/cli.py
+++ b/triage/one_marcus_recon/cli.py
@@ -1,14 +1,13 @@
 """CLI for the 1 Marcus recon engine (generate + relink modes).
 
 Examples:
-    python -m triage.one_marcus_recon.cli generate \\
-        --input "Candidates/inventory recon/1M_Recon_READY.xlsx" \\
-        --output "Outputs/one_marcus_recon/1M_Recon_READY.xlsx"
-
     python -m triage.one_marcus_recon.cli relink \\
-        --input "Candidates/inventory recon/...CANDIDATE_v2.xlsx" \\
-        --date auto \\
-        --output "Outputs/1_Marcus_Recon_2026-05-28_WEBSAFE.xlsx"
+        --input "Candidates/inventory recon/Try Again Asshole - 1M_Recon_READY.xlsx" \\
+        --output "Outputs/one_marcus_recon/1M_Recon_READY_relink.xlsx"
+
+    python -m triage.one_marcus_recon.cli generate \\
+        --input "tests/fixtures/.../integrated_source.xlsx" \\
+        --output "Outputs/one_marcus_recon/generated.xlsx"
 """
 from __future__ import annotations
 
@@ -19,6 +18,8 @@ from pathlib import Path
 
 from .date_inference import AmbiguousDateError
 from .exporter import run_generate, run_recon
+from .integrated_guard import IntegratedWorkbookError
+from .path_guard import SourcePathWriteForbiddenError
 
 
 def _add_shared_args(p: argparse.ArgumentParser) -> None:
@@ -40,7 +41,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     gen = sub.add_parser(
         "generate",
-        help="Clean-render Part Numbers + executive pivot with Visual column (default path).",
+        help="Clean-render for sanitized 2-sheet fixtures only (not integrated READY workbooks).",
     )
     _add_shared_args(gen)
 
@@ -54,19 +55,19 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _default_generate_output(_input_path: str) -> str:
-    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_READY.xlsx")
+    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_generated.xlsx")
 
 
 def _default_relink_output(_input_path: str) -> str:
-    return str(Path("Outputs") / "1_Marcus_Recon_WEBSAFE.xlsx")
+    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_relink.xlsx")
 
 
 def main(argv=None) -> int:
     args = build_parser().parse_args(argv)
 
-    if args.command == "generate":
-        output = args.output or _default_generate_output(args.input)
-        try:
+    try:
+        if args.command == "generate":
+            output = args.output or _default_generate_output(args.input)
             result = run_generate(
                 args.input,
                 output_path=output,
@@ -75,12 +76,8 @@ def main(argv=None) -> int:
                 dry_run=args.dry_run,
                 strict=args.strict,
             )
-        except AmbiguousDateError as exc:
-            print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
-            return 2
-    else:
-        output = args.output or _default_relink_output(args.input)
-        try:
+        else:
+            output = args.output or _default_relink_output(args.input)
             result = run_recon(
                 args.input,
                 output_path=output,
@@ -90,9 +87,15 @@ def main(argv=None) -> int:
                 dry_run=args.dry_run,
                 strict=args.strict,
             )
-        except AmbiguousDateError as exc:
-            print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
-            return 2
+    except AmbiguousDateError as exc:
+        print(json.dumps({"error": "ambiguous_date", "detail": str(exc)}, indent=2))
+        return 2
+    except SourcePathWriteForbiddenError as exc:
+        print(json.dumps({"error": "source_path_write_forbidden", "detail": str(exc)}, indent=2))
+        return 2
+    except IntegratedWorkbookError as exc:
+        print(json.dumps({"error": "integrated_workbook_use_relink_not_generate", "detail": str(exc)}, indent=2))
+        return 2
 
     report = result.report.to_dict()
     print(json.dumps(report, indent=2))
@@ -102,11 +105,15 @@ def main(argv=None) -> int:
         Path(args.report_json).write_text(json.dumps(report, indent=2), encoding="utf-8")
 
     if args.command == "generate":
-        if not result.report.webexcel_preflight_pass or not result.report.operational_pass:
+        if (
+            not result.report.webexcel_preflight_pass
+            or not result.report.operational_pass
+            or not result.report.baseline_compare_pass
+        ):
             return 1
         return 0
 
-    if not result.report.webexcel_preflight_pass:
+    if not result.report.webexcel_preflight_pass or not result.report.baseline_compare_pass:
         return 1
     return 0
 

--- a/triage/one_marcus_recon/exporter.py
+++ b/triage/one_marcus_recon/exporter.py
@@ -16,9 +16,12 @@ from . import date_inference as di
 from . import formula_relink as fr
 from . import preflight as pf
 from .config import PART_NUMBERS_SHEET
+from .baseline_gate import run_baseline_gate
 from .generator import build_workbook, load_snapshot
+from .integrated_guard import assert_generate_allowed
 from .models import ReconChange, ReconReport
 from .operational_checks import run_operational_checks
+from .path_guard import assert_output_path_allowed
 from .package_cleanup import (
     Package,
     broken_relationship_targets,
@@ -45,6 +48,17 @@ def _sidecar_base(output_path: str) -> Path:
     return out.with_name(stem)
 
 
+def _apply_baseline_gate(report: ReconReport, input_path: str, output_path: str):
+    gate = run_baseline_gate(input_path, output_path)
+    report.baseline_compare_pass = gate.baseline_compare_pass
+    report.baseline_compare_failures = list(gate.failures)
+    report.baseline_raw_sha256 = gate.baseline_raw_sha256
+    report.baseline_semantic_sha256 = gate.baseline_semantic_sha256
+    if not gate.baseline_compare_pass:
+        report.warnings.extend(gate.failures)
+    return gate
+
+
 def run_recon(
     input_path: str,
     *,
@@ -55,6 +69,7 @@ def run_recon(
     dry_run: bool = False,
     strict: bool = False,
 ) -> ReconResult:
+    assert_output_path_allowed(input_path, output_path)
     report = ReconReport(input_workbook=str(Path(input_path).resolve()), dry_run=dry_run, mode="relink")
 
     pkg = Package.from_path(input_path)
@@ -180,6 +195,8 @@ def run_recon(
         set(report.remaining_external_links) | set(pre.external_link_parts)
     )
 
+    _apply_baseline_gate(report, input_path, scan_path)
+
     result = ReconResult(report=report)
     if dry_run:
         if cleanup_tmp:
@@ -208,6 +225,10 @@ def run_recon(
         "external_link_parts_removed": report.external_link_parts_removed,
         "calc_chain_removed": report.calc_chain_removed,
         "webexcel_preflight_pass": report.webexcel_preflight_pass,
+        "baseline_compare_pass": report.baseline_compare_pass,
+        "baseline_compare_failures": report.baseline_compare_failures,
+        "baseline_raw_sha256": report.baseline_raw_sha256,
+        "baseline_semantic_sha256": report.baseline_semantic_sha256,
         "sidecars": {
             "preflight": str(pre_path.resolve()),
             "review_queue": str(review_path.resolve()),
@@ -262,6 +283,8 @@ def run_generate(
     strict: bool = False,
 ) -> ReconResult:
     """Clean-render a full recon workbook from an integrated source spreadsheet."""
+    assert_output_path_allowed(input_path, output_path)
+    assert_generate_allowed(input_path)
     report = ReconReport(
         input_workbook=str(Path(input_path).resolve()),
         dry_run=dry_run,
@@ -306,6 +329,8 @@ def run_generate(
     report.operational_pass = ops.operational_pass
     report.operational_failures = list(ops.failures)
 
+    _apply_baseline_gate(report, input_path, output_path)
+
     result = ReconResult(report=report)
     base = _sidecar_base(output_path)
     out_dir = base.parent
@@ -334,6 +359,10 @@ def run_generate(
         "webexcel_preflight_pass": report.webexcel_preflight_pass,
         "operational_pass": report.operational_pass,
         "operational_failures": report.operational_failures,
+        "baseline_compare_pass": report.baseline_compare_pass,
+        "baseline_compare_failures": report.baseline_compare_failures,
+        "baseline_raw_sha256": report.baseline_raw_sha256,
+        "baseline_semantic_sha256": report.baseline_semantic_sha256,
         "sidecars": {
             "preflight": str(pre_path.resolve()),
             "operational": str(ops_path.resolve()),

--- a/triage/one_marcus_recon/incident_compare.py
+++ b/triage/one_marcus_recon/incident_compare.py
@@ -1,0 +1,139 @@
+"""Forensic compare helper for One Marcus workbook incidents."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from triage.artifact_compare import compare_artifacts
+from triage.artifact_fingerprint import fingerprint_file
+from triage.diff import diff_packages
+
+
+def build_incident_report(
+    *,
+    working: str,
+    cursor_broke: Optional[str] = None,
+    excel_repaired: Optional[str] = None,
+    profile: str = "one_marcus_recon",
+) -> Dict:
+    """Fingerprint and compare operator incident workbooks."""
+    report: Dict = {
+        "working": _file_summary(working),
+        "comparisons": [],
+        "zip_diffs": [],
+    }
+    for label, path in (
+        ("cursor_broke", cursor_broke),
+        ("excel_repaired", excel_repaired),
+    ):
+        if not path or not Path(path).is_file():
+            continue
+        report[label] = _file_summary(path)
+        report["comparisons"].append(
+            {
+                "label": f"working_vs_{label}",
+                "compare": compare_artifacts(working, path, profile),
+            }
+        )
+        diff = diff_packages(working, path)
+        report["zip_diffs"].append(
+            {
+                "label": f"working_vs_{label}",
+                **diff.to_dict(),
+            }
+        )
+    return report
+
+
+def _file_summary(path: str) -> Dict:
+    fp = fingerprint_file(path)
+    return {
+        "path": str(Path(path).resolve()),
+        "size_bytes": Path(path).stat().st_size,
+        "raw_sha256": fp.raw_sha256,
+        "canonical_package_sha256": fp.canonical_package_sha256,
+        "semantic_sha256": fp.semantic_sha256,
+        "sheet_order": fp.sheet_order,
+        "sheets": fp.sheets,
+        "table_count": fp.table_count,
+        "chart_count": fp.chart_count,
+    }
+
+
+def write_incident_report(out_dir: str, report: Dict) -> Dict[str, str]:
+    """Write JSON + markdown carryover for an incident folder."""
+    root = Path(out_dir)
+    root.mkdir(parents=True, exist_ok=True)
+    json_path = root / "incident_compare.json"
+    md_path = root / "incident_carryover.md"
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    md_path.write_text(_markdown_carryover(report), encoding="utf-8")
+    return {"json": str(json_path.resolve()), "markdown": str(md_path.resolve())}
+
+
+def _markdown_carryover(report: Dict) -> str:
+    lines = [
+        "# One Marcus incident compare",
+        "",
+        "## Working baseline",
+        "",
+    ]
+    w = report.get("working") or {}
+    lines.append(f"- Path: `{w.get('path', '')}`")
+    lines.append(f"- Size: {w.get('size_bytes', 0)} bytes")
+    lines.append(f"- Sheets ({len(w.get('sheet_order') or [])}): {', '.join(w.get('sheet_order') or [])}")
+    lines.append(f"- Semantic SHA: `{w.get('semantic_sha256', '')}`")
+    lines.append("")
+    for comp in report.get("comparisons") or []:
+        label = comp.get("label", "")
+        c = comp.get("compare") or {}
+        lines.extend(
+            [
+                f"## {label}",
+                "",
+                f"- compare_pass: **{c.get('compare_pass')}**",
+                f"- semantic_sha_match: {c.get('semantic_sha_match')}",
+                f"- profile_failures: {c.get('profile_failures')}",
+                "",
+            ]
+        )
+        ref = (c.get("fingerprints") or {}).get("reference", {}).get("sheets") or {}
+        cand = (c.get("fingerprints") or {}).get("candidate", {}).get("sheets") or {}
+        for name in sorted(set(ref) | set(cand)):
+            if name not in cand:
+                lines.append(f"- sheet deleted: **{name}** (baseline cells: {ref.get(name, {}).get('cell_count')})")
+            elif ref.get(name, {}).get("cell_value_hash") != cand.get(name, {}).get("cell_value_hash"):
+                lines.append(
+                    f"- sheet delta: **{name}** "
+                    f"({ref.get(name, {}).get('cell_count')} -> {cand.get(name, {}).get('cell_count')} cells)"
+                )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Forensic compare for One Marcus workbook incident.")
+    ap.add_argument("--working", required=True, help="Restored working baseline workbook.")
+    ap.add_argument("--cursor-broke", help="Broken generator output.")
+    ap.add_argument("--excel-repaired", help="Excel-repaired broken output.")
+    ap.add_argument(
+        "--out-dir",
+        default="Outputs/one_marcus_recon/incident_2026-06-04",
+        help="Output folder for incident_compare.json and carryover.",
+    )
+    args = ap.parse_args(argv)
+    report = build_incident_report(
+        working=args.working,
+        cursor_broke=args.cursor_broke,
+        excel_repaired=args.excel_repaired,
+    )
+    paths = write_incident_report(args.out_dir, report)
+    print(json.dumps({"written": paths, "working_sheets": report["working"]["sheet_order"]}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/triage/one_marcus_recon/integrated_guard.py
+++ b/triage/one_marcus_recon/integrated_guard.py
@@ -1,0 +1,36 @@
+"""Detect integrated multi-sheet workbooks unsuitable for clean-render generate mode."""
+from __future__ import annotations
+
+from typing import List, Tuple
+
+import openpyxl
+
+from .config import EXPECTED_SHEETS
+
+
+class IntegratedWorkbookError(ValueError):
+    """Raised when generate mode is invoked on a full integrated workbook."""
+
+
+def inspect_workbook_sheets(path: str) -> List[str]:
+    wb = openpyxl.load_workbook(path, read_only=True)
+    try:
+        return list(wb.sheetnames)
+    finally:
+        wb.close()
+
+
+def assert_generate_allowed(input_path: str) -> List[str]:
+    """Refuse generate on integrated workbooks; return sheet names when allowed."""
+    names = inspect_workbook_sheets(input_path)
+    if len(names) > len(EXPECTED_SHEETS):
+        raise IntegratedWorkbookError(
+            f"integrated workbook has {len(names)} sheets; "
+            f"use relink mode to preserve sheets (generate destroys non-target tabs)"
+        )
+    extra = [n for n in names if n not in EXPECTED_SHEETS]
+    if extra:
+        raise IntegratedWorkbookError(
+            f"unexpected sheets {extra}; use relink mode for integrated workbooks"
+        )
+    return names

--- a/triage/one_marcus_recon/models.py
+++ b/triage/one_marcus_recon/models.py
@@ -60,6 +60,10 @@ class ReconReport:
     operational_pass: bool = False
     operational_failures: List[str] = field(default_factory=list)
     rollup_key_count: int = 0
+    baseline_compare_pass: bool = False
+    baseline_compare_failures: List[str] = field(default_factory=list)
+    baseline_raw_sha256: str = ""
+    baseline_semantic_sha256: str = ""
 
     def add_change(self, change: ReconChange) -> None:
         self.changes.append(dataclasses.asdict(change))

--- a/triage/one_marcus_recon/path_guard.py
+++ b/triage/one_marcus_recon/path_guard.py
@@ -1,0 +1,33 @@
+"""Output path guards — operator source folders are read-only inputs."""
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_READONLY_ROOTS = ("Candidates", "Active")
+
+
+class SourcePathWriteForbiddenError(ValueError):
+    """Raised when engine output would overwrite or write into read-only input zones."""
+
+
+def assert_output_path_allowed(input_path: str, output_path: str) -> None:
+    """Fail closed if output equals input or targets Candidates/ or Active/."""
+    inp = Path(input_path).resolve()
+    out = Path(output_path).resolve()
+
+    if inp == out:
+        raise SourcePathWriteForbiddenError(
+            "output path must not equal input path; write delivery artifacts under Outputs/"
+        )
+
+    try:
+        rel = out.relative_to(_REPO_ROOT.resolve())
+    except ValueError:
+        return
+
+    if rel.parts and rel.parts[0] in _READONLY_ROOTS:
+        raise SourcePathWriteForbiddenError(
+            f"output path must not be under {rel.parts[0]}/; "
+            "Candidates/ and Active/ are read-only operator inputs"
+        )


### PR DESCRIPTION
## **User description**
## Summary
- Documents the Candidates/1M_Recon_READY overwrite incident and adds AGENTS.md immutability rules (Candidates/Active are read-only; output only under Outputs/).
- Blocks CLI/exporter writes to Candidates/Active/ and input==output paths.
- Refuses generate mode on integrated multi-sheet workbooks; relink is the correct lane for operator READY files.
- Adds baseline fingerprint gate that fails delivery when sheets are deleted (allows dated Part Numbers -> Part Numbers rename only).
- Adds incident_compare tooling and forensic report under Outputs/one_marcus_recon/incident_2026-06-04/.

## Recovery verified locally
- Relink from \Try Again Asshole - 1M_Recon_READY.xlsx\ -> \Outputs/one_marcus_recon/1M_Recon_READY_relink.xlsx\
- baseline_compare_pass: true, all 6 sheets preserved, tab renamed to Part Numbers
- Candidates source file **not modified**

## Test plan
- [x] \python -m pytest tests/test_one_marcus_recon.py tests/test_one_marcus_generate.py tests/test_one_marcus_immutability.py -q\ (24 passed, 1 skipped)
- [x] Full artifact engine suite (122 passed, 2 skipped)
- [x] \python -m triage.gitignore_hygiene\
- [x] incident_compare report generated


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Prevent One Marcus workbook overwrites and block unsafe generate runs**

### What Changed
- The tool now refuses to write output into `Candidates/` or `Active/`, and it also blocks using the same file as both input and output.
- Generate mode now stops when used on a full integrated workbook; those files must use relink mode so the extra sheets stay intact.
- Delivery now checks the result against the original workbook and fails if sheets were deleted, while allowing the expected `Part Numbers` tab rename.
- Added incident compare output plus updated docs and workflow coverage for the new immutability and preservation rules.

### Impact
`✅ Fewer source workbook overwrites`
`✅ Fewer lost sheets in delivered workbooks`
`✅ Safer handling of integrated READY files`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
