### PR TITLE
feat: Bonita Neuron Track Hours repair-free golden profile gate

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -41,6 +41,7 @@ jobs:
             tests/test_cybernet_targets.py \
             tests/test_nw_prj_neuron_track_hours.py \
             tests/test_nw_prj_neuron_track_hours_bonita.py \
+            tests/test_nw_prj_neuron_track_hours_repairfree_profile.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \

--- a/configs/artifact_profiles/neuron_track_hours_repairfree_golden.json
+++ b/configs/artifact_profiles/neuron_track_hours_repairfree_golden.json
@@ -1,0 +1,50 @@
+{
+  "profile": "neuron_track_hours_repairfree_golden",
+  "submission_safe": true,
+  "required_sheets": ["Apr 26", "May 26", "Rules & Legend"],
+  "month_sheet_names": ["Apr 26", "May 26"],
+  "legend_sheet": "Rules & Legend",
+  "header_row1": ["", "TECH", "START", "END", "TOTAL", "PROJECT", "ASSIGNMENT"],
+  "header_row2": ["DATE", "NAME", "TIME", "TIME", "HOURS", "NAME", "TYPE"],
+  "column_widths": [12, 22, 12, 12, 10, 22, 32],
+  "freeze_panes": "A3",
+  "header_fill_row1": "1F4E78",
+  "header_fill_row2": "5B9BD5",
+  "assignment_fills": {
+    "Inventory Management": "D9EAD3",
+    "Configurations": "D9EAF7",
+    "Ticket Forwarding": "FFF2CC",
+    "Client Coordination": "EADCF8",
+    "Documentation": "E7E6E6",
+    "Deployments": "FCE4D6",
+    "Logistics": "DDEBF7",
+    "Troubleshooting / Incident Response": "F4CCCC"
+  },
+  "allowed_assignment_types": [
+    "Inventory Management",
+    "Configurations",
+    "Ticket Forwarding",
+    "Client Coordination",
+    "Documentation",
+    "Deployments",
+    "Logistics",
+    "Troubleshooting / Incident Response"
+  ],
+  "package_stop_ship": {
+    "no_calc_chain": true,
+    "no_external_links": true,
+    "no_vba": true,
+    "no_formula_error_tokens": true,
+    "no_inline_str": true,
+    "no_formulas_in_month_sheets": true,
+    "no_conditional_formatting_in_month_sheets": true,
+    "no_merged_cells_in_month_sheets": true
+  },
+  "legend_rows": [
+    ["Neuron Track Hours — Rules & Legend", ""],
+    ["", ""],
+    ["Assignment types and fill colors match the Neuron Track Hours submission workbook.", ""],
+    ["Client Coordination is limited to approved coordinators (see resolver allowlist).", ""],
+    ["Review issues are recorded in sidecars only, not on month sheets.", ""]
+  ]
+}

--- a/tests/fixtures/nw_prj_neuron_track_hours/bonita_fixtures.py
+++ b/tests/fixtures/nw_prj_neuron_track_hours/bonita_fixtures.py
@@ -11,7 +11,11 @@ April (counted shifts):
   Foxtrot Tech Apr 03  8h   Neuron, Delivery/Transport activity sub-label
   Hotel Tech   Apr 15  17h  long shift (counted + flagged)
   India Tech   Apr 02  8h   default Delivery, Assignments override -> Neuron
-  => 7 rows, 66.0h
+  Mixed Tech   Apr 06  8h   inventory+configuration note -> split (2 rows)
+  => 9 rows, 74.0h
+
+April (excluded, recorded in review) — continued:
+  Kilo Tech    Apr 05  client coordination outside allowlist
 
 April (excluded, recorded in review):
   Charlie Tech Apr 01  / Bonita off-project coverage punch
@@ -31,6 +35,17 @@ from pathlib import Path
 
 from openpyxl import Workbook
 
+_APR_DAYS = (1, 2, 3, 4, 5, 6, 15, 30)
+
+
+def _apr_row(name: str, project: str, punches: dict[int, tuple[str, str]]) -> list:
+    """Build one Live-April row aligned to the eight punch columns in the header."""
+    row = [name, project]
+    for day in _APR_DAYS:
+        cin, cout = punches.get(day, ("", ""))
+        row.extend([cin, cout])
+    return row
+
 
 def write_bonita_roster(path: Path) -> None:
     wb = Workbook()
@@ -45,43 +60,48 @@ def write_bonita_roster(path: Path) -> None:
         "Apr 02 - Clock In", "Apr 02 - Clock Out",
         "Apr 03 - Clock In", "Apr 03 - Clock Out",
         "Apr 04 - Clock In", "Apr 04 - Clock Out",
+        "Apr 05 - Clock In", "Apr 05 - Clock Out",
+        "Apr 06 - Clock In", "Apr 06 - Clock Out",
         "Apr 15 - Clock In", "Apr 15 - Clock Out",
         "Apr 30 - Clock In", "Apr 30 - Clock Out",
     ])
