### PR TITLE
feat: repo-wide emulator immutability and Outputs run layout

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.output_policy; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
@@ -44,6 +44,7 @@ jobs:
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \
+            tests/test_output_policy.py \
             tests/test_one_marcus_immutability.py \
             tests/test_sidecar_html_portal.py \
             tests/test_artifact_compare.py \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,14 +77,16 @@ Friday is the reporting batch marker. Work performed Monday through Friday maps 
 - Internal task-tracker context may be richer, but it must not leak into admin submission artifacts.
 - Backfill into the roster log must be proposed, reviewed, and approved before mutation.
 
-## Operator source immutability
+## Operator source immutability (repo-wide)
 
-**Candidates/** and **Active/** are read-only operator inputs (backup/emulator files).
+Emulator roots (`Candidates/`, `Active/`, `ArtifactIntake/`, `References/`, and related
+read-only folders) are **inputs only**. All artifact engines write under
+`Outputs/<engine>/<YYYY-MM-DD>_<run>/` or `artifacts/` via [`triage/output_policy.py`](triage/output_policy.py).
 
-- Never write, overwrite, or copy engine output into these paths.
-- Never set `--output` equal to `--input`.
-- All generated workbooks, sidecars, and forensic reports go under **Outputs/**.
-- Overwrites elsewhere require timestamped backup under `Outputs/backups/`.
-- Delivery requires baseline fingerprint compare against the declared source; fail if sheets are deleted.
+- Never write engine output into emulator paths; never set `--output` equal to `--input`.
+- Record `source_emulator_path` + `source_raw_sha256` in run manifests.
+- Delivery requires baseline fingerprint compare; fail if sheets are deleted.
+- Overwrites outside Outputs require timestamped backup under `Outputs/backups/`.
 
-See [`docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md) for the incident that motivated this rule.
+Canonical doctrine: [`docs/OPERATOR_SOURCE_IMMUTABILITY.md`](docs/OPERATOR_SOURCE_IMMUTABILITY.md).
+Incident case study: [`docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](docs/ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md).

--- a/ArtifactIntake/2026-06-02/README.md
+++ b/ArtifactIntake/2026-06-02/README.md
@@ -4,6 +4,11 @@ Use this dated folder for the 2026-06-02 billing/admin comparison cycle.
 
 Real workbooks stay local. Do not commit private artifacts.
 
+**Emulator rule:** folders under `admin/`, `internal/`, and sibling raw trees are
+read-only inputs for engines. Generators write only under `Outputs/` or
+`artifacts/` (or manually promote into `outputs/admin-ready/` after review). See
+[`docs/OPERATOR_SOURCE_IMMUTABILITY.md`](../../docs/OPERATOR_SOURCE_IMMUTABILITY.md).
+
 ## Put files here
 
 ```text

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Scope-filtered sprint target workbook from All-Wave upstream + live sprint dashb
 Generate `Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx` locally from the private roster log:
 
 - Docs: [`docs/NW_PRJ_NEURON_TRACK_HOURS_CONTRACT.md`](docs/NW_PRJ_NEURON_TRACK_HOURS_CONTRACT.md)
-- Run: `python -m triage.nw_prj_neuron_track_hours.cli --roster-log "<roster>.xlsx" --out-dir Outputs/nw_prj_neuron_track_hours_2026_06_01 --months 2026-04 2026-05 --websafe --zip`
+- Run: `python -m triage.nw_prj_neuron_track_hours.cli --roster-log "<roster>.xlsx" --months 2026-04 2026-05 --websafe --zip` (default: `Outputs/nw_prj_neuron_track_hours/<YYYY-MM-DD>_track_hours/`)
 - Neuron scope uses Worked-Project per-date classification (not default team membership); totals: April 1048.19, May 697.83, total 1746.02, Go Live weekend 2 rows / 22h.
 
 #### Bonita submission workbook (clean two-tab)
@@ -94,7 +94,7 @@ Generate `Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx` locally from the priva
 Generate the admin-facing Bonita submission workbook from the same package:
 
 - Docs: [`docs/BONITA_NEURON_TRACK_HOURS_CONTRACT.md`](docs/BONITA_NEURON_TRACK_HOURS_CONTRACT.md)
-- Run: `python -m triage.nw_prj_neuron_track_hours.bonita_cli --roster-log "<roster>.xlsx" --months 2026-04 2026-05 --out-dir Outputs/neuron_track_hours_2026_06_02 --websafe`
+- Run: `python -m triage.nw_prj_neuron_track_hours.bonita_cli --roster-log "<roster>.xlsx" --months 2026-04 2026-05 --websafe` (default: `Outputs/nw_prj_neuron_track_hours/<YYYY-MM-DD>_bonita/`)
 - Output: exactly two tabs (`Apr 26` / `May 26`), two-line headers, one values-only row per Neuron shift; off-project (`/ Bonita`), non-work markers, excluded names and long shifts go to a gitignored review-queue sidecar. `PROJECT NAME` is the `Neuron Deployments → Northwell - Neurons` display alias; `ASSIGNMENT TYPE` defaults to `Neuron Installation`.
 
 ### Admin Billing Summary (My Preferred Format)
@@ -102,7 +102,7 @@ Generate the admin-facing Bonita submission workbook from the same package:
 Generate the monthly admin billing summary in the April "My Preferred Format" (with charts) for any month, with an embedded Neuron Track Hours tracker tab:
 
 - Docs: [`docs/ADMIN_BILLING_SUMMARY_PREFERRED_FORMAT_CONTRACT.md`](docs/ADMIN_BILLING_SUMMARY_PREFERRED_FORMAT_CONTRACT.md) and roster mechanics in [`docs/ACTIVE_ROSTER_LOG_MECHANICS.md`](docs/ACTIVE_ROSTER_LOG_MECHANICS.md)
-- Run: `python -m triage.admin_billing_summary.cli --roster-log "<roster>.xlsx" --months 2026-04 2026-05 --out-dir Outputs/admin_billing_summary_2026_06_02 --prior "<April preferred-format copy>.xlsx" --websafe`
+- Run: `python -m triage.admin_billing_summary.cli --roster-log "<roster>.xlsx" --months 2026-04 2026-05 --prior "<April preferred-format copy>.xlsx" --websafe` (default: `Outputs/admin_billing_summary/<YYYY-MM-DD>_run/`). Source immutability: [`docs/OPERATOR_SOURCE_IMMUTABILITY.md`](docs/OPERATOR_SOURCE_IMMUTABILITY.md).
 
 ### Same-family compare and roster log compare (internal)
 
@@ -124,6 +124,7 @@ Generated workbooks pass through distinct gates. Do not treat one gate as proof 
 | **Presentation quality** | Calm styling and hierarchy match design configs without rewriting logic. |
 | **Web Excel acceptance** | Opens in Excel for Web without repair banner or silent corruption. |
 | **Operator acceptance** | Human validated in the real target environment — **field judge**. |
+| **Source preservation** | Emulator input SHA unchanged at run time; sheet count non-decreasing for graft/relink lanes. |
 
 **Valid** means the workbook opens. **Correct** means the requested operational surface exists and behaves. **Accepted** means the operator validated it in Excel for Web (or the stated target).
 
@@ -176,7 +177,8 @@ This repo uses lifecycle folders so the engine can keep artifacts organized:
 - `Deprecated/` — **work area**. Iteration/repair/experiments happen here.
 - `Candidates/` — inputs you want to triage (often uploaded as the Candidate).
 - `Repaired/` — “repaired by Excel” variants (web-exported or desktop SaveCopyAs).
-- `Outputs/` — all generated artifacts (reports, recipes, patched workbooks, probe runs, backups).
+- `Outputs/<engine>/<YYYY-MM-DD>_<run>/` — artifact engine runs (delivery, sidecars, compare). See [`docs/OPERATOR_SOURCE_IMMUTABILITY.md`](docs/OPERATOR_SOURCE_IMMUTABILITY.md).
+- `Outputs/` — also reports, recipes, patched workbooks, probe runs, backups.
 
 Tiny lifecycle flow:
 

--- a/configs/artifact_profiles/README.md
+++ b/configs/artifact_profiles/README.md
@@ -3,6 +3,11 @@
 Committed JSON profiles drive stop-ship checks and approved-reference comparison.
 Private blessed workbooks live under `References/approved/` (gitignored).
 
+`one_marcus_recon.json` sets `require_sheet_preservation` — baseline compare must not
+delete sheets vs the emulator. Other engines may adopt the same flag when integrated
+multi-tab sources need relink-not-regenerate protection. See
+[`docs/OPERATOR_SOURCE_IMMUTABILITY.md`](../../docs/OPERATOR_SOURCE_IMMUTABILITY.md).
+
 ## Approved delta file
 
 When a semantic change is intentional, provide a sidecar JSON:

--- a/docs/OPERATOR_SOURCE_IMMUTABILITY.md
+++ b/docs/OPERATOR_SOURCE_IMMUTABILITY.md
@@ -1,0 +1,89 @@
+# Operator source immutability (repo-wide doctrine)
+
+Canonical rules for every artifact engine in this repository. Supersedes
+lane-specific notes; the One Marcus incident doc remains the concrete case study.
+
+Related:
+
+- [`ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md`](ONE_MARCUS_SOURCE_OVERWRITE_INCIDENT_2026_06_04.md)
+- [`triage/output_policy.py`](../triage/output_policy.py)
+- [`AGENTS.md`](../AGENTS.md) (agent contract pointer)
+
+## Emulator folders (read-only)
+
+Engines **read** from these roots and **never write** into them:
+
+| Root | Role |
+|------|------|
+| `Candidates/` | Triage inputs and operator copies |
+| `Active/` | Golden standards (analysis only) |
+| `ArtifactIntake/` | Dated intake batches (raw evidence) |
+| `References/` | Approved/blessed references |
+| `Repaired/` | Excel-repaired variants |
+| `Workbook Payload Artifacts/` | Payload snapshots |
+| `RecoveredArtifacts/` | Recovery dumps |
+
+`Deprecated/` remains a **work area** (mutation allowed by design). It is not
+treated as an emulator root for this policy.
+
+## Writable output roots
+
+All engine artifacts go under:
+
+- `Outputs/<engine>/<YYYY-MM-DD>_<run_slug>/` — default run layout
+- `artifacts/<engine>/...` — compare-only tools (e.g. roster log compare)
+
+Optional subfolders per run:
+
+```text
+delivery/     submission-facing .xlsx
+internal/     internal/QA variants
+sidecars/     manifests, preflight JSON, review queues
+compare/      artifact_compare results
+forensics/    incident_compare, zip diffs
+index.html    HTML portal when emitted
+```
+
+`Outputs/backups/backup_<timestamp>/` — only via explicit overwrite approval
+([`triage/repo_apply.py`](../triage/repo_apply.py)).
+
+## Rules
+
+1. **Emulator = backup/reference.** Engines read; they do not mutate integrated
+   multi-tab operator workbooks in place.
+2. **No `--output == --input`.** No writes under readonly roots (enforced by
+   `assert_output_path_allowed` / `assert_not_overwriting_emulator`).
+3. **Reserialization gate.** Generators that `save()` via openpyxl must not target
+   integrated multi-tab emulators without a sheet-preservation gate (One Marcus:
+   use **relink**, not **generate**, on READY workbooks).
+4. **Delivery requires baseline compare.** Compare against declared baseline
+   (emulator or `References/approved/`); fail closed when sheets are deleted or
+   profile gates fail.
+5. **Overwrite outside Outputs** requires timestamped backup via `repo_apply`.
+
+## Manifest provenance
+
+Each engine run should record in its manifest (or sidecar):
+
+| Field | Meaning |
+|-------|---------|
+| `source_emulator_path` | Primary read-only input path |
+| `source_raw_sha256` | SHA-256 of that file at run start |
+| `run_id` | `<YYYY-MM-DD>_<slug>` folder name |
+| `output_layout_version` | `1` — standard run folder layout |
+
+## ArtifactIntake
+
+Raw folders under `ArtifactIntake/<date>/` are emulator evidence. Only
+`outputs/admin-ready/` and `outputs/internal-review/` receive **manual** promotion
+after validation — engines do not auto-write into intake raw trees.
+
+See [`ArtifactIntake/2026-06-02/README.md`](../ArtifactIntake/2026-06-02/README.md).
+
+## Deferred (known gaps)
+
+- Visual XML graft for One Marcus (relink preserves sheets; Visual column graft is
+  a follow-up lane).
+- Automatic backup on every engine run (only on explicit overwrite via `repo_apply`).
+- Auto-promotion into `ArtifactIntake/.../outputs/admin-ready/` (operator-controlled).
+- `Deprecated/` mutation policy unchanged.

--- a/tests/test_admin_billing_summary.py
+++ b/tests/test_admin_billing_summary.py
@@ -31,14 +31,16 @@ def april(fixtures):
 
 @pytest.fixture(scope="module")
 def generated(fixtures, tmp_path_factory):
-    out = tmp_path_factory.mktemp("abs_out")
+    root = tmp_path_factory.mktemp("abs_repo")
+    out = root / "Outputs" / "admin_billing_summary" / "test_run"
+    out.mkdir(parents=True)
     return run(
         roster_log=str(fixtures["roster"]),
         out_dir=str(out),
         months=["2026-04", "2026-05"],
         prior=str(fixtures["prior"]),
         websafe=True,
-        repo_root=REPO_ROOT,
+        repo_root=root,
     )
 
 
@@ -387,7 +389,7 @@ def test_multi_month_rejects_legacy_client_reference(fixtures):
     with pytest.raises(SystemExit):
         run(
             roster_log=str(fixtures["roster"]),
-            out_dir=str(fixtures["roster"].parent / "out_should_not_run"),
+            out_dir=str(REPO_ROOT / "Outputs" / "_test_should_not_run"),
             months=["2026-04", "2026-05"],
             websafe=False,
             reference_client=str(fixtures["roster"]),

--- a/tests/test_artifact_compare.py
+++ b/tests/test_artifact_compare.py
@@ -320,13 +320,15 @@ def generated_bonita_workbook(fixtures_bonita, tmp_path_factory):
 
     FIX = Path(__file__).resolve().parent / "fixtures" / "nw_prj_neuron_track_hours"
     fx = build_bonita_fixtures(FIX)
-    out = tmp_path_factory.mktemp("bonita_nb")
+    root = tmp_path_factory.mktemp("bonita_nb_repo")
+    out = root / "Outputs" / "nw_prj_neuron_track_hours" / "compare_run"
+    out.mkdir(parents=True)
     manifest = bonita_run(
         roster_log=str(fx["roster"]),
         out_dir=str(out),
         months=["2026-04", "2026-05"],
         websafe=True,
-        repo_root=REPO_ROOT,
+        repo_root=root,
     )
     return manifest["outputs"]["workbook"]
 

--- a/tests/test_cybernet_targets.py
+++ b/tests/test_cybernet_targets.py
@@ -116,11 +116,13 @@ def test_ssuh_replaces_placeholder_locations(fixture_paths):
 
 
 def test_cli_on_fixtures(fixture_paths, tmp_path):
+    out = tmp_path / "Outputs" / "cybernet_targets" / "test_run"
+    out.mkdir(parents=True)
     manifest = run(
         all_wave=str(fixture_paths["all_wave"]),
         existing_dashboard=str(fixture_paths["sprint_dashboard"]),
         deployment_tracker=str(fixture_paths["deployment_tracker"]),
-        out_dir=str(tmp_path),
+        out_dir=str(out),
         as_of="2026-06-01-test",
         websafe=True,
         repo_root=REPO_ROOT,
@@ -132,11 +134,13 @@ def test_cli_on_fixtures(fixture_paths, tmp_path):
 
 @pytest.mark.skipif(not REAL_ALL_WAVE.exists(), reason="Real Candidates workbooks not present")
 def test_real_workbook_93_targets(tmp_path):
+    out = tmp_path / "Outputs" / "cybernet_targets" / "real_run"
+    out.mkdir(parents=True)
     manifest = run(
         all_wave=str(REAL_ALL_WAVE),
         existing_dashboard=str(REAL_DASH),
         deployment_tracker=str(REAL_DEPLOY) if REAL_DEPLOY.exists() else None,
-        out_dir=str(tmp_path),
+        out_dir=str(out),
         as_of="2026-06-01",
         websafe=True,
         repo_root=REPO_ROOT,

--- a/tests/test_nw_prj_neuron_track_hours.py
+++ b/tests/test_nw_prj_neuron_track_hours.py
@@ -40,14 +40,16 @@ def fixtures():
 
 @pytest.fixture(scope="module")
 def generated(fixtures, tmp_path_factory):
-    out = tmp_path_factory.mktemp("nth_out")
+    root = tmp_path_factory.mktemp("nth_repo")
+    out = root / "Outputs" / "nw_prj_neuron_track_hours" / "test_run"
+    out.mkdir(parents=True)
     manifest = run(
         roster_log=str(fixtures["roster"]),
         out_dir=str(out),
         months=["2026-04", "2026-05"],
         websafe=True,
         zip_output=True,
-        repo_root=REPO_ROOT,
+        repo_root=root,
     )
     return manifest
 

--- a/tests/test_nw_prj_neuron_track_hours_bonita.py
+++ b/tests/test_nw_prj_neuron_track_hours_bonita.py
@@ -28,13 +28,15 @@ def resolution(fixtures):
 
 @pytest.fixture(scope="module")
 def generated(fixtures, tmp_path_factory):
-    out = tmp_path_factory.mktemp("bonita_out")
+    root = tmp_path_factory.mktemp("bonita_repo")
+    out = root / "Outputs" / "nw_prj_neuron_track_hours" / "test_run"
+    out.mkdir(parents=True)
     return run(
         roster_log=str(fixtures["roster"]),
         out_dir=str(out),
         months=MONTHS,
         websafe=True,
-        repo_root=REPO_ROOT,
+        repo_root=root,
     )
 
 

--- a/tests/test_one_marcus_immutability.py
+++ b/tests/test_one_marcus_immutability.py
@@ -20,14 +20,14 @@ def test_rejects_output_under_candidates():
     inp = str(repo / "Candidates" / "inventory recon" / "in.xlsx")
     out = str(repo / "Candidates" / "inventory recon" / "out.xlsx")
     with pytest.raises(SourcePathWriteForbiddenError):
-        assert_output_path_allowed(inp, out)
+        assert_output_path_allowed(inp, output_path=out)
 
 
 def test_rejects_output_equals_input(tmp_path):
     p = tmp_path / "book.xlsx"
     p.write_bytes(b"x")
     with pytest.raises(SourcePathWriteForbiddenError):
-        assert_output_path_allowed(str(p), str(p))
+        assert_output_path_allowed(str(p), output_path=str(p))
 
 
 def test_generate_refuses_multi_sheet_integrated(tmp_path):

--- a/tests/test_output_policy.py
+++ b/tests/test_output_policy.py
@@ -1,0 +1,76 @@
+"""Shared output path policy tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from triage.output_policy import (
+    SourcePathWriteForbiddenError,
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    assert_output_path_allowed,
+    run_id_from_dir,
+)
+
+
+def test_rejects_output_under_candidates():
+    repo = Path(__file__).resolve().parents[1]
+    inp = str(repo / "Candidates" / "in.xlsx")
+    out = str(repo / "Candidates" / "out.xlsx")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(inp, output_path=out)
+
+
+def test_rejects_output_under_artifact_intake():
+    repo = Path(__file__).resolve().parents[1]
+    inp = str(repo / "ArtifactIntake" / "2026-06-02" / "in.xlsx")
+    out = str(repo / "ArtifactIntake" / "2026-06-02" / "out.xlsx")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(inp, output_path=out)
+
+
+def test_rejects_output_under_references():
+    repo = Path(__file__).resolve().parents[1]
+    out = str(repo / "References" / "approved" / "out.xlsx")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(output_path=out)
+
+
+def test_rejects_output_equals_input(tmp_path):
+    p = tmp_path / "book.xlsx"
+    p.write_bytes(b"x")
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_output_path_allowed(str(p), output_path=str(p))
+
+
+def test_accepts_outputs_subpath(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRIAGE_REPO_ROOT", str(tmp_path))
+    out = tmp_path / "Outputs" / "engine" / "2026-06-04_run" / "delivery.xlsx"
+    out.parent.mkdir(parents=True)
+    assert_output_path_allowed(output_path=str(out))
+    assert_out_dir_allowed(out.parent)
+
+
+def test_accepts_artifacts_subpath(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRIAGE_REPO_ROOT", str(tmp_path))
+    out_dir = tmp_path / "artifacts" / "roster_log_compare" / "2026-06-04_run"
+    out_dir.mkdir(parents=True)
+    assert_out_dir_allowed(out_dir)
+
+
+def test_rejects_out_dir_outside_writable_roots(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRIAGE_REPO_ROOT", str(tmp_path))
+    bad = tmp_path / "Candidates" / "run"
+    bad.mkdir(parents=True)
+    with pytest.raises(SourcePathWriteForbiddenError):
+        assert_out_dir_allowed(bad)
+
+
+def test_allocate_run_dir_creates_expected_path(tmp_path, monkeypatch):
+    monkeypatch.setenv("TRIAGE_REPO_ROOT", str(tmp_path))
+    run = allocate_run_dir("admin_billing_summary", "proof")
+    assert run.is_dir()
+    assert run.parts[-2] == "admin_billing_summary"
+    assert run.name.endswith("_proof")
+    assert run_id_from_dir(run) == run.name

--- a/tests/test_roster_log_compare.py
+++ b/tests/test_roster_log_compare.py
@@ -38,8 +38,10 @@ def test_verdict_scenarios(roster_base, builder, expected):
 
 def test_cli_outputs_json_and_xlsx(roster_base, tmp_path):
     paths = b.build_punch_diff(roster_base)
-    out_xlsx = tmp_path / "comparison.xlsx"
-    out_json = tmp_path / "comparison.json"
+    out_root = tmp_path / "artifacts" / "roster_log_compare" / "test_run"
+    out_root.mkdir(parents=True)
+    out_xlsx = out_root / "comparison.xlsx"
+    out_json = out_root / "comparison.json"
     code = main([
         "--left", str(paths["left"]),
         "--right", str(paths["right"]),

--- a/tests/test_sidecar_html_portal.py
+++ b/tests/test_sidecar_html_portal.py
@@ -112,10 +112,13 @@ def test_admin_billing_manifest_portal(tmp_path_factory):
     from triage.admin_billing_summary.cli import run
 
     fx = build(Path(__file__).resolve().parent / "fixtures" / "admin_billing_summary")
-    out = tmp_path_factory.mktemp("portal_out")
+    root = tmp_path_factory.mktemp("portal_repo")
+    out = root / "Outputs" / "admin_billing_summary" / "portal_run"
+    out.mkdir(parents=True)
     manifest = run(
         roster_log=str(fx["roster"]),
         out_dir=str(out),
+        repo_root=root,
         months=["2026-04"],
         websafe=True,
     )

--- a/triage/admin_billing_summary/cli.py
+++ b/triage/admin_billing_summary/cli.py
@@ -2,7 +2,7 @@
 
     python -m triage.admin_billing_summary.cli \\
         --roster-log <roster.xlsx> --months 2026-04 2026-05 \\
-        --out-dir Outputs/admin_billing_summary_2026_06_02 \\
+        --out-dir Outputs/admin_billing_summary/<YYYY-MM-DD>_run/ \\
         --prior "<April copy>.xlsx" --websafe
 """
 from __future__ import annotations
@@ -22,6 +22,12 @@ from triage.nw_prj_neuron_track_hours.bonita_exporter import tab_name_for_month_
 from triage.artifact_compare import compare_artifacts
 from triage.release_status import enrich_variant_output
 from triage.sidecar_html.adapters import admin_billing_sections
+from triage.output_policy import (
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    run_id_from_dir,
+    source_manifest_fields,
+)
 from triage.sidecar_html.portal import build_run_portal
 
 DEFAULT_MONTHS = ["2026-04", "2026-05"]
@@ -218,7 +224,7 @@ def run(
     roster_path = _resolve(roster_log, root)
     if roster_path is None or not roster_path.exists():
         raise FileNotFoundError(f"roster-log not found: {roster_path}")
-    out = _resolve(out_dir, root) or (root / "Outputs")
+    out = assert_out_dir_allowed(_resolve(out_dir, root) or (root / "Outputs"))
     out.mkdir(parents=True, exist_ok=True)
     prior_path = _resolve(prior, root)
     ref_client = _resolve(reference_client or reference, root)
@@ -342,6 +348,8 @@ def run(
         "engine": "triage.admin_billing_summary.cli",
         "format": "openai_native_tables_v1",
         "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "run_id": run_id_from_dir(out),
+        **source_manifest_fields(roster_path),
         "roster_log": str(roster_path),
         "prior": str(prior_path) if prior_path else "",
         "reference_client": str(ref_client) if ref_client else "",
@@ -381,7 +389,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap = argparse.ArgumentParser(prog="triage.admin_billing_summary.cli")
     ap.add_argument("--roster-log", required=True)
     ap.add_argument("--months", nargs="+", default=DEFAULT_MONTHS)
-    ap.add_argument("--out-dir", default="Outputs/admin_billing_summary_2026_06_02")
+    ap.add_argument(
+        "--out-dir",
+        default=None,
+        help="Run directory under Outputs/admin_billing_summary/ (default: dated run folder)",
+    )
     ap.add_argument("--prior")
     ap.add_argument(
         "--reference",
@@ -408,9 +420,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--websafe", action="store_true", default=True)
     ap.add_argument("--no-websafe", action="store_false", dest="websafe")
     args = ap.parse_args(argv)
+    out_dir = args.out_dir or str(allocate_run_dir("admin_billing_summary", "run"))
     manifest = run(
         roster_log=args.roster_log,
-        out_dir=args.out_dir,
+        out_dir=out_dir,
         months=args.months,
         prior=args.prior,
         websafe=args.websafe,

--- a/triage/artifact_compare.py
+++ b/triage/artifact_compare.py
@@ -16,6 +16,7 @@ from triage.artifact_profiles import (
     load_profile,
     run_profile_checks,
 )
+from triage.output_policy import assert_output_path_allowed, assert_out_dir_allowed
 from triage.webexcel_semantic_gate import run_semantic_gate
 
 try:
@@ -207,6 +208,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument("--variant", default="client", choices=("internal", "client"))
     args = ap.parse_args(argv)
 
+    assert_output_path_allowed(
+        args.reference, args.candidate, output_path=args.candidate,
+    )
     report = compare_artifacts(
         args.reference,
         args.candidate,
@@ -217,9 +221,13 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     text = json.dumps(report, indent=2, default=str)
     if args.out:
-        out = Path(args.out)
-        out.parent.mkdir(parents=True, exist_ok=True)
-        out.write_text(text, encoding="utf-8")
+        assert_output_path_allowed(
+            args.reference, args.candidate, output_path=args.out,
+        )
+        assert_out_dir_allowed(Path(args.out).parent)
+        out_path = Path(args.out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text, encoding="utf-8")
     print(text)
     return 0 if report.get("compare_pass") else 1
 

--- a/triage/billing_context/cli.py
+++ b/triage/billing_context/cli.py
@@ -18,6 +18,12 @@ from .exporters import (
     scan_workbook_errors,
 )
 from .html_dashboard import export_html_dashboard
+from triage.output_policy import (
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    run_id_from_dir,
+    source_manifest_fields,
+)
 from .reconcile import (
     build_task_context_index,
     extract_track_hours,
@@ -34,14 +40,20 @@ def main() -> None:
     parser.add_argument("--roster-log")
     parser.add_argument("--admin-copy")
     parser.add_argument("--dashboard")
-    parser.add_argument("--out-dir", default="Outputs")
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="Run directory under Outputs/billing_context/ (default: dated run folder)",
+    )
     parser.add_argument("--html", action="store_true")
     parser.add_argument("--include-tracker-import", action="store_true")
     parser.add_argument("--internal-xlsx", action="store_true")
     parser.add_argument("--zip", action="store_true", help="Bundle all outputs into a single ZIP")
     args = parser.parse_args()
 
-    out_dir = Path(args.out_dir)
+    out_dir = assert_out_dir_allowed(
+        Path(args.out_dir) if args.out_dir else allocate_run_dir("billing_context", "run")
+    )
     out_dir.mkdir(parents=True, exist_ok=True)
 
     task_index = build_task_context_index(args.april_context)
@@ -121,6 +133,12 @@ def main() -> None:
     print(
         json.dumps(
             {
+                "run_id": run_id_from_dir(out_dir),
+                **source_manifest_fields(
+                    args.track_hours,
+                    args.april_context,
+                    args.roster_log,
+                ),
                 "outputs": outputs,
                 "manifest": manifest,
                 "entry_count": len(entries),

--- a/triage/cybernet_targets/cli.py
+++ b/triage/cybernet_targets/cli.py
@@ -26,6 +26,12 @@ from triage.cybernet_targets.resolver import resolve_sprint_targets
 from triage.nw_prj_config import is_repair_filename
 from triage.webexcel_preflight import run_preflight
 from triage.sidecar_html.adapters import cybernet_sections
+from triage.output_policy import (
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    run_id_from_dir,
+    source_manifest_fields,
+)
 from triage.sidecar_html.portal import build_run_portal
 
 
@@ -54,7 +60,7 @@ def run(
 
     aw_path = _resolve(all_wave, root)
     dash_path = _resolve(existing_dashboard, root)
-    out = _resolve(out_dir, root) or root / "Outputs"
+    out = assert_out_dir_allowed(_resolve(out_dir, root) or root / "Outputs")
     deploy_path = _resolve(deployment_tracker, root) if deployment_tracker else None
 
     for label, p in [("all_wave", aw_path), ("existing_dashboard", dash_path)]:
@@ -124,6 +130,8 @@ def run(
 
     manifest = {
         "as_of": as_of,
+        "run_id": run_id_from_dir(out),
+        **source_manifest_fields(aw_path, dash_path),
         "total_active_targets": total,
         "site_counts": site_counts,
         "amb_counts": {
@@ -165,18 +173,20 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--existing-dashboard", required=True)
     ap.add_argument("--scope", default="configs/cybernet_sprint_scope_2026_06.json")
     ap.add_argument("--deployment-tracker")
-    ap.add_argument("--out-dir", default="Outputs")
+    ap.add_argument("--out-dir", default=None, help="Run dir under Outputs/cybernet_targets/")
     ap.add_argument("--as-of", default="2026-06-01")
     ap.add_argument("--websafe", action="store_true", default=True)
     ap.add_argument("--no-websafe", action="store_false", dest="websafe")
     args = ap.parse_args(argv)
 
+    slug = args.as_of.replace("-", "")
+    out_dir = args.out_dir or str(allocate_run_dir("cybernet_targets", slug))
     manifest = run(
         all_wave=args.all_wave,
         existing_dashboard=args.existing_dashboard,
         scope_path=args.scope,
         deployment_tracker=args.deployment_tracker,
-        out_dir=args.out_dir,
+        out_dir=out_dir,
         as_of=args.as_of,
         websafe=args.websafe,
     )

--- a/triage/nw_prj_neuron_track_hours/bonita_cli.py
+++ b/triage/nw_prj_neuron_track_hours/bonita_cli.py
@@ -6,7 +6,7 @@ log, plus gitignored manifest / review-queue / preflight sidecars.
     python -m triage.nw_prj_neuron_track_hours.bonita_cli \
         --roster-log <x> --admin-log <y> [--template <t>] \
         --months 2026-04 2026-05 \
-        --out-dir Outputs/neuron_track_hours_2026_06_02 --websafe
+        --out-dir Outputs/nw_prj_neuron_track_hours/<YYYY-MM-DD>_run/ --websafe
 
 The admin log is used for reconciliation context only (manifest / review),
 never as workbook truth. The template is style-only and optional.
@@ -32,6 +32,12 @@ from triage.nw_prj_neuron_track_hours.bonita_exporter import (
 from triage.nw_prj_neuron_track_hours.bonita_resolver import resolve_bonita_shifts
 from triage.nw_prj_neuron_track_hours.reader import _month_label
 from triage.sidecar_html.adapters import bonita_sections
+from triage.output_policy import (
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    run_id_from_dir,
+    source_manifest_fields,
+)
 from triage.sidecar_html.portal import build_run_portal
 
 DEFAULT_MONTHS = ["2026-04", "2026-05"]
@@ -179,7 +185,7 @@ def run(
     roster_path = _resolve(roster_log, root)
     if roster_path is None or not roster_path.exists():
         raise FileNotFoundError(f"roster-log not found: {roster_path}")
-    out = _resolve(out_dir, root) or (root / "Outputs")
+    out = assert_out_dir_allowed(_resolve(out_dir, root) or (root / "Outputs"))
     out.mkdir(parents=True, exist_ok=True)
 
     resolution = resolve_bonita_shifts(str(roster_path), months)
@@ -231,6 +237,8 @@ def run(
     manifest = {
         "engine": "triage.nw_prj_neuron_track_hours.bonita_cli",
         "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "run_id": run_id_from_dir(out),
+        **source_manifest_fields(roster_path),
         "roster_log": str(roster_path),
         "admin_log": str(_resolve(admin_log, root)) if admin_log else "",
         "template": str(_resolve(template, root)) if template else "",
@@ -300,7 +308,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--admin-log")
     ap.add_argument("--template")
     ap.add_argument("--months", nargs="+", default=DEFAULT_MONTHS)
-    ap.add_argument("--out-dir", default="Outputs/neuron_track_hours_2026_06_02")
+    ap.add_argument("--out-dir", default=None, help="Run dir under Outputs/nw_prj_neuron_track_hours/")
     ap.add_argument("--reference", help="Approved reference workbook for artifact_compare")
     ap.add_argument(
         "--artifact-profile",
@@ -311,9 +319,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--no-websafe", action="store_false", dest="websafe")
     args = ap.parse_args(argv)
 
+    out_dir = args.out_dir or str(allocate_run_dir("nw_prj_neuron_track_hours", "bonita"))
     manifest = run(
         roster_log=args.roster_log,
-        out_dir=args.out_dir,
+        out_dir=out_dir,
         months=args.months,
         admin_log=args.admin_log,
         template=args.template,

--- a/triage/nw_prj_neuron_track_hours/cli.py
+++ b/triage/nw_prj_neuron_track_hours/cli.py
@@ -14,6 +14,12 @@ from triage.nw_prj_neuron_track_hours.classifier import (
 )
 from triage.nw_prj_neuron_track_hours.exporter import EXPECTED_SHEETS, build_workbook
 from triage.sidecar_html.adapters import neuron_track_sections
+from triage.output_policy import (
+    allocate_run_dir,
+    assert_out_dir_allowed,
+    run_id_from_dir,
+    source_manifest_fields,
+)
 from triage.sidecar_html.portal import build_run_portal
 from triage.nw_prj_neuron_track_hours.models import TrackHoursReport
 from triage.nw_prj_neuron_track_hours.preflight import run_preflight
@@ -145,7 +151,7 @@ def run(
     roster_path = _resolve(roster_log, root)
     if roster_path is None or not roster_path.exists():
         raise FileNotFoundError(f"roster-log not found: {roster_path}")
-    out = _resolve(out_dir, root) or (root / "Outputs")
+    out = assert_out_dir_allowed(_resolve(out_dir, root) or (root / "Outputs"))
     out.mkdir(parents=True, exist_ok=True)
 
     report = build_report(str(roster_path), months, pinned_techs=pinned_techs)
@@ -190,6 +196,8 @@ def run(
 
     manifest = {
         "engine": "triage.nw_prj_neuron_track_hours.cli",
+        "run_id": run_id_from_dir(out),
+        **source_manifest_fields(roster_path),
         "roster_log": str(roster_path),
         "admin_control": str(_resolve(admin_control, root)) if admin_control else "",
         "reference": str(_resolve(reference, root)) if reference else "",
@@ -230,7 +238,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--roster-log", required=True)
     ap.add_argument("--admin-control")
     ap.add_argument("--reference")
-    ap.add_argument("--out-dir", default="Outputs/nw_prj_neuron_track_hours_2026_06_01")
+    ap.add_argument("--out-dir", default=None, help="Run dir under Outputs/nw_prj_neuron_track_hours/")
     ap.add_argument("--months", nargs="+", default=DEFAULT_MONTHS)
     ap.add_argument("--pinned", nargs="*", default=[])
     ap.add_argument("--websafe", action="store_true", default=True)
@@ -238,9 +246,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--zip", action="store_true", default=False, dest="zip_output")
     args = ap.parse_args(argv)
 
+    out_dir = args.out_dir or str(allocate_run_dir("nw_prj_neuron_track_hours", "track_hours"))
     manifest = run(
         roster_log=args.roster_log,
-        out_dir=args.out_dir,
+        out_dir=out_dir,
         months=args.months,
         admin_control=args.admin_control,
         reference=args.reference,

--- a/triage/one_marcus_recon/cli.py
+++ b/triage/one_marcus_recon/cli.py
@@ -19,7 +19,12 @@ from pathlib import Path
 from .date_inference import AmbiguousDateError
 from .exporter import run_generate, run_recon
 from .integrated_guard import IntegratedWorkbookError
-from .path_guard import SourcePathWriteForbiddenError
+from triage.output_policy import (
+    SourcePathWriteForbiddenError,
+    allocate_run_dir,
+    assert_output_path_allowed,
+    ensure_run_subdirs,
+)
 
 
 def _add_shared_args(p: argparse.ArgumentParser) -> None:
@@ -55,11 +60,15 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _default_generate_output(_input_path: str) -> str:
-    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_generated.xlsx")
+    run = allocate_run_dir("one_marcus_recon", "generate")
+    ensure_run_subdirs(run, ("delivery",))
+    return str(run / "delivery" / "1M_Recon_generated.xlsx")
 
 
 def _default_relink_output(_input_path: str) -> str:
-    return str(Path("Outputs") / "one_marcus_recon" / "1M_Recon_relink.xlsx")
+    run = allocate_run_dir("one_marcus_recon", "relink")
+    ensure_run_subdirs(run, ("delivery",))
+    return str(run / "delivery" / "1M_Recon_relink.xlsx")
 
 
 def main(argv=None) -> int:
@@ -68,6 +77,7 @@ def main(argv=None) -> int:
     try:
         if args.command == "generate":
             output = args.output or _default_generate_output(args.input)
+            assert_output_path_allowed(args.input, output_path=output)
             result = run_generate(
                 args.input,
                 output_path=output,
@@ -78,6 +88,7 @@ def main(argv=None) -> int:
             )
         else:
             output = args.output or _default_relink_output(args.input)
+            assert_output_path_allowed(args.input, output_path=output)
             result = run_recon(
                 args.input,
                 output_path=output,

--- a/triage/one_marcus_recon/exporter.py
+++ b/triage/one_marcus_recon/exporter.py
@@ -69,7 +69,7 @@ def run_recon(
     dry_run: bool = False,
     strict: bool = False,
 ) -> ReconResult:
-    assert_output_path_allowed(input_path, output_path)
+    assert_output_path_allowed(input_path, output_path=output_path)
     report = ReconReport(input_workbook=str(Path(input_path).resolve()), dry_run=dry_run, mode="relink")
 
     pkg = Package.from_path(input_path)
@@ -283,7 +283,7 @@ def run_generate(
     strict: bool = False,
 ) -> ReconResult:
     """Clean-render a full recon workbook from an integrated source spreadsheet."""
-    assert_output_path_allowed(input_path, output_path)
+    assert_output_path_allowed(input_path, output_path=output_path)
     assert_generate_allowed(input_path)
     report = ReconReport(
         input_workbook=str(Path(input_path).resolve()),

--- a/triage/one_marcus_recon/path_guard.py
+++ b/triage/one_marcus_recon/path_guard.py
@@ -1,33 +1,16 @@
-"""Output path guards — operator source folders are read-only inputs."""
+"""One Marcus path guards — re-export shared output policy."""
 from __future__ import annotations
 
-from pathlib import Path
+from triage.output_policy import (  # noqa: F401
+    SourcePathWriteForbiddenError,
+    assert_not_overwriting_emulator,
+    assert_output_path_allowed,
+    assert_out_dir_allowed,
+)
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_READONLY_ROOTS = ("Candidates", "Active")
-
-
-class SourcePathWriteForbiddenError(ValueError):
-    """Raised when engine output would overwrite or write into read-only input zones."""
-
-
-def assert_output_path_allowed(input_path: str, output_path: str) -> None:
-    """Fail closed if output equals input or targets Candidates/ or Active/."""
-    inp = Path(input_path).resolve()
-    out = Path(output_path).resolve()
-
-    if inp == out:
-        raise SourcePathWriteForbiddenError(
-            "output path must not equal input path; write delivery artifacts under Outputs/"
-        )
-
-    try:
-        rel = out.relative_to(_REPO_ROOT.resolve())
-    except ValueError:
-        return
-
-    if rel.parts and rel.parts[0] in _READONLY_ROOTS:
-        raise SourcePathWriteForbiddenError(
-            f"output path must not be under {rel.parts[0]}/; "
-            "Candidates/ and Active/ are read-only operator inputs"
-        )
+__all__ = [
+    "SourcePathWriteForbiddenError",
+    "assert_output_path_allowed",
+    "assert_not_overwriting_emulator",
+    "assert_out_dir_allowed",
+]

--- a/triage/output_policy.py
+++ b/triage/output_policy.py
@@ -1,0 +1,162 @@
+"""Repo-wide output path policy — emulator inputs stay read-only.
+
+Artifact engines read from lifecycle/emulator folders and write only under
+``Outputs/`` or ``artifacts/`` (both gitignored). See
+``docs/OPERATOR_SOURCE_IMMUTABILITY.md``.
+"""
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from typing import Iterable, Optional
+
+from triage.artifact_fingerprint import raw_sha256
+from triage.path_policy import is_under_folder, repo_root
+
+READONLY_INPUT_ROOTS = (
+    "Candidates",
+    "Active",
+    "ArtifactIntake",
+    "References",
+    "Repaired",
+    "Workbook Payload Artifacts",
+    "RecoveredArtifacts",
+)
+WRITABLE_OUTPUT_ROOTS = ("Outputs", "artifacts")
+OUTPUT_LAYOUT_VERSION = 1
+
+
+class SourcePathWriteForbiddenError(ValueError):
+    """Raised when an engine would write into read-only emulator/input zones."""
+
+
+def _resolve(path: str | Path) -> Path:
+    pp = Path(path).expanduser()
+    if pp.is_absolute():
+        return pp.resolve(strict=False)
+    return (repo_root() / pp).resolve(strict=False)
+
+
+def _writable_root_index(parts: tuple[str, ...]) -> Optional[int]:
+    for folder in WRITABLE_OUTPUT_ROOTS:
+        if folder in parts:
+            return parts.index(folder)
+    return None
+
+
+def assert_not_overwriting_emulator(path: str | Path) -> None:
+    """Fail closed if *path* targets a read-only emulator/input root."""
+    p = _resolve(path)
+    parts = p.parts
+    widx = _writable_root_index(parts)
+    for folder in READONLY_INPUT_ROOTS:
+        if folder not in parts:
+            if is_under_folder(p, folder):
+                raise SourcePathWriteForbiddenError(
+                    f"write target must not be under {folder}/; "
+                    f"{folder}/ is a read-only operator input zone"
+                )
+            continue
+        ro_idx = parts.index(folder)
+        if widx is None or ro_idx < widx:
+            raise SourcePathWriteForbiddenError(
+                f"write target must not be under {folder}/; "
+                f"{folder}/ is a read-only operator input zone"
+            )
+
+
+def assert_output_path_allowed(
+    *input_paths: str | Path,
+    output_path: str | Path,
+) -> None:
+    """Fail closed if output equals any input or targets a readonly root."""
+    out = _resolve(output_path)
+    assert_not_overwriting_emulator(out)
+
+    for raw_inp in input_paths:
+        if raw_inp is None:
+            continue
+        inp = _resolve(raw_inp)
+        if inp == out:
+            raise SourcePathWriteForbiddenError(
+                "output path must not equal input path; "
+                "write delivery artifacts under Outputs/ or artifacts/"
+            )
+
+
+def assert_out_dir_allowed(out_dir: str | Path) -> Path:
+    """Require *out_dir* to live under Outputs/ or artifacts/."""
+    p = _resolve(out_dir)
+    parts = p.parts
+    idx = _writable_root_index(parts)
+    if idx is None:
+        for folder in WRITABLE_OUTPUT_ROOTS:
+            if is_under_folder(p, folder):
+                return p
+        raise SourcePathWriteForbiddenError(
+            f"output directory must be under one of {WRITABLE_OUTPUT_ROOTS}; got {p}"
+        )
+    for ro in READONLY_INPUT_ROOTS:
+        if ro in parts[:idx]:
+            raise SourcePathWriteForbiddenError(
+                f"output directory must not be under {ro}/ before writable root; got {p}"
+            )
+    return p
+
+
+def allocate_run_dir(
+    engine: str,
+    slug: str,
+    *,
+    root: Optional[Path] = None,
+    writable_root: str = "Outputs",
+) -> Path:
+    """Create ``<writable_root>/<engine>/<YYYY-MM-DD>_<slug>/`` for one operator batch."""
+    if writable_root not in WRITABLE_OUTPUT_ROOTS:
+        raise ValueError(f"writable_root must be one of {WRITABLE_OUTPUT_ROOTS}")
+    base = root or repo_root()
+    today = date.today().isoformat()
+    safe_slug = re.sub(r"[^\w\-]+", "_", slug).strip("_") or "run"
+    run_dir = base / writable_root / engine / f"{today}_{safe_slug}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    return run_dir
+
+
+def run_id_from_dir(run_dir: Path) -> str:
+    return run_dir.name
+
+
+def source_manifest_fields(*source_paths: str | Path) -> dict:
+    """Standard manifest provenance for the primary emulator input."""
+    primary: Optional[Path] = None
+    for sp in source_paths:
+        if sp is None:
+            continue
+        p = Path(sp)
+        if not p.is_absolute():
+            p = _resolve(p)
+        if p.is_file():
+            primary = p
+            break
+
+    if primary is None:
+        first = str(source_paths[0]) if source_paths else ""
+        return {
+            "source_emulator_path": first,
+            "source_raw_sha256": "",
+            "output_layout_version": OUTPUT_LAYOUT_VERSION,
+        }
+
+    return {
+        "source_emulator_path": str(primary.resolve()),
+        "source_raw_sha256": raw_sha256(primary),
+        "output_layout_version": OUTPUT_LAYOUT_VERSION,
+    }
+
+
+def ensure_run_subdirs(run_dir: Path, names: Iterable[str] = ()) -> None:
+    """Optionally create standard layout folders under a run directory."""
+    defaults = ("delivery", "internal", "sidecars", "compare", "forensics")
+    for name in names or defaults:
+        (run_dir / name).mkdir(parents=True, exist_ok=True)

--- a/triage/roster_log_compare/compare.py
+++ b/triage/roster_log_compare/compare.py
@@ -17,6 +17,7 @@ from triage.roster_log_compare.models import ComparisonResult
 from triage.roster_log_compare.override_check import compare_override_tables
 from triage.roster_log_compare.report import write_comparison_workbook
 from triage.roster_log_compare.structure import compare_structure
+from triage.output_policy import assert_output_path_allowed, assert_out_dir_allowed
 from triage.roster_log_compare.verdict import compute_verdict
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -77,6 +78,9 @@ def run(
     root = repo_root or _REPO_ROOT
     left_p = resolve_path(left, root)
     right_p = resolve_path(right, root)
+    assert_output_path_allowed(left_p, right_p, output_path=out_xlsx)
+    assert_output_path_allowed(left_p, right_p, output_path=json_out)
+    assert_out_dir_allowed(resolve_path(json_out, root).parent)
     payload = run_comparison(
         left_p, right_p, live_include_formatting=live_include_formatting,
     )

--- a/triage/roster_log_review_queue/run.py
+++ b/triage/roster_log_review_queue/run.py
@@ -12,6 +12,8 @@ from .package_io import Package, remove_calc_chain, remove_external_links
 from .preflight import run_preflight
 from .provenance import build_provenance
 from .queue_builder import build_review_queue
+from triage.output_policy import assert_output_path_allowed
+
 from .workbook_graft import graft_review_layer
 
 
@@ -42,6 +44,12 @@ def run(
 
     if not input_path:
         raise ValueError("--input is required for this mode")
+
+    assert_output_path_allowed(input_path, output_path=output_path)
+    if provenance_out:
+        assert_output_path_allowed(input_path, output_path=provenance_out)
+    if zip_out:
+        assert_output_path_allowed(input_path, output_path=zip_out)
 
     input_name = Path(input_path).name
     out = Path(output_path)

--- a/triage/same_family_compare/cli.py
+++ b/triage/same_family_compare/cli.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from triage.same_family_compare.compare import CompareError, run_same_family_compare, write_compare_outputs
 from triage.same_family_compare.readiness import build_submission_readiness, write_submission_readiness
+from triage.output_policy import allocate_run_dir, assert_out_dir_allowed
 from triage.same_family_compare.scan import scan_intake, write_scan_outputs
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -27,13 +28,19 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument("--candidate", default=None)
     ap.add_argument("--family", default=None)
     ap.add_argument("--months", nargs="*", default=None)
-    ap.add_argument("--out-dir", default="artifacts/same_family_compare")
+    ap.add_argument("--out-dir", default=None, help="Run dir under artifacts/same_family_compare/")
     ap.add_argument("--expect-neuron-tab", default=None)
     ap.add_argument("--browser-excel-status", default="UNKNOWN")
     args = ap.parse_args(argv)
 
     root = Path(args.repo_root).resolve() if args.repo_root else _REPO_ROOT
-    out_dir = _resolve(args.out_dir, root)
+    if args.out_dir:
+        out_dir = assert_out_dir_allowed(_resolve(args.out_dir, root))
+    else:
+        slug = "scan" if args.scan_only else "compare"
+        out_dir = allocate_run_dir(
+            "same_family_compare", slug, root=root, writable_root="artifacts"
+        )
 
     if args.scan_only:
         if not args.intake_root:


### PR DESCRIPTION
## **User description**
## Summary
- Merge prerequisite PR #44 is on main; this generalizes One Marcus path guards into shared `triage/output_policy.py`.
- All artifact engine CLIs enforce read-only emulator roots, default to `Outputs/<engine>/<YYYY-MM-DD>_<slug>/` (or `artifacts/` for compare tools), and record `source_emulator_path` + `source_raw_sha256` in manifests.
- Adds canonical doctrine in `docs/OPERATOR_SOURCE_IMMUTABILITY.md` plus CI `tests/test_output_policy.py`.

## Test plan
- [x] `python -m pytest` artifact-engines suite (135 passed)
- [x] `python -m triage.gitignore_hygiene`
- [ ] After merge: confirm `git status` clean on `main` and emulator SHAs unchanged under `Candidates/` / `ArtifactIntake/`


Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Add repo-wide rules for safe artifact output and immutable source inputs**

### What Changed
- Artifact engines now write to dated run folders under `Outputs/<engine>/...` or `artifacts/...` instead of loose top-level output paths
- Output paths are checked to prevent writing into read-only source folders like `Candidates/`, `Active/`, `ArtifactIntake/`, and `References/`
- Run manifests now record the source file path, source file checksum, run ID, and output layout version
- One Marcus recon keeps its source workbook protected by defaulting to a run folder and blocking output paths that would overwrite the input
- Added shared tests and updated existing CLI tests to use the new run-folder layout

### Impact
`✅ Fewer accidental overwrites of source workbooks`
`✅ Safer artifact runs in read-only emulator folders`
`✅ Easier traceability for generated files and run provenance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