-    # Alpha: full-month bookends.
-    apr.append(["Alpha Tech", "Neuron Deployments",
-                "9:00 AM", "6:00 PM", "", "", "", "", "", "", "", "",
-                "8:00 AM", "4:00 PM"])
-    # Bravo: note-bearing punch on Apr 03.
-    apr.append(["Bravo Tech", "Neuron Deployments",
-                "", "", "", "", "8:00 AM", "4:00 PM - lunch covered",
-                "", "", "", "", "", ""])
-    # Charlie: off-project / Bonita coverage punch on Apr 01.
-    apr.append(["Charlie Tech", "Neuron Deployments",
-                "9:00:00 AM/ Bonita", "1:00 PM", "", "", "", "",
-                "", "", "", "", "", ""])
-    # Delta: default Delivery, override-to-Neuron via Worked Projects on Apr 02.
-    apr.append(["Delta Tech", "Delivery / Transport",
-                "", "", "7:00 AM", "3:00 PM", "", "", "", "", "", "", "", ""])
-    # Echo: default Neuron, override-away-from-Neuron via Worked Projects Apr 02.
-    apr.append(["Echo Tech", "Neuron Deployments",
-                "", "", "9:00 AM", "5:00 PM", "", "", "", "", "", "", "", ""])
-    # Foxtrot: Neuron with a Delivery/Transport activity note on Apr 03.
-    apr.append(["Foxtrot Tech", "Neuron Deployments",
-                "", "", "", "", "6:00 AM", "2:00 PM - Delivery / Transport",
-                "", "", "", "", "", ""])
-    # Golf: PTO non-work marker on Apr 04.
-    apr.append(["Golf Tech", "Neuron Deployments",
-                "", "", "", "", "", "", "PTO", "", "", "", "", ""])
-    # Hotel: long shift on Apr 15.
-    apr.append(["Hotel Tech", "Neuron Deployments",
-                "", "", "", "", "", "", "", "", "6:00 AM", "11:00 PM", "", ""])
-    # Yostinn Minaya: excluded name (never counted).
-    apr.append(["Yostinn Minaya", "Neuron Deployments",
-                "9:00 AM", "6:00 PM", "", "", "", "", "", "", "", "", "", ""])
-    # India: default Delivery, Assignments-override-to-Neuron on Apr 02.
-    apr.append(["India Tech", "Delivery / Transport",
-                "", "", "8:00 AM", "4:00 PM", "", "", "", "", "", "", "", ""])
+    apr.append(_apr_row("Alpha Tech", "Neuron Deployments", {
+        1: ("9:00 AM", "6:00 PM"),
+        30: ("8:00 AM", "4:00 PM"),
+    }))
+    apr.append(_apr_row("Bravo Tech", "Neuron Deployments", {
+        3: ("8:00 AM", "4:00 PM - lunch covered"),
+    }))
+    apr.append(_apr_row("Charlie Tech", "Neuron Deployments", {
+        1: ("9:00:00 AM/ Bonita", "1:00 PM"),
+    }))
+    apr.append(_apr_row("Delta Tech", "Delivery / Transport", {
+        2: ("7:00 AM", "3:00 PM"),
+    }))
+    apr.append(_apr_row("Echo Tech", "Neuron Deployments", {
+        2: ("9:00 AM", "5:00 PM"),
+    }))
+    apr.append(_apr_row("Foxtrot Tech", "Neuron Deployments", {
+        3: ("6:00 AM", "2:00 PM - Delivery / Transport"),
+    }))
+    apr.append(_apr_row("Golf Tech", "Neuron Deployments", {
+        4: ("PTO", ""),
+    }))
+    apr.append(_apr_row("Hotel Tech", "Neuron Deployments", {
+        15: ("6:00 AM", "11:00 PM"),
+    }))
+    apr.append(_apr_row("Yostinn Minaya", "Neuron Deployments", {
+        1: ("9:00 AM", "6:00 PM"),
+    }))
+    apr.append(_apr_row("India Tech", "Delivery / Transport", {
+        2: ("8:00 AM", "4:00 PM"),
+    }))
+    apr.append(_apr_row("Kilo Tech", "Neuron Deployments", {
+        5: ("2:00 PM", "4:00 PM - client status call"),
+    }))
+    apr.append(_apr_row("Mixed Tech", "Neuron Deployments", {
+        6: ("9:00 AM", "5:00 PM - inventory warehouse and configuration baseline"),
+    }))
 
     # ── Worked Projects - April 2026 ─────────────────────────────────
     wapr = wb.create_sheet("Worked Projects - April 2026")

--- a/tests/fixtures/nw_prj_neuron_track_hours_repairfree/golden_profile.json
+++ b/tests/fixtures/nw_prj_neuron_track_hours_repairfree/golden_profile.json
@@ -1,0 +1,50 @@
+{
+  "profile": "neuron_track_hours_repairfree_golden",
+  "submission_safe": true,
+  "required_sheets": ["Apr 26", "May 26", "Rules & Legend"],
+  "month_sheet_names": ["Apr 26", "May 26"],
+  "legend_sheet": "Rules & Legend",
+  "header_row1": ["", "TECH", "START", "END", "TOTAL", "PROJECT", "ASSIGNMENT"],
+  "header_row2": ["DATE", "NAME", "TIME", "TIME", "HOURS", "NAME", "TYPE"],
+  "column_widths": [12, 22, 12, 12, 10, 22, 32],
+  "freeze_panes": "A3",
+  "header_fill_row1": "1F4E78",
+  "header_fill_row2": "5B9BD5",
+  "assignment_fills": {
+    "Inventory Management": "D9EAD3",
+    "Configurations": "D9EAF7",
+    "Ticket Forwarding": "FFF2CC",
+    "Client Coordination": "EADCF8",
+    "Documentation": "E7E6E6",
+    "Deployments": "FCE4D6",
+    "Logistics": "DDEBF7",
+    "Troubleshooting / Incident Response": "F4CCCC"
+  },
+  "allowed_assignment_types": [
+    "Inventory Management",
+    "Configurations",
+    "Ticket Forwarding",
+    "Client Coordination",
+    "Documentation",
+    "Deployments",
+    "Logistics",
+    "Troubleshooting / Incident Response"
+  ],
+  "package_stop_ship": {
+    "no_calc_chain": true,
+    "no_external_links": true,
+    "no_vba": true,
+    "no_formula_error_tokens": true,
+    "no_inline_str": true,
+    "no_formulas_in_month_sheets": true,
+    "no_conditional_formatting_in_month_sheets": true,
+    "no_merged_cells_in_month_sheets": true
+  },
+  "legend_rows": [
+    ["Neuron Track Hours — Rules & Legend", ""],
+    ["", ""],
+    ["Assignment types and fill colors match the Neuron Track Hours submission workbook.", ""],
+    ["Client Coordination is limited to approved coordinators (see resolver allowlist).", ""],
+    ["Review issues are recorded in sidecars only, not on month sheets.", ""]
+  ]
+}

--- a/tests/test_nw_prj_neuron_track_hours_bonita.py
+++ b/tests/test_nw_prj_neuron_track_hours_bonita.py
@@ -45,10 +45,10 @@ def test_cli_imports():
     assert hasattr(mod, "main")
 
 
-# 2 ─ Exactly Apr 26 + May 26 tabs ───────────────────────────────────
-def test_exactly_two_named_tabs(generated):
+# 2 ─ Exactly Apr 26 + May 26 + Rules & Legend ───────────────────────
+def test_month_tabs_and_legend_sheet(generated):
     wb = openpyxl.load_workbook(generated["outputs"]["workbook"], read_only=True)
-    assert wb.sheetnames == ["Apr 26", "May 26"]
+    assert wb.sheetnames == ["Apr 26", "May 26", "Rules & Legend"]
     wb.close()
 
 
@@ -176,6 +176,8 @@ def test_excluded_name_never_counted(resolution):
 def test_no_blank_cells_on_populated_rows(generated):
     wb = openpyxl.load_workbook(generated["outputs"]["workbook"], read_only=True)
     for ws in wb.worksheets:
+        if ws.title == "Rules & Legend":
+            continue
         rows = list(ws.iter_rows(min_row=3, values_only=True))
         for row in rows:
             if not any(c is not None for c in row):
@@ -189,11 +191,11 @@ def test_no_blank_cells_on_populated_rows(generated):
 # 11 ─ Manifest has per-month row counts + total hours ───────────────
 def test_manifest_has_per_month_counts_and_totals(generated):
     pm = generated["per_month"]
-    assert pm["2026-04"]["row_count"] == 7
-    assert pm["2026-04"]["total_hours"] == 66.0
+    assert pm["2026-04"]["row_count"] == 9
+    assert pm["2026-04"]["total_hours"] == 74.0
     assert pm["2026-05"]["row_count"] == 2
     assert pm["2026-05"]["total_hours"] == 16.0
-    assert generated["grand_total_hours"] == 82.0
+    assert generated["grand_total_hours"] == 90.0
 
 
 # 12 ─ Preflight passes (no inlineStr/ns0/calcChain/external links) ──
@@ -275,3 +277,21 @@ def test_override_beats_worked_project_in_bonita_resolver(tmp_path):
     assert len(zulu) == 1
     assert zulu[0].total_hours == 8.0
     assert zulu[0].project_name == "Northwell - Neurons"
+
+
+def test_client_coordination_outside_allowlist_reviewed(resolution):
+    kilo = [r for r in resolution.review if r.tech == "Kilo Tech"
+            and r.category == "client_coordination_outside_allowlist"]
+    assert len(kilo) == 1
+    assert not [s for s in resolution.shifts if s.tech == "Kilo Tech"]
+
+
+def test_mixed_assignment_split(resolution):
+    mixed = [s for s in resolution.shifts if s.tech == "Mixed Tech"]
+    assert len(mixed) == 2
+    types = {s.assignment_type for s in mixed}
+    assert "Inventory Management" in types
+    assert "Configurations" in types
+    assert round(sum(s.total_hours for s in mixed), 2) == 8.0
+    split_review = [r for r in resolution.review if r.category == "mixed_assignment_split"]
+    assert len(split_review) == 1

--- a/tests/test_nw_prj_neuron_track_hours_repairfree_profile.py
+++ b/tests/test_nw_prj_neuron_track_hours_repairfree_profile.py
@@ -1,0 +1,110 @@
+"""Repair-free Bonita-format Neuron Track Hours profile gate tests."""
+from __future__ import annotations
+
+import importlib
+import json
+import zipfile
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from triage.nw_prj_neuron_track_hours.bonita_cli import run
+from triage.nw_prj_neuron_track_hours.repairfree_profile_gate import (
+    load_repairfree_profile,
+    run_repairfree_profile_gate,
+)
+from tests.fixtures.nw_prj_neuron_track_hours.bonita_fixtures import build_bonita_fixtures
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_DIR = REPO_ROOT / "tests" / "fixtures" / "nw_prj_neuron_track_hours"
+PROFILE_PATH = REPO_ROOT / "tests" / "fixtures" / "nw_prj_neuron_track_hours_repairfree" / "golden_profile.json"
+MONTHS = ["2026-04", "2026-05"]
+
+
+@pytest.fixture(scope="module")
+def fixtures():
+    return build_bonita_fixtures(FIXTURE_DIR)
+
+
+@pytest.fixture(scope="module")
+def generated(fixtures, tmp_path_factory):
+    out = tmp_path_factory.mktemp("repairfree_out")
+    return run(
+        roster_log=str(fixtures["roster"]),
+        out_dir=str(out),
+        months=MONTHS,
+        websafe=True,
+        reference_profile=str(PROFILE_PATH),
+        repo_root=REPO_ROOT,
+    )
+
+
+def test_cli_imports():
+    mod = importlib.import_module("triage.nw_prj_neuron_track_hours.bonita_cli")
+    assert hasattr(mod, "run")
+
+
+def test_golden_profile_json_valid():
+    profile = load_repairfree_profile(PROFILE_PATH)
+    assert profile["profile"] == "neuron_track_hours_repairfree_golden"
+    assert "Apr 26" in profile["required_sheets"]
+    assert profile["header_row2"][0] == "DATE"
+
+
+def test_generated_workbook_passes_profile_gate(generated):
+    wb_path = generated["outputs"]["workbook"]
+    gate = run_repairfree_profile_gate(wb_path, PROFILE_PATH)
+    assert gate["profile_pass"] is True, gate.get("profile_failures")
+
+
+def test_preflight_includes_repairfree_profile(generated):
+    pf = generated["preflight_data"]
+    assert pf.get("repairfree_profile_pass") is True
+
+
+def test_month_sheet_headers_match_profile(generated):
+    profile = load_repairfree_profile(PROFILE_PATH)
+    wb = openpyxl.load_workbook(generated["outputs"]["workbook"], read_only=True)
+    ws = wb["Apr 26"]
+    assert ws.cell(1, 2).value == profile["header_row1"][1]
+    assert ws.cell(2, 1).value == "DATE"
+    wb.close()
+
+
+def test_month_sheet_uses_columns_a_through_g_only(generated):
+    wb = openpyxl.load_workbook(generated["outputs"]["workbook"], read_only=True)
+    ws = wb["Apr 26"]
+    assert ws.max_column <= 7
+    wb.close()
+
+
+def test_no_formulas_in_month_sheets(generated):
+    wb = openpyxl.load_workbook(generated["outputs"]["workbook"], data_only=False)
+    for name in ("Apr 26", "May 26"):
+        ws = wb[name]
+        for row in ws.iter_rows(min_row=3, max_row=ws.max_row, min_col=1, max_col=7):
+            for cell in row:
+                assert getattr(cell, "data_type", None) != "f"
+    wb.close()
+
+
+def test_package_has_no_calc_chain_or_external_links(generated):
+    path = generated["outputs"]["workbook"]
+    with zipfile.ZipFile(path, "r") as z:
+        names = z.namelist()
+    assert "xl/calcChain.xml" not in names
+    assert not any("externalLink" in n for n in names)
+
+
+def test_websafe_alias_emitted(generated, tmp_path_factory):
+    out = Path(generated["outputs"]["workbook"]).parent
+    alias = out / "Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx"
+    assert alias.is_file()
+
+
+def test_sidecars_emitted(generated):
+    out = Path(generated["outputs"]["workbook"]).parent
+    assert (out / "Neuron_Track_Hours_April_May_2026_manifest.json").is_file()
+    assert (out / "Neuron_Track_Hours_April_May_2026_review_queue.csv").is_file()
+    assert (out / "Neuron_Track_Hours_April_May_2026_preflight.json").is_file()

--- a/triage/nw_prj_neuron_track_hours/bonita_cli.py
+++ b/triage/nw_prj_neuron_track_hours/bonita_cli.py
@@ -163,6 +163,7 @@ def run(
     websafe: bool = True,
     repo_root: Optional[Path] = None,
     reference: Optional[str] = None,
+    reference_profile: Optional[str] = None,
     artifact_profile: str = "bonita_neuron_track_hours",
     approved_delta: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -185,12 +186,32 @@ def run(
     resolution = resolve_bonita_shifts(str(roster_path), months)
 
     xlsx_path = out / WORKBOOK_NAME
-    _, tabs = build_bonita_workbook(resolution, months, str(xlsx_path))
+    profile_path = _resolve(reference_profile, root)
+    _, tabs = build_bonita_workbook(
+        resolution,
+        months,
+        str(xlsx_path),
+        profile_path=str(profile_path) if profile_path else None,
+    )
 
     review_path = out / REVIEW_NAME
     _write_review_queue_csv(review_path, resolution)
 
     preflight = preflight_bonita(str(xlsx_path)) if websafe else {}
+    if websafe and profile_path and profile_path.is_file():
+        from triage.nw_prj_neuron_track_hours.repairfree_profile_gate import (
+            run_repairfree_profile_gate,
+        )
+        profile_gate = run_repairfree_profile_gate(str(xlsx_path), profile_path)
+        preflight["repairfree_profile"] = profile_gate.get("profile")
+        preflight["repairfree_profile_pass"] = profile_gate.get("profile_pass")
+        preflight["repairfree_profile_failures"] = profile_gate.get("profile_failures", [])
+        if not profile_gate.get("profile_pass"):
+            preflight["preflight_pass"] = False
+    elif websafe and profile_path:
+        preflight["repairfree_profile_pass"] = False
+        preflight["repairfree_profile_failures"] = ["reference_profile_not_found"]
+        preflight["preflight_pass"] = False
     preflight_path = out / PREFLIGHT_NAME
     preflight_path.write_text(json.dumps(preflight, indent=2, default=str), encoding="utf-8")
 
@@ -245,6 +266,7 @@ def run(
         "websafe_preflight_pass": bool(preflight.get("preflight_pass")) if websafe else None,
         "preflight_data": preflight if websafe else {},
         "reference": str(reference_path) if reference_path else "",
+        "reference_profile": str(profile_path) if profile_path else "",
         "artifact_profile": artifact_profile if reference_path else "",
         "warnings": resolution.warnings,
         "outputs": {
@@ -303,6 +325,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     ap.add_argument("--out-dir", default="Outputs/neuron_track_hours_2026_06_02")
     ap.add_argument("--reference", help="Approved reference workbook for artifact_compare")
     ap.add_argument(
+        "--reference-profile",
+        default="configs/artifact_profiles/neuron_track_hours_repairfree_golden.json",
+        help="Repair-free golden profile JSON for structural gate",
+    )
+    ap.add_argument(
         "--artifact-profile",
         default="bonita_neuron_track_hours",
     )
@@ -319,6 +346,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         template=args.template,
         websafe=args.websafe,
         reference=args.reference,
+        reference_profile=args.reference_profile,
         artifact_profile=args.artifact_profile,
         approved_delta=args.approved_delta,
     )

--- a/triage/nw_prj_neuron_track_hours/bonita_exporter.py
+++ b/triage/nw_prj_neuron_track_hours/bonita_exporter.py
@@ -1,35 +1,38 @@
-"""Build the clean, submission-grade Bonita Neuron Track Hours workbook.
+"""Build the clean, submission-grade Bonita-format Neuron Track Hours workbook.
 
-Exactly two tabs (``Apr 26`` / ``May 26``), two-line headers, one row per
-included shift, values only (no formulas, no notes/commentary). Reuses the
-proven private inlineStr repair from ``exporter`` for Web Excel safety.
+Three tabs (``Apr 26`` / ``May 26`` / ``Rules & Legend``), two-line headers,
+one row per included shift, values only. Layout follows the repair-free golden
+profile (``configs/artifact_profiles/neuron_track_hours_repairfree_golden.json``).
 """
 from __future__ import annotations
 
+import shutil
 from datetime import date
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from triage.nw_prj_neuron_track_hours.bonita_resolver import BonitaResolution, BonitaShift
 from triage.nw_prj_neuron_track_hours.exporter import _repair_inlinestr
+from triage.nw_prj_neuron_track_hours.repairfree_profile_gate import (
+    default_profile_path,
+    load_repairfree_profile,
+)
 
-# Two-line column headers matching the "Mon YY" reference tracker tab. Column A
-# is the day/date locator and intentionally has no header text (the weekday name
-# and date are stacked there per date group, exactly like the reference).
+WEBSAFE_ALIAS_NAME = "Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx"
+
+# Backward-compatible header constants (profile JSON is authoritative).
 HEADER_TOP = ["", "TECH", "START", "END", "TOTAL", "PROJECT", "ASSIGNMENT"]
-HEADER_BOTTOM = ["", "NAME", "TIME", "TIME", "HOURS", "NAME", "TYPE"]
+HEADER_BOTTOM = ["DATE", "NAME", "TIME", "TIME", "HOURS", "NAME", "TYPE"]
 
-_MONTH_ABBR = {1: "Jan", 2: "Feb", 3: "Mar", 4: "Apr", 5: "May", 6: "Jun",
-               7: "Jul", 8: "Aug", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dec"}
-
-_HEADER_FILL = "1F365C"
-# Excel number formats matching the reference tracker.
+_MONTH_ABBR = {
+    1: "Jan", 2: "Feb", 3: "Mar", 4: "Apr", 5: "May", 6: "Jun",
+    7: "Jul", 8: "Aug", 9: "Sep", 10: "Oct", 11: "Nov", 12: "Dec",
+}
 _TIME_FMT = "h:mm AM/PM"
 _DATE_FMT = "mm-dd-yy"
 
 
 def tab_name_for_month_key(month_key: str) -> str:
-    """'2026-04' -> 'Apr 26'."""
     year, mon = month_key.split("-")[0], int(month_key.split("-")[1])
     return f"{_MONTH_ABBR[mon]} {year[-2:]}"
 
@@ -42,11 +45,6 @@ def _require_openpyxl():
 
 
 def _group_locators(shifts: List[BonitaShift]) -> List[object]:
-    """Column-A locator per row: weekday name on the first row of a date group,
-    the date value on the second row, blank thereafter (reference layout).
-
-    Single-row date groups get the date directly so the date is never dropped.
-    """
     locators: List[object] = []
     n = len(shifts)
     i = 0
@@ -65,17 +63,24 @@ def _group_locators(shifts: List[BonitaShift]) -> List[object]:
     return locators
 
 
-def _write_month_tab(wb, tab: str, shifts: List[BonitaShift]) -> None:
+def _write_month_tab(wb, tab: str, shifts: List[BonitaShift], profile: Dict[str, Any]) -> None:
     Workbook, Alignment, Font, PatternFill, get_column_letter = _require_openpyxl()
     ws = wb.create_sheet(tab)
-    fill = PatternFill("solid", fgColor=_HEADER_FILL)
-    for c, (top, bottom) in enumerate(zip(HEADER_TOP, HEADER_BOTTOM), 1):
+    fill1 = PatternFill("solid", fgColor=profile.get("header_fill_row1", "1F4E78"))
+    fill2 = PatternFill("solid", fgColor=profile.get("header_fill_row2", "5B9BD5"))
+    h1 = profile.get("header_row1") or HEADER_TOP
+    h2 = profile.get("header_row2") or HEADER_BOTTOM
+    asn_fills = profile.get("assignment_fills") or {}
+
+    for c, (top, bottom) in enumerate(zip(h1, h2), 1):
         t = ws.cell(row=1, column=c, value=top)
         b = ws.cell(row=2, column=c, value=bottom)
-        for cell in (t, b):
-            cell.font = Font(bold=True, color="FFFFFF")
-            cell.fill = fill
-            cell.alignment = Alignment(horizontal="center")
+        t.font = Font(bold=True, color="FFFFFF")
+        t.fill = fill1
+        t.alignment = Alignment(horizontal="center")
+        b.font = Font(bold=True, color="FFFFFF")
+        b.fill = fill2
+        b.alignment = Alignment(horizontal="center")
 
     bold = Font(bold=True)
     locators = _group_locators(shifts)
@@ -86,8 +91,6 @@ def _write_month_tab(wb, tab: str, shifts: List[BonitaShift]) -> None:
             a.number_format = _DATE_FMT
 
         tech = ws.cell(row=r_idx, column=2, value=shift.tech)
-
-        # Real time cells (h:mm AM/PM) when available, else the display string.
         if shift.start_time is not None:
             si = ws.cell(row=r_idx, column=3, value=shift.start_time)
             si.number_format = _TIME_FMT
@@ -103,20 +106,43 @@ def _write_month_tab(wb, tab: str, shifts: List[BonitaShift]) -> None:
         tot.number_format = "0.00"
         proj = ws.cell(row=r_idx, column=6, value=shift.project_name)
         asn = ws.cell(row=r_idx, column=7, value=shift.assignment_type)
+        fill_hex = asn_fills.get(shift.assignment_type)
+        if fill_hex:
+            asn.fill = PatternFill("solid", fgColor=fill_hex)
         for cell in (tech, si, so, tot, proj, asn):
             cell.font = bold
 
-    widths = [14, 27, 12, 12, 11, 22, 28]
+    widths = profile.get("column_widths") or [12, 22, 12, 12, 10, 22, 32]
     for c, w in enumerate(widths, 1):
         ws.column_dimensions[get_column_letter(c)].width = w
+    ws.freeze_panes = profile.get("freeze_panes") or "A3"
+
+
+def _write_rules_legend_tab(wb, profile: Dict[str, Any]) -> None:
+    Workbook, Alignment, Font, PatternFill, get_column_letter = _require_openpyxl()
+    name = profile.get("legend_sheet") or "Rules & Legend"
+    ws = wb.create_sheet(name)
+    fill1 = PatternFill("solid", fgColor=profile.get("header_fill_row1", "1F4E78"))
+    rows = profile.get("legend_rows") or []
+    for r_idx, row in enumerate(rows, 1):
+        for c_idx, val in enumerate(row[:2], 1):
+            cell = ws.cell(row=r_idx, column=c_idx, value=val)
+            if r_idx == 1:
+                cell.font = Font(bold=True, color="FFFFFF")
+                cell.fill = fill1
+    ws.column_dimensions["A"].width = 60
+    ws.column_dimensions["B"].width = 22
+    ws.freeze_panes = profile.get("freeze_panes") or "A3"
 
 
 def build_bonita_workbook(
     resolution: BonitaResolution,
     months: List[str],
     out_path: str,
+    profile_path: Optional[str] = None,
+    emit_websafe_alias: bool = True,
 ) -> Tuple[str, List[Tuple[str, str]]]:
-    """Write the two-tab workbook. Returns (path, [(month_key, tab_name)...])."""
+    profile = load_repairfree_profile(profile_path or default_profile_path())
     Workbook, *_ = _require_openpyxl()
     wb = Workbook()
     wb.remove(wb.active)
@@ -130,10 +156,16 @@ def build_bonita_workbook(
         _, _, mon = _month_label(mk)
         short = month_name[mon]
         shifts = resolution.shifts_for_month(short)
-        _write_month_tab(wb, tab, shifts)
+        _write_month_tab(wb, tab, shifts, profile)
         tabs.append((mk, tab))
+
+    _write_rules_legend_tab(wb, profile)
 
     Path(out_path).parent.mkdir(parents=True, exist_ok=True)
     wb.save(out_path)
     _repair_inlinestr(out_path)
+
+    if emit_websafe_alias:
+        shutil.copy2(out_path, Path(out_path).parent / WEBSAFE_ALIAS_NAME)
+
     return out_path, tabs

--- a/triage/nw_prj_neuron_track_hours/bonita_resolver.py
+++ b/triage/nw_prj_neuron_track_hours/bonita_resolver.py
@@ -33,7 +33,9 @@ from pathlib import Path
 from typing import Dict, List, Optional
 
 from triage.neuron_work_context_rules import (
+    CLIENT_COORDINATION,
     CONFIGURATIONS,
+    INVENTORY_MANAGEMENT,
     LOGISTICS,
     classify_neuron_work_context,
 )
@@ -71,9 +73,153 @@ EXCLUDED_NAMES = {"yostinn minaya", "steven marques", "inventory"}
 # Non-work markers (whole-cell text instead of a punch time).
 _NON_WORK_MARKER = re.compile(
     r"^\s*(pto|non[\s-]*pto|n/?a|out\s*sick|sick|vacation|off\b.*|holiday|"
-    r"unpaid|leave|absent)\s*$",
+    r"unpaid|leave|absent|car\s*issue|off\s*/\s*car\s*issue)\s*$",
     re.IGNORECASE,
 )
+
+# Client Coordination may appear on the submission sheet only for approved coordinators.
+CLIENT_COORDINATION_ALLOWLIST = frozenset({
+    "richard perez",
+    "rich perez",
+    "khadejah harrison",
+    "alejandro perales",
+})
+
+TECH_DISPLAY_ALIASES: Dict[str, str] = {
+    "rich perez": "Richard Perez",
+    "eman": "Emmanuel Perales",
+    "emmanuel perales": "Emmanuel Perales",
+    "suhan": "Md Suhan Newaz",
+    "md suhan newaz": "Md Suhan Newaz",
+    "val": "Valentin Nikoliuch",
+    "valentin nikoliuch": "Valentin Nikoliuch",
+}
+
+_MIXED_INV_CONFIG_NOTE = re.compile(
+    r"(inventory|stock|warehouse|recon).*(config|configuration|image|baseline)|"
+    r"(config|configuration|image|baseline).*(inventory|stock|warehouse|recon)",
+    re.IGNORECASE,
+)
+
+
+def normalize_tech_display(name: str) -> str:
+    key = name.strip().lower()
+    return TECH_DISPLAY_ALIASES.get(key, name.strip())
+
+
+def _client_coordination_allowed(tech: str) -> bool:
+    return tech.strip().lower() in CLIENT_COORDINATION_ALLOWLIST
+
+
+def _notes_indicate_mixed_inv_config(note: str) -> bool:
+    return bool(note and _MIXED_INV_CONFIG_NOTE.search(note))
+
+
+def _append_shift_or_split(
+    resolution: BonitaResolution,
+    *,
+    month_key: str,
+    short: str,
+    d: date,
+    day: str,
+    staff: str,
+    ci,
+    co,
+    gross: float,
+    note: str,
+    cell_ref: str,
+    worked_label: str,
+    assign_label: str,
+    resolved: str,
+    decision,
+) -> None:
+    """Include shift row(s), applying mixed inventory/configuration split when needed."""
+    long_shift = gross >= LONG_SHIFT_HOURS
+    base_kwargs = dict(
+        month_key=month_key,
+        month_name=short,
+        date=d,
+        day=day,
+        tech=staff,
+        clock_in=_format_clock(ci),
+        clock_out=_format_clock(co),
+        project_name=NEURON_DISPLAY_NAME,
+        note=note,
+        long_shift=long_shift,
+        start_time=_decimal_to_time(ci),
+        end_time=_decimal_to_time(co),
+        assignment_rule=decision.rule,
+        assignment_confidence=decision.confidence,
+    )
+
+    if _notes_indicate_mixed_inv_config(note):
+        half = round(gross / 2, 2)
+        remainder = round(gross - half, 2)
+        resolution.shifts.append(BonitaShift(
+            **base_kwargs,
+            total_hours=half,
+            assignment_type=INVENTORY_MANAGEMENT,
+        ))
+        resolution.shifts.append(BonitaShift(
+            **base_kwargs,
+            total_hours=remainder,
+            assignment_type=CONFIGURATIONS,
+        ))
+        resolution.review.append(BonitaReviewItem(
+            category="mixed_assignment_split",
+            month_name=short,
+            date=d,
+            day=day,
+            tech=staff,
+            clock_in=_format_clock(ci),
+            clock_out=_format_clock(co),
+            total_hours=gross,
+            project=NEURON_DISPLAY_NAME,
+            note=note,
+            source_cell=cell_ref,
+            detail=(
+                f"split {gross:g}h -> {half:g}h Inventory Management + "
+                f"{remainder:g}h Configurations"
+            ),
+        ))
+        return
+
+    resolution.shifts.append(BonitaShift(
+        **base_kwargs,
+        total_hours=gross,
+        assignment_type=decision.assignment_type,
+    ))
+
+    if long_shift:
+        resolution.review.append(BonitaReviewItem(
+            category="long_shift",
+            month_name=short,
+            date=d,
+            day=day,
+            tech=staff,
+            clock_in=_format_clock(ci),
+            clock_out=_format_clock(co),
+            total_hours=gross,
+            project=NEURON_DISPLAY_NAME,
+            note=note,
+            source_cell=cell_ref,
+            detail=f"long shift {gross:g}h included; verify",
+        ))
+    if decision.confidence == "low":
+        resolution.review.append(BonitaReviewItem(
+            category="assignment_heuristic_low_confidence",
+            month_name=short,
+            date=d,
+            day=day,
+            tech=staff,
+            clock_in=_format_clock(ci),
+            clock_out=_format_clock(co),
+            total_hours=gross,
+            project=NEURON_DISPLAY_NAME,
+            note="",
+            source_cell=cell_ref,
+            detail=f"assignment resolved by heuristic rule: {decision.rule}",
+        ))
 
 
 @dataclass
@@ -231,7 +377,7 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
             continue
         if isinstance(staff_val, (int, float)):
             continue
-        staff = str(staff_val).strip()
+        staff = normalize_tech_display(str(staff_val).strip())
         default_proj = str(live_ws.cell(r, 2).value or "").strip()
         if default_proj == "0":
             default_proj = ""
@@ -315,58 +461,44 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                 worked_label=worked_label or assign_label,
                 resolved_project=resolved,
             )
-            long_shift = gross >= LONG_SHIFT_HOURS
 
-            shift = BonitaShift(
-                month_key=month_key,
-                month_name=short,
-                date=d,
-                day=day,
-                tech=staff,
-                clock_in=_format_clock(ci),
-                clock_out=_format_clock(co),
-                total_hours=gross,
-                project_name=NEURON_DISPLAY_NAME,
-                assignment_type=decision.assignment_type,
-                note=note,
-                long_shift=long_shift,
-                start_time=_decimal_to_time(ci),
-                end_time=_decimal_to_time(co),
-                assignment_rule=decision.rule,
-                assignment_confidence=decision.confidence,
-            )
-            resolution.shifts.append(shift)
-
-            if long_shift:
+            if (
+                decision.assignment_type == CLIENT_COORDINATION
+                and not _client_coordination_allowed(staff)
+            ):
                 resolution.review.append(BonitaReviewItem(
-                    category="long_shift",
+                    category="client_coordination_outside_allowlist",
                     month_name=short,
                     date=d,
                     day=day,
                     tech=staff,
-                    clock_in=shift.clock_in,
-                    clock_out=shift.clock_out,
+                    clock_in=_format_clock(ci),
+                    clock_out=_format_clock(co),
                     total_hours=gross,
                     project=NEURON_DISPLAY_NAME,
                     note=note,
                     source_cell=cell_ref,
-                    detail=f"long shift {gross:g}h included; verify",
+                    detail="Client Coordination not allowed for this tech; excluded from workbook",
                 ))
-            if decision.confidence == "low":
-                resolution.review.append(BonitaReviewItem(
-                    category="assignment_heuristic_low_confidence",
-                    month_name=short,
-                    date=d,
-                    day=day,
-                    tech=staff,
-                    clock_in=shift.clock_in,
-                    clock_out=shift.clock_out,
-                    total_hours=gross,
-                    project=NEURON_DISPLAY_NAME,
-                    note="",
-                    source_cell=cell_ref,
-                    detail=f"assignment resolved by heuristic rule: {decision.rule}",
-                ))
+                continue
+
+            _append_shift_or_split(
+                resolution,
+                month_key=month_key,
+                short=short,
+                d=d,
+                day=day,
+                staff=staff,
+                ci=ci,
+                co=co,
+                gross=gross,
+                note=note,
+                cell_ref=cell_ref,
+                worked_label=worked_label,
+                assign_label=assign_label,
+                resolved=resolved,
+                decision=decision,
+            )
 
 
 def resolve_bonita_shifts(

--- a/triage/nw_prj_neuron_track_hours/repairfree_profile_gate.py
+++ b/triage/nw_prj_neuron_track_hours/repairfree_profile_gate.py
@@ -1,0 +1,167 @@
+"""Structural gate for repair-free Bonita-format Neuron Track Hours workbooks."""
+from __future__ import annotations
+
+import json
+import zipfile
+from datetime import date, datetime, time
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+_FORMULA_ERRORS = ("#REF!", "#VALUE!", "#NAME?", "#DIV/0!", "#NULL!", "#NUM!", "#N/A")
+_DEFAULT_PROFILE = (
+    Path(__file__).resolve().parent.parent.parent
+    / "configs"
+    / "artifact_profiles"
+    / "neuron_track_hours_repairfree_golden.json"
+)
+
+
+def load_repairfree_profile(path: Optional[str | Path] = None) -> Dict[str, Any]:
+    p = Path(path) if path else _DEFAULT_PROFILE
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def default_profile_path() -> Path:
+    return _DEFAULT_PROFILE
+
+
+def _cell_str(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _is_numeric_like(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, (int, float, datetime, date, time)):
+        return True
+    if isinstance(value, str):
+        try:
+            float(value)
+            return True
+        except ValueError:
+            return False
+    return False
+
+
+def run_repairfree_profile_gate(
+    workbook_path: str | Path,
+    profile_path: Optional[str | Path] = None,
+) -> Dict[str, Any]:
+    profile = load_repairfree_profile(profile_path)
+    path = Path(workbook_path)
+    failures: List[str] = []
+
+    if not path.is_file():
+        return {
+            "profile": profile.get("profile"),
+            "profile_pass": False,
+            "profile_failures": ["file_not_found"],
+        }
+
+    pkg = profile.get("package_stop_ship") or {}
+    try:
+        with zipfile.ZipFile(path, "r") as z:
+            if z.testzip() is not None:
+                failures.append("zip_testzip_failed")
+            names = z.namelist()
+            all_text = ""
+            for name in names:
+                if name.endswith((".xml", ".rels")):
+                    all_text += z.read(name).decode("utf-8", errors="ignore")
+            if pkg.get("no_calc_chain") and "xl/calcChain.xml" in names:
+                failures.append("calc_chain_present")
+            if pkg.get("no_external_links") and any("externalLink" in n for n in names):
+                failures.append("external_links_present")
+            if pkg.get("no_vba") and "xl/vbaProject.bin" in names:
+                failures.append("vba_present")
+            if pkg.get("no_formula_error_tokens"):
+                for tok in _FORMULA_ERRORS:
+                    if tok in all_text:
+                        failures.append(f"formula_error_token:{tok}")
+            if pkg.get("no_inline_str"):
+                for name in names:
+                    if name.startswith("xl/worksheets/sheet") and name.endswith(".xml"):
+                        ws_text = z.read(name).decode("utf-8", errors="ignore")
+                        if 't="inlineStr"' in ws_text:
+                            failures.append("inlineStr_present")
+                            break
+    except zipfile.BadZipFile:
+        return {
+            "profile": profile.get("profile"),
+            "profile_pass": False,
+            "profile_failures": failures + ["bad_zip"],
+        }
+
+    import openpyxl
+
+    wb = openpyxl.load_workbook(path, data_only=False)
+    try:
+        for sheet in profile.get("required_sheets") or []:
+            if sheet not in wb.sheetnames:
+                failures.append(f"missing_sheet:{sheet}")
+
+        month_tabs = profile.get("month_sheet_names") or []
+        h1 = profile.get("header_row1") or []
+        h2 = profile.get("header_row2") or []
+        allowed_asn = set(profile.get("allowed_assignment_types") or [])
+        freeze = profile.get("freeze_panes") or "A3"
+
+        for tab in month_tabs:
+            if tab not in wb.sheetnames:
+                continue
+            ws = wb[tab]
+            if ws.freeze_panes != freeze:
+                failures.append(f"{tab}:freeze_panes_not_{freeze}")
+
+            for col_idx, (top, bottom) in enumerate(zip(h1, h2), 1):
+                if _cell_str(ws.cell(row=1, column=col_idx).value) != _cell_str(top):
+                    failures.append(f"{tab}:header_row1_col{col_idx}_mismatch")
+                if _cell_str(ws.cell(row=2, column=col_idx).value) != _cell_str(bottom):
+                    failures.append(f"{tab}:header_row2_col{col_idx}_mismatch")
+
+            if ws.max_column > 7:
+                failures.append(f"{tab}:columns_beyond_G")
+
+            if pkg.get("no_merged_cells_in_month_sheets") and ws.merged_cells.ranges:
+                failures.append(f"{tab}:merged_cells_present")
+
+            if pkg.get("no_conditional_formatting_in_month_sheets") and ws.conditional_formatting:
+                failures.append(f"{tab}:conditional_formatting_present")
+
+            for row in ws.iter_rows(min_row=3, max_row=ws.max_row, min_col=1, max_col=7):
+                vals = [c.value for c in row]
+                if all(v is None or str(v).strip() == "" for v in vals):
+                    continue
+                if pkg.get("no_formulas_in_month_sheets"):
+                    for c in row:
+                        if getattr(c, "data_type", None) == "f":
+                            failures.append(f"{tab}:formula_at_{c.coordinate}")
+                            break
+                tech, start, end, hours, project, asn = vals[1:7]
+                if not _cell_str(tech):
+                    failures.append(f"{tab}:blank_tech_row")
+                if start is None or (isinstance(start, str) and not start.strip()):
+                    failures.append(f"{tab}:blank_start")
+                if end is None or (isinstance(end, str) and not end.strip()):
+                    failures.append(f"{tab}:blank_end")
+                if hours is None:
+                    failures.append(f"{tab}:blank_hours")
+                elif not _is_numeric_like(hours):
+                    failures.append(f"{tab}:non_numeric_hours")
+                if not _cell_str(project):
+                    failures.append(f"{tab}:blank_project")
+                asn_s = _cell_str(asn)
+                if not asn_s:
+                    failures.append(f"{tab}:blank_assignment")
+                elif allowed_asn and asn_s not in allowed_asn:
+                    failures.append(f"{tab}:assignment_not_allowed:{asn_s}")
+    finally:
+        wb.close()
+
+    return {
+        "profile": profile.get("profile"),
+        "profile_pass": len(failures) == 0,
+        "profile_failures": failures,
+    }

--- a/triage/webexcel_semantic_gate.py
+++ b/triage/webexcel_semantic_gate.py
@@ -168,16 +168,17 @@ def _check_admin_billing_sentinels(path: str, tabs: List[str]) -> List[str]:
 
 
 def _check_bonita_sentinels(path: str, tabs: List[str]) -> List[str]:
-    """Return list of sentinel failure descriptions for Bonita workbooks."""
+    """Return list of sentinel failure descriptions for Bonita month tabs."""
     try:
         import openpyxl
     except ImportError:
         return ["openpyxl_not_installed"]
 
-    data_tabs = [t for t in tabs if t not in _META_TABS]
+    month_tab_re = re.compile(r"^[A-Za-z]{3} \d{2}$")
+    data_tabs = [t for t in tabs if month_tab_re.match(t)]
     failures: List[str] = []
     if len(data_tabs) < 2:
-        failures.append(f"expected_at_least_2_data_tabs:got_{len(data_tabs)}")
+        failures.append(f"expected_at_least_2_month_tabs:got_{len(data_tabs)}")
 
     try:
         wb = openpyxl.load_workbook(path, data_only=True, read_only=True)


### PR DESCRIPTION
## **User description**
## Summary

- Harden the existing **Bonita-format Neuron Track Hours** path (`bonita_cli` / `bonita_exporter` / `bonita_resolver`) against a sanitized **repair-free golden structural profile**—no second engine.
- Add `Rules & Legend`, profile-driven headers/widths/fills/freeze (`A3`), and a WEBSAFE filename alias.
- Add `repairfree_profile_gate` plus `--reference-profile` preflight wiring; extend resolver with client-coordination allowlist, mixed inventory/configuration split, and tech display aliases.
- Extend fixture-only tests (30 cases) and register repairfree tests in `artifact-engines.yml`.

## Test plan

- [x] `pytest tests/test_nw_prj_neuron_track_hours_bonita.py tests/test_nw_prj_neuron_track_hours_repairfree_profile.py -q` (30 passed locally)
- [x] `python -m triage.gitignore_hygiene`
- [ ] CI `artifact-engines` workflow on this branch
- [ ] Operator: place `Candidates/reference_artifacts/Neuron_Track_Hours_RepairFree_Emulation_Package.zip` locally and run:
  ```powershell
  python -m triage.nw_prj_neuron_track_hours.bonita_cli `
    --roster-log "Candidates\<active roster>.xlsx" `
    --reference-profile configs/artifact_profiles/neuron_track_hours_repairfree_golden.json `
    --months 2026-04 2026-05 `
    --out-dir Outputs/neuron_track_hours_validate `
    --websafe
  ```
- [ ] Review `*_preflight.json` (`repairfree_profile_pass`), `*_review_queue.csv`, and `index.html` under `Outputs/` (gitignored)
- [ ] Manual Excel for Web open/upload on generated WEBSAFE workbook (**NOT_PROVEN** in CI)

## Known gaps / risks

| Item | Notes |
|------|--------|
| Golden zip | Not committed; operator-local under `Candidates/**` |
| Excel for Web | Manual proof only |
| Structural gate | Does not replace billing/submission approval; sidecars still required |
| Full `pytest tests/` | Only targeted bonita + repairfree modules run in this PR |

## Outputs to analyze (operator, gitignored)

- `Bonita_Neuron_Track_Hours_April_May_2026.xlsx`
- `Neuron_Track_Hours_April_May_2026_WEBSAFE.xlsx`
- `*_manifest.json`, `*_preflight.json`, `*_review_queue.csv`, `index.html`


___

## **CodeAnt-AI Description**
**Make Bonita Neuron Track Hours follow the repair-free golden profile**

### What Changed
- The workbook now includes a `Rules & Legend` sheet and matches the repair-free golden layout for month tabs, including header text, column widths, freeze position, and assignment-based fill colors.
- The export now creates a WEBSAFE workbook alias and includes the repair-free profile result in the preflight output; if the workbook does not match the profile, preflight fails.
- The resolver now keeps approved Client Coordination shifts, excludes unapproved ones, recognizes mixed inventory/configuration notes as split shifts, and normalizes several tech display names.
- The generated workbook no longer allows formulas, external links, calc chains, or extra columns on month sheets under the repair-free gate.

### Impact
`✅ Fewer workbook rejections during submission`
`✅ Clearer month-sheet layout for review`
`✅ Correct handling of Client Coordination and mixed work entries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
