### PR TITLE
feat(triage): add workbook package hygiene validator and clipboard record

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; import triage.workbook_package_hygiene; print('imports ok')"
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
@@ -51,4 +51,5 @@ jobs:
             tests/test_same_family_compare.py \
             tests/test_gitignore_hygiene.py \
             tests/test_roster_log_review_queue.py \
+            tests/test_workbook_package_hygiene.py \
             -q

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -22,21 +22,18 @@ jobs:
         run: python -m pip install pytest
 
       - name: Import workbook package validators
-        run: |
-          python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; import triage.prompt_kit_contract; print('workbook package validators import ok')"
+        run: python -c "import triage.workbook_package_hygiene; import triage.prompt_kit_contract; print('workbook validators import ok')"
 
       - name: Run workbook package hygiene tests
         run: |
           python -m pytest \
             tests/test_workbook_package_hygiene.py \
-            tests/test_copy_surface_bounds.py \
             tests/test_prompt_kit_contract.py \
             -q
 
       - name: Verify workbook package validator CLIs
         run: |
           python -m triage.workbook_package_hygiene --help
-          python -m triage.copy_surface_bounds --help
           python -m triage.prompt_kit_contract --help
 
   artifact-engines:

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -6,6 +6,30 @@ on:
     branches: [main]
 
 jobs:
+  workbook-package-hygiene:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Import workbook package hygiene validator
+        run: python -c "import triage.workbook_package_hygiene; print('workbook package hygiene import ok')"
+
+      - name: Run workbook package hygiene tests
+        run: python -m pytest tests/test_workbook_package_hygiene.py -q
+
+      - name: Verify workbook package hygiene CLI
+        run: python -m triage.workbook_package_hygiene --help
+
   artifact-engines:
     runs-on: ubuntu-latest
 
@@ -30,13 +54,10 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; import triage.workbook_package_hygiene; print('imports ok')"
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
-
-      - name: Run workbook package hygiene tests
-        run: python -m pytest tests/test_workbook_package_hygiene.py -q
 
       - name: Run artifact engine tests
         run: |

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -23,19 +23,21 @@ jobs:
 
       - name: Import workbook package validators
         run: |
-          python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; print('workbook package validators import ok')"
+          python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; import triage.prompt_kit_contract; print('workbook package validators import ok')"
 
       - name: Run workbook package hygiene tests
         run: |
           python -m pytest \
             tests/test_workbook_package_hygiene.py \
             tests/test_copy_surface_bounds.py \
+            tests/test_prompt_kit_contract.py \
             -q
 
       - name: Verify workbook package validator CLIs
         run: |
           python -m triage.workbook_package_hygiene --help
           python -m triage.copy_surface_bounds --help
+          python -m triage.prompt_kit_contract --help
 
   artifact-engines:
     runs-on: ubuntu-latest

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -21,14 +21,21 @@ jobs:
       - name: Install test dependency
         run: python -m pip install pytest
 
-      - name: Import workbook package hygiene validator
-        run: python -c "import triage.workbook_package_hygiene; print('workbook package hygiene import ok')"
+      - name: Import workbook package validators
+        run: |
+          python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; print('workbook package validators import ok')"
 
       - name: Run workbook package hygiene tests
-        run: python -m pytest tests/test_workbook_package_hygiene.py -q
+        run: |
+          python -m pytest \
+            tests/test_workbook_package_hygiene.py \
+            tests/test_copy_surface_bounds.py \
+            -q
 
-      - name: Verify workbook package hygiene CLI
-        run: python -m triage.workbook_package_hygiene --help
+      - name: Verify workbook package validator CLIs
+        run: |
+          python -m triage.workbook_package_hygiene --help
+          python -m triage.copy_surface_bounds --help
 
   artifact-engines:
     runs-on: ubuntu-latest

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -63,7 +63,56 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
+          python -c "
+          import triage.cybernet_targets.cli
+          import triage.nw_prj_neuron_track_hours.cli
+          import triage.nw_prj_neuron_track_hours.bonita_cli
+          import triage.admin_billing_summary.cli
+          import triage.one_marcus_recon.cli
+          import triage.sidecar_html
+          import triage.artifact_fingerprint
+          import triage.artifact_profiles
+          import triage.artifact_compare
+          import triage.same_family_compare
+          import triage.roster_log_compare.compare
+          import triage.roster_log_review_queue.cli
+          import triage.gitignore_hygiene
+          import triage.admin_billing_context_rules
+          import triage.attendance_report
+          import triage.billing_bridge_validator
+          import triage.billing_context.cli
+          import triage.billing_context.context_rules
+          import triage.billing_context.exporters
+          import triage.billing_context.html_dashboard
+          import triage.billing_context.models
+          import triage.billing_context.reconcile
+          import triage.billing_rules
+          import triage.billing_summary_generator
+          import triage.cf_engine
+          import triage.cf_policy_deploymenttracker
+          import triage.dv_engine
+          import triage.gate_checks
+          import triage.hours_basis_policy
+          import triage.insight_ingest
+          import triage.nw_prj_artifact_compare
+          import triage.nw_prj_config
+          import triage.nw_prj_dashboard_generator
+          import triage.nw_prj_dashboard_validator
+          import triage.patcher
+          import triage.payable_hours_corrections
+          import triage.promote
+          import triage.refactor_engine
+          import triage.repo_apply
+          import triage.repo_engine
+          import triage.roster_parser
+          import triage.storage_policy
+          import triage.tech_hours_parser
+          import triage.tutorial
+          import triage.web_excel_browser
+          import triage.web_excel_compatibility_rules
+          import triage.xlsx_utils
+          print('imports ok')
+          "
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
@@ -84,4 +133,33 @@ jobs:
             tests/test_same_family_compare.py \
             tests/test_gitignore_hygiene.py \
             tests/test_roster_log_review_queue.py \
+            tests/test_admin_billing_context_rules.py \
+            tests/test_attendance_report.py \
+            tests/test_billing_bridge_validator.py \
+            tests/test_billing_context_rules.py \
+            tests/test_billing_context_cli_e2e.py \
+            tests/test_billing_context_html.py \
+            tests/test_billing_context_reconcile.py \
+            tests/test_billing_regression.py \
+            tests/test_billing_rules.py \
+            tests/test_billing_summary_generator.py \
+            tests/test_cf_engine.py \
+            tests/test_cf_policy_deploymenttracker.py \
+            tests/test_dv_engine.py \
+            tests/test_hours_basis_policy.py \
+            tests/test_insight_ingest.py \
+            tests/test_nw_prj_dashboard.py \
+            tests/test_patcher.py \
+            tests/test_payable_hours_corrections.py \
+            tests/test_promote.py \
+            tests/test_refactor_engine.py \
+            tests/test_repo_apply.py \
+            tests/test_repo_engine.py \
+            tests/test_roster_parser.py \
+            tests/test_storage_policy.py \
+            tests/test_tutorial.py \
+            tests/test_web_excel_browser.py \
+            tests/test_web_excel_compatibility_rules.py \
+            tests/test_worker_project_hours_trace_doctrine.py \
+            tests/test_xlsx_utils.py \
             -q

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
 
+      - name: Run workbook package hygiene tests
+        run: python -m pytest tests/test_workbook_package_hygiene.py -q
+
       - name: Run artifact engine tests
         run: |
           python -m pytest \
@@ -51,5 +54,4 @@ jobs:
             tests/test_same_family_compare.py \
             tests/test_gitignore_hygiene.py \
             tests/test_roster_log_review_queue.py \
-            tests/test_workbook_package_hygiene.py \
             -q

--- a/.github/workflows/worksheet-cell-integrity.yml
+++ b/.github/workflows/worksheet-cell-integrity.yml
@@ -1,0 +1,31 @@
+name: Worksheet cell integrity
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  worksheet-cell-integrity:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Import validator
+        run: python -c "import triage.worksheet_cell_integrity; print('worksheet cell integrity import ok')"
+
+      - name: Run synthetic regressions
+        run: python -m pytest tests/test_worksheet_cell_integrity.py -q
+
+      - name: Verify CLI
+        run: python -m triage.worksheet_cell_integrity --help

--- a/docs/AI_PROMPT_KIT_NEXT_VERSION_ACCEPTANCE_CONTRACT.md
+++ b/docs/AI_PROMPT_KIT_NEXT_VERSION_ACCEPTANCE_CONTRACT.md
@@ -1,0 +1,135 @@
+# AI Prompt Kit Next-Version Acceptance Contract
+
+Date: 2026-07-14
+
+## Purpose
+
+This contract defines the required workbook behavior for the version following the clean-opening `AI_Harness_Prompt_Kit_v18.xlsx` artifact.
+
+The next version must preserve the Microsoft-native package posture that succeeded in Excel for Web while improving prompt navigation, semantic color labeling, font compatibility, readability, and clipboard payload bounds.
+
+## Structural inheritance
+
+Use the clean-opening V18 workbook as the structural fixture.
+
+Do not regenerate the workbook from a blank package or round-trip it through a general serializer after applying the compatibility fixes.
+
+Preserve:
+
+- non-overlapping merge geometry;
+- absence of stale native table objects unless a synchronized table-bearing control is field-tested;
+- ordinary scalar formulas only;
+- Microsoft `x14:dataValidations` dropdown structures;
+- conditional formatting;
+- worksheet protection;
+- freeze panes;
+- internal worksheet hyperlinks;
+- valid calculation metadata;
+- Microsoft-normalized dimensions, sheet views, columns, and styles unless an intentional bounded change requires otherwise.
+
+## Prompt Library navigation
+
+Both compact identifiers that name the destination must navigate to the corresponding copy-safe tab.
+
+For every prompt row:
+
+- `Prompt ID` must be an internal hyperlink to `Pxx_COPY_SAFE!A1`;
+- `Copy-Safe Sheet` must remain an internal hyperlink to the same destination;
+- the displayed Prompt ID remains compact, for example `P07`;
+- the displayed sheet name remains explicit, for example `P07_COPY_SAFE`;
+- hyperlink targets must be validated for all prompt rows before delivery.
+
+Expected invariant:
+
+```text
+Prompt_Library Prompt ID Pxx -> Pxx_COPY_SAFE!A1
+Prompt_Library Copy-Safe Sheet Pxx_COPY_SAFE -> Pxx_COPY_SAFE!A1
+```
+
+## Color semantics
+
+The Prompt Library must not present a field named `Color Meaning` whose values are only raw color names.
+
+Use the compact two-surface design:
+
+1. Rename the Prompt Library field to `Color`.
+2. Store the short color name in that field, such as `Green`, `Amber`, or `Gray`.
+3. Keep the authoritative semantic explanation in `Prompt_Class_Legend`.
+4. Ensure every color used by the Prompt Library has exactly one corresponding legend entry.
+5. The legend must explain what the color communicates operationally, not merely repeat the color name.
+
+A hyperlink from the Prompt Library color cell or header to the legend is desirable when it can be added without widening the table or destabilizing the package.
+
+## Web-compatible typography
+
+Only the following workbook font families are approved for the next version:
+
+- `Aptos` for regular text;
+- `Aptos Display` only when already present in the Microsoft fixture and proven harmless, otherwise normalize it to `Aptos`;
+- `Aptos` with bold weight for headings and emphasized text.
+
+The intended visible contract is `Aptos` and `Aptos Bold`. Do not introduce custom, bundled, legacy, or environment-dependent fonts.
+
+Font validation must inspect `xl/styles.xml` and fail when an unexpected font family is referenced by a visible cell style.
+
+## Prompt Library readability
+
+On `Prompt_Library`, column H (`Use This When`) must use a 12-point font for its body cells.
+
+Requirements:
+
+- preserve the existing column width unless a field test demonstrates clipping;
+- use Aptos at 12 points for body cells in column H;
+- keep the header visually distinct with Aptos Bold;
+- do not apply the larger font through an unbounded whole-column style that creates cells or rows below the actual data range;
+- apply the style only to the populated Prompt Library range.
+
+## Copy-surface row bounds
+
+Every `P00_COPY_SAFE` through `P20_COPY_SAFE` sheet must end at its final populated prompt row.
+
+For each copy-safe sheet:
+
+- preserve intentional blank rows inside the prompt;
+- remove every explicit row node after the final populated row;
+- remove every blank or styled cell after the final populated row;
+- trim the worksheet dimension to the final payload row;
+- avoid full-column or full-sheet formatting and protection operations that recreate trailing cells;
+- pass `triage.copy_surface_bounds` with `--max-trailing-rows 0`.
+
+Known V18 defects to remove:
+
+| Sheet | Final payload row | V18 package end | Required next-version end |
+| --- | ---: | ---: | ---: |
+| `P07_COPY_SAFE` | 112 | 113 | 112 |
+| `P14_COPY_SAFE` | 58 | 160 | 58 |
+
+## Acceptance gates
+
+The next version is accepted only when all of these gates pass:
+
+1. ZIP CRC integrity passes.
+2. Every XML and relationship part parses.
+3. All relationship targets resolve.
+4. Merge rectangles do not overlap.
+5. Native table metadata is absent or fully synchronized.
+6. No dynamic-array, shared-formula, or stop-ship formula structure is introduced.
+7. All 21 Prompt ID hyperlinks resolve to the matching copy-safe tab.
+8. All 21 Copy-Safe Sheet hyperlinks resolve to the matching copy-safe tab.
+9. Every Prompt Library color has an authoritative meaning in `Prompt_Class_Legend`.
+10. Visible fonts are Aptos/Aptos Bold-compatible.
+11. Prompt Library column H body text is 12-point Aptos.
+12. Every copy-safe sheet reports zero trailing package rows.
+13. Formula, validation, conditional-formatting, protection, and hyperlink counts remain semantically intact.
+14. The exact artifact opens in Excel for Web without repair or silent structural rewrite.
+15. The operator confirms that copying an entire prompt tab produces only the intended prompt payload.
+
+## Claim boundaries
+
+A local package pass does not prove Excel for Web acceptance.
+
+A clean Excel for Web open does not prove clipboard payload bounds.
+
+A clipboard test on one prompt tab does not prove all prompt tabs are bounded.
+
+Keep package validity, Web Excel acceptance, navigation acceptance, semantic presentation, and clipboard acceptance as separate recorded gates.

--- a/docs/AI_PROMPT_KIT_NEXT_VERSION_ACCEPTANCE_CONTRACT.md
+++ b/docs/AI_PROMPT_KIT_NEXT_VERSION_ACCEPTANCE_CONTRACT.md
@@ -27,24 +27,37 @@ Preserve:
 - valid calculation metadata;
 - Microsoft-normalized dimensions, sheet views, columns, and styles unless an intentional bounded change requires otherwise.
 
-## Prompt Library navigation
+## Prompt Library navigation and selected payload ranges
 
-Both compact identifiers that name the destination must navigate to the corresponding copy-safe tab.
+Both compact identifiers that name the destination must navigate to and select the exact copyable payload range, not merely activate the destination sheet.
 
 For every prompt row:
 
-- `Prompt ID` must be an internal hyperlink to `Pxx_COPY_SAFE!A1`;
-- `Copy-Safe Sheet` must remain an internal hyperlink to the same destination;
+- `Prompt ID` must be an internal hyperlink to `Pxx_COPY_SAFE!A1:A<last_payload_row>`;
+- `Copy-Safe Sheet` must remain an internal hyperlink to the same exact range;
 - the displayed Prompt ID remains compact, for example `P07`;
 - the displayed sheet name remains explicit, for example `P07_COPY_SAFE`;
-- hyperlink targets must be validated for all prompt rows before delivery.
+- use a direct internal range location rather than adding a defined name unless a field test proves the direct range unreliable;
+- hyperlink targets must be validated for all prompt rows before delivery;
+- the final target row must equal the last populated row reported by the copy-surface validator.
 
-Expected invariant:
+Expected invariant for a prompt ending on row 88:
 
 ```text
-Prompt_Library Prompt ID Pxx -> Pxx_COPY_SAFE!A1
-Prompt_Library Copy-Safe Sheet Pxx_COPY_SAFE -> Pxx_COPY_SAFE!A1
+Prompt_Library Prompt ID Pxx -> Pxx_COPY_SAFE!A1:A88
+Prompt_Library Copy-Safe Sheet Pxx_COPY_SAFE -> Pxx_COPY_SAFE!A1:A88
 ```
+
+The intended operator flow is:
+
+1. click either link in `Prompt_Library`;
+2. arrive with the exact payload range selected;
+3. copy immediately without worksheet select-all;
+4. paste only the prompt payload into a text box or terminal.
+
+Range selection is a separate field gate. Package inspection can prove that the hyperlink `location` names the correct range, but it cannot prove that Excel for Web or another spreadsheet application preserves the multi-cell selection after navigation.
+
+If a tested application collapses the target to one active cell, the bounded and dense copy surface remains the fallback protection.
 
 ## Color semantics
 
@@ -84,13 +97,12 @@ Requirements:
 - do not apply the larger font through an unbounded whole-column style that creates cells or rows below the actual data range;
 - apply the style only to the populated Prompt Library range.
 
-## Copy-surface row bounds
+## Copy-surface physical row bounds
 
-Every `P00_COPY_SAFE` through `P20_COPY_SAFE` sheet must end at its final populated prompt row.
+Every `P00_COPY_SAFE` through `P20_COPY_SAFE` sheet must physically end at its final populated prompt row.
 
 For each copy-safe sheet:
 
-- preserve intentional blank rows inside the prompt;
 - remove every explicit row node after the final populated row;
 - remove every blank or styled cell after the final populated row;
 - trim the worksheet dimension to the final payload row;
@@ -104,6 +116,57 @@ Known V18 defects to remove:
 | `P07_COPY_SAFE` | 112 | 113 | 112 |
 | `P14_COPY_SAFE` | 58 | 160 | 58 |
 
+## Copy-surface payload density
+
+Physical trimming alone is insufficient. Text boxes preserve empty rows inside the selected range even when terminals visually collapse or trim some whitespace.
+
+The V18 prompt tabs contain:
+
+- 1,222 rows between the first and final populated cells;
+- 1,016 populated rows;
+- 206 internal blank rows;
+- an overall internal blank-row ratio of approximately 16.9 percent.
+
+Representative V18 density:
+
+| Sheet | Payload span | Populated rows | Internal blank rows |
+| --- | ---: | ---: | ---: |
+| `P03_COPY_SAFE` | 142 | 127 | 15 |
+| `P06_COPY_SAFE` | 133 | 113 | 20 |
+| `P07_COPY_SAFE` | 112 | 88 | 24 |
+| `P13_COPY_SAFE` | 30 | 20 | 10 |
+
+V19 should use a dense copy surface:
+
+- remove empty spacer rows inside the payload range;
+- preserve readability with explicit headings, labels, punctuation, and contiguous instruction rows rather than empty worksheet rows;
+- keep one logical prompt line per populated cell;
+- do not replace empty rows with giant multiline cells, because that can reintroduce clipboard wrapper-quote behavior;
+- target zero internal blank rows for every production copy-safe sheet;
+- if an internal blank row is retained, it requires an explicit documented reason and field evidence that the resulting paste is desirable.
+
+The strict payload-density invariant is:
+
+```text
+last_payload_row - first_payload_row + 1 == populated_payload_row_count
+```
+
+For the current prompt design, `first_payload_row` should remain row 1.
+
+## Why all three controls are required
+
+The row and link controls solve different failure modes:
+
+| Control | Failure prevented |
+| --- | --- |
+| physical package bound | styled or explicit rows below the prompt are included by whole-sheet copy |
+| dense payload | empty spacer rows inside the prompt are preserved by text boxes |
+| range-target hyperlink | the user can copy the intended range without selecting the whole sheet |
+
+Do not rely on the range-target hyperlink alone. Other spreadsheet tools may ignore or collapse a multi-cell target, and users may still use whole-sheet selection.
+
+Do not rely on physical trimming alone. A perfectly bounded sheet can still paste many blank lines when its payload contains spacer rows.
+
 ## Acceptance gates
 
 The next version is accepted only when all of these gates pass:
@@ -114,22 +177,29 @@ The next version is accepted only when all of these gates pass:
 4. Merge rectangles do not overlap.
 5. Native table metadata is absent or fully synchronized.
 6. No dynamic-array, shared-formula, or stop-ship formula structure is introduced.
-7. All 21 Prompt ID hyperlinks resolve to the matching copy-safe tab.
-8. All 21 Copy-Safe Sheet hyperlinks resolve to the matching copy-safe tab.
-9. Every Prompt Library color has an authoritative meaning in `Prompt_Class_Legend`.
-10. Visible fonts are Aptos/Aptos Bold-compatible.
-11. Prompt Library column H body text is 12-point Aptos.
-12. Every copy-safe sheet reports zero trailing package rows.
-13. Formula, validation, conditional-formatting, protection, and hyperlink counts remain semantically intact.
-14. The exact artifact opens in Excel for Web without repair or silent structural rewrite.
-15. The operator confirms that copying an entire prompt tab produces only the intended prompt payload.
+7. All 21 Prompt ID hyperlinks resolve to the exact matching copy-safe payload range.
+8. All 21 Copy-Safe Sheet hyperlinks resolve to the exact matching copy-safe payload range.
+9. Clicking each hyperlink in Excel for Web selects the intended multi-cell range, or the result is explicitly recorded as unsupported.
+10. Every Prompt Library color has an authoritative meaning in `Prompt_Class_Legend`.
+11. Visible fonts are Aptos/Aptos Bold-compatible.
+12. Prompt Library column H body text is 12-point Aptos.
+13. Every copy-safe sheet reports zero trailing package rows.
+14. Every production copy-safe sheet reports zero internal blank rows.
+15. Formula, validation, conditional-formatting, protection, and hyperlink counts remain semantically intact.
+16. The exact artifact opens in Excel for Web without repair or silent structural rewrite.
+17. The operator confirms that clicking a library link and copying immediately produces only the intended prompt payload in a text box.
+18. The operator confirms that the whole-sheet fallback also produces only the intended dense prompt payload.
 
 ## Claim boundaries
 
 A local package pass does not prove Excel for Web acceptance.
 
+A correct range string in OOXML does not prove that the Web Excel interface will preserve the selected range.
+
 A clean Excel for Web open does not prove clipboard payload bounds.
 
-A clipboard test on one prompt tab does not prove all prompt tabs are bounded.
+A successful range-copy test does not prove the whole-sheet fallback is clean.
 
-Keep package validity, Web Excel acceptance, navigation acceptance, semantic presentation, and clipboard acceptance as separate recorded gates.
+A clipboard test on one prompt tab does not prove all prompt tabs are bounded and dense.
+
+Keep package validity, Web Excel acceptance, navigation acceptance, range-selection behavior, semantic presentation, payload density, and clipboard acceptance as separate recorded gates.

--- a/docs/AI_PROMPT_KIT_V10_XML_AND_CLIPBOARD_RECORD.md
+++ b/docs/AI_PROMPT_KIT_V10_XML_AND_CLIPBOARD_RECORD.md
@@ -1,0 +1,297 @@
+# AI Prompt Kit v10 XML and Clipboard Record
+
+## Record purpose
+
+This record connects the latest AI Harness Prompt Kit artifact to the broader Web-Excel Repair Triage doctrine.
+
+Artifact examined locally:
+
+```text
+ai_harness_prompt_kit_v10_paste_only.xlsx
+```
+
+The workbook itself is not committed because generated binary artifacts and operator-specific working files do not belong in the repo by default. The reusable findings, package observations, validation contract, and operator workflow belong here.
+
+Related doctrine:
+
+```text
+docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
+```
+
+## Why this artifact matters to Triage
+
+Triage is evolving into a spreadsheet harness: a set of contracts, package checks, acceptance gates, and operator evidence that helps generated workbooks remain healthy in Excel for Web.
+
+The prompt kit adds a second future layer. It is also an AI harness artifact. Its spreadsheet structure controls how instructions are copied into agent chats, so workbook package health and copy-surface behavior directly affect software-agent behavior.
+
+This makes the workbook a useful boundary artifact:
+
+```text
+spreadsheet package -> Excel UI/clipboard -> agent prompt interpretation -> repo action
+```
+
+A defect at the spreadsheet or clipboard layer can look like an agent reasoning failure. Triage should preserve enough evidence to distinguish those layers.
+
+## Operator-observed clipboard behavior
+
+Current successful workflow:
+
+1. Open `P07_COPY_SAFE` or `P12_COPY_SAFE`.
+2. Use the worksheet select-all control so all cells in the tab are selected.
+3. Copy.
+4. Paste into the agent chat.
+5. The prompt arrives as executable text and agents are more likely to perform repo work.
+
+Current risky workflow:
+
+1. Copy a giant multiline prompt from the `Prompt_Library` cell.
+2. Paste into the agent chat.
+3. Excel may wrap the payload with a quote at the beginning and another at the end.
+4. The agent may treat the payload as quoted material to rewrite instead of instructions to execute.
+
+The operator also observed that removing one of the wrapper quotes can be enough to avoid this lazy rewrite behavior. That is useful diagnostic evidence, but it is not a stable product contract. The workbook should avoid creating the wrappers in the first place.
+
+## Package inventory
+
+The inspected artifact contains:
+
+- 24 worksheets,
+- 3 worksheet table objects,
+- dedicated `P07_COPY_SAFE` and `P12_COPY_SAFE` sheets,
+- a wide `Prompt_Library` table,
+- no macros,
+- no committed live/customer data in the examined package.
+
+Relevant sheets:
+
+```text
+START_HERE
+Prompt_Sequence
+Prompt_Library
+P07_COPY_SAFE
+P12_COPY_SAFE
+Copy_Mode_Rules
+V10_PasteOnly_Fix
+```
+
+## Copy-surface XML shape
+
+### `P07_COPY_SAFE`
+
+Observed package shape:
+
+- 86 populated cells,
+- populated cells are in column `A`,
+- first populated cell is `A1`,
+- `A1` begins directly with:
+
+```text
+EXECUTE THE REPO SPRINT. DO NOT REWRITE THIS PROMPT.
+```
+
+- blank worksheet rows provide paragraph spacing,
+- prompt lines are separate cells instead of one giant multiline cell,
+- no title row precedes the executable payload,
+- no `END PROMPT` sentinel appears in the copy surface.
+
+### `P12_COPY_SAFE`
+
+Observed package shape:
+
+- 29 populated cells,
+- populated cells are in column `A`,
+- first populated cell is `A1`,
+- `A1` begins directly with:
+
+```text
+COMPRESS THIS SPRINT INTO A NEXT-AGENT HANDOFF.
+```
+
+This is the intended closeout surface and remains separate from the build executor.
+
+### `Prompt_Library`
+
+The `Prompt_Library` retains large multiline prompt cells in column `N` for several prompt types.
+
+Examples from package inspection:
+
+| Cell | Approximate length | Embedded newlines | Role |
+| --- | ---: | ---: | --- |
+| `N2` | 1062 | 16 | general harness doctrine |
+| `N4` | 1428 | 50 | conversation closeout mapper |
+| `N5` | 1569 | 64 | repo-aware sprint distributor |
+| `N6` | 1913 | 71 | sprint plan pack generator |
+| `N7` | 1499 | 67 | repo/worktree hygiene coordinator |
+| `N10` | 1638 | 49 | live/runtime proof sprint |
+| `N11` | 1606 | 52 | read-only code intelligence |
+| `N12` | 1618 | 47 | local hook/artifact hygiene |
+| `N13` | 1481 | 55 | synthetic harness validator |
+| `N15` | 847 | 29 | reusable rules review |
+
+Those cells are useful as catalog/reference surfaces, but they are unsafe as the default executable clipboard surface.
+
+The P07 and P12 rows now point the operator to their dedicated copy-safe sheets. That is directionally correct.
+
+## OOXML table record
+
+The artifact contains these table definitions:
+
+| Part | Table name/displayName | Ref | Columns |
+| --- | --- | --- | ---: |
+| `xl/tables/table1.xml` | `StartHereV9` | `A4:H13` | 8 |
+| `xl/tables/table2.xml` | `PromptSequenceV9` | `A1:L15` | 12 |
+| `xl/tables/table3.xml` | `PromptLibraryV9` | `A1:N15` | 14 |
+
+Positive findings:
+
+- table IDs are unique: `1`, `2`, `3`,
+- table refs match the current visible rectangular table ranges,
+- table column counts match the declared table ranges,
+- table headers match the visible header cells,
+- table refs have matching `autoFilter` refs,
+- the prior duplicate-table-ID and stale-column-count defects are not present.
+
+Record-impact finding:
+
+- the v10 artifact still uses `V9` in its table object names.
+
+This does not by itself make the workbook invalid. It is provenance/version drift. The package is structurally describing a newer artifact with older internal object names. Triage should report this as metadata drift or a warning when artifact-version expectations are supplied, not automatically as corruption.
+
+## Worksheet metadata record
+
+On the inspected sheets `START_HERE`, `Prompt_Library`, `P07_COPY_SAFE`, and `P12_COPY_SAFE`:
+
+- no worksheet `<dimension>` node was present,
+- no worksheet `<pane>` node was present.
+
+The workbook therefore does not currently provide XML proof for previously claimed freeze panes on these sheets.
+
+Interpretation:
+
+- missing dimensions are metadata drift and may be tolerated by Excel,
+- missing panes mean the freeze-pane claim is not proven in the package,
+- neither condition alone proves an Excel for Web repair event,
+- the validator should distinguish `WARN` metadata drift from package-breaking `FAIL` conditions.
+
+## Merge-range record
+
+The current inspected artifact does not repeat the earlier overlapping merge defect on the key sheets.
+
+Earlier failure pattern:
+
+```text
+A1:H1 overlapped A1:J1
+```
+
+Current relevant title merge on `START_HERE`:
+
+```text
+A1:J1
+```
+
+The package-hygiene validator should continue checking all merge rectangles pairwise because this defect can be introduced by a visual redesign even when the visible sheet looks reasonable.
+
+## Acceptance-gate impact
+
+This artifact reinforces that workbook acceptance needs separate gates:
+
+| Gate | Current artifact evidence |
+| --- | --- |
+| ZIP/package readable | locally observed |
+| XML well-formed | locally observed |
+| table metadata consistent | locally observed for the three tables |
+| merge ranges non-overlapping | locally observed on package scan |
+| freeze panes proven | not proven on inspected sheets |
+| copy-surface package shape | improved for P07/P12 |
+| clipboard accepted | operator observed for copy-safe sheets |
+| Prompt Library clipboard accepted | not accepted as default executable surface |
+| Excel for Web accepted | not proven by this local package inspection |
+| operator accepted | partial: copy-safe workflow works; broader workbook acceptance remains separate |
+
+Do not replace these gates with one `valid` flag.
+
+## New diagnostic surface
+
+This PR adds:
+
+```text
+python -m triage.workbook_package_hygiene <workbook.xlsx>
+```
+
+Useful invocation for the prompt kit:
+
+```powershell
+python -m triage.workbook_package_hygiene `
+  "<path>\ai_harness_prompt_kit_v10_paste_only.xlsx" `
+  --expect-freeze START_HERE `
+  --expect-freeze Prompt_Library `
+  --copy-surface P07_COPY_SAFE `
+  --copy-surface P12_COPY_SAFE
+```
+
+The validator is read-only and inspects the ZIP/XML package directly.
+
+It checks:
+
+- ZIP CRC integrity,
+- XML and relationship-part well-formedness,
+- table ID uniqueness,
+- table name/displayName uniqueness,
+- table refs and autoFilter refs,
+- declared/range table column counts,
+- visible headers against table XML columns,
+- overlapping merge ranges,
+- expected freeze panes,
+- missing worksheet dimension nodes,
+- formula/error literal markers,
+- copy-surface package shape.
+
+Copy-surface checks can identify risky shapes such as:
+
+- multiple populated columns,
+- giant multiline cells,
+- `PASTE THIS DIRECTLY` guidance contamination,
+- `END PROMPT` sentinels,
+- missing copy-surface sheets.
+
+They cannot prove what Microsoft Excel places on the system clipboard. That still requires operator evidence.
+
+## Record update rule
+
+When a prompt-kit workbook changes again, preserve the following in the record instead of committing the binary by default:
+
+- artifact filename/version,
+- worksheet inventory,
+- table object names and refs,
+- table IDs and column counts,
+- merge-overlap result,
+- pane/dimension inventory,
+- nominated copy-surface sheets,
+- operator clipboard outcome,
+- Excel for Web outcome,
+- package validator command/output,
+- exact gap between package proof and operator proof.
+
+## Next layer
+
+The spreadsheet harness is now mature enough to support an AI-harness layer, but the two should remain distinguishable:
+
+```text
+Spreadsheet harness
+  -> package validity
+  -> semantic workbook contract
+  -> presentation safety
+  -> clipboard acceptance
+  -> Web Excel acceptance
+
+AI harness
+  -> prompt classification
+  -> copy-safe execution surfaces
+  -> repo evidence
+  -> bounded action
+  -> committed work
+  -> validation
+  -> report / next decision
+```
+
+The AI layer should consume spreadsheet-harness evidence rather than declaring the workbook healthy on its own.

--- a/docs/AI_PROMPT_KIT_V18_WEB_EXCEL_ACCEPTANCE_RECORD.md
+++ b/docs/AI_PROMPT_KIT_V18_WEB_EXCEL_ACCEPTANCE_RECORD.md
@@ -1,0 +1,178 @@
+# AI Prompt Kit v18 Web Excel Acceptance Record
+
+Date: 2026-07-14
+
+## Result
+
+`AI_Harness_Prompt_Kit_v18.xlsx` opened successfully in Excel for Web without a repair event.
+
+This is field acceptance for that exact artifact. It is not a blanket claim that every workbook produced by the same Python libraries or every later prompt-kit version will open cleanly.
+
+## Evidence chain
+
+The compatibility investigation progressed through distinct artifacts instead of treating every valid ZIP as Web Excel-safe:
+
+1. The earlier prompt-kit artifact opened in Google Sheets but failed to open in Excel for Web.
+2. Local package preflight passed, proving that the preflight did not yet model every Web Excel requirement.
+3. Validation and column-normalization probes A, B, and C also failed to load.
+4. Scalar/table probes D, E, and F reached Excel for Web but were returned as repaired workbooks.
+5. The three repaired outputs were compared against their exact inputs part by part and cell by cell.
+6. V18 was produced from Microsoft's repaired D workbook as the structural fixture, with bounded byte-safe metadata updates rather than workbook regeneration.
+7. The operator confirmed that V18 opened successfully in Excel for Web.
+
+## Confirmed package defect
+
+The strongest common repair trigger was overlapping merged-cell geometry.
+
+The failed probes contained these collisions:
+
+```text
+START_HERE
+A1:J1 overlaps A1:H1
+
+Prompt_Class_Legend
+A2:F2 overlaps A2:H2
+```
+
+Excel for Web removed one range from each collision in every repaired D/E/F output. No cell values or worksheet formulas changed during those repairs.
+
+Therefore:
+
+- intersecting `mergeCell` rectangles are a generation failure;
+- applying a wider title or subtitle merge must first remove the stale narrower merge;
+- visual correctness in a renderer does not excuse invalid merge geometry.
+
+The package-hygiene validator already detects this defect and must keep it as a hard failure.
+
+## Separate stale-table defect
+
+The failed v17 lineage also carried three native Excel table objects whose stored column schemas no longer matched the visible worksheet headers:
+
+```text
+StartHereV9
+PromptLibraryV9
+PromptSequenceV9
+```
+
+The scalar probes removed those table objects. Their removal alone did not prevent repair because the merge collisions remained.
+
+The supported conclusion is:
+
+- stale or mismatched table XML is unsafe;
+- table-free output is not proven to be universally required;
+- when a table is present, its `ref`, `autoFilter`, column count, column names, visible headers, and actual row bounds must remain synchronized.
+
+## Features that survived and are allowed
+
+The repaired D workbook and the clean-opening V18 artifact prove that Web Excel can accept these features together:
+
+- eight ordinary scalar worksheet formulas;
+- zero array formulas;
+- zero shared formulas;
+- no dynamic-array spill metadata;
+- 18 cross-sheet dropdown validations represented in Microsoft's `x14:dataValidations` extension;
+- conditional formatting;
+- protected worksheets;
+- frozen panes;
+- 21 internal hyperlinks from `Prompt_Library` to the matching `Pxx_COPY_SAFE` tabs;
+- shared strings and Microsoft-generated calculation metadata.
+
+Consequently, the correct contract is not "remove every formula and rule." It is "use compatible scalar structures and keep package relationships internally consistent."
+
+## Microsoft repair normalization that is not yet a proven trigger
+
+The repaired D/E/F workbooks also received broad normalization:
+
+- dimensions added to worksheets;
+- default sheet views added where absent;
+- overlapping column-definition records normalized;
+- style records deduplicated;
+- document properties added;
+- calculation metadata generated for surviving scalar formulas.
+
+These are useful diagnostics and known-good fixture characteristics. They were common to Microsoft's rewrite, but the current evidence does not prove that any one of them independently caused the repair event.
+
+Do not turn correlation into a stop-ship rule without a single-variable field test.
+
+## Generation method that succeeded
+
+V18 was not exported from a blank workbook and was not round-tripped through a general workbook serializer after Microsoft repair.
+
+The successful posture was:
+
+1. use the Microsoft-repaired D workbook as the structural fixture;
+2. preserve its package topology and Microsoft-native extension records;
+3. keep native tables absent until a clean table-bearing control is field-tested;
+4. update only bounded shared-string metadata, core properties, and one existing shared-string cell reference;
+5. verify ZIP CRC, XML parsing, merge non-overlap, scalar formula shape, calculation-chain targets, dropdown count, conditional-formatting count, and internal hyperlink count;
+6. perform the real Excel-for-Web open gate.
+
+## Prompt copy-surface payload bounds
+
+A separate operator problem remains for the next prompt-kit version: copy-safe sheets may contain hundreds or thousands of package rows below the final prompt line. Spreadsheet applications can include those rows when the whole sheet is copied, producing enormous pasted payloads.
+
+For every declared copy surface:
+
+- find the final populated prompt row;
+- compare it with the worksheet dimension end row;
+- compare it with the highest explicit `<row r="...">` node;
+- compare it with the highest cell reference, including styled blank cells;
+- report the largest package row as the effective copy-surface end;
+- require zero trailing rows by default for production prompt tabs.
+
+The dedicated validator reports each sheet's `last_payload_row`, `package_end_row`, and `trailing_rows`.
+
+Use the strict generation gate:
+
+```powershell
+python -m triage.copy_surface_bounds `
+  "<prompt-kit.xlsx>" `
+  --sheet P00_COPY_SAFE `
+  --sheet P01_COPY_SAFE `
+  --max-trailing-rows 0
+```
+
+The generator should also avoid formatting or protection operations over full-column or full-sheet row ranges when a bounded prompt range is sufficient.
+
+## Acceptance model
+
+Keep these claims separate:
+
+| Gate | V18 evidence |
+| --- | --- |
+| ZIP readable | passed |
+| XML well-formed | passed |
+| tables internally consistent or absent | tables absent |
+| merge ranges non-overlapping | passed |
+| scalar formula structure | passed |
+| dropdown and conditional-formatting surfaces preserved | passed |
+| internal copy-tab links preserved | passed |
+| Excel for Web opens without repair | operator confirmed |
+| clipboard contains no trailing-row bloat | not yet accepted; next-version gate |
+
+## Canonical lessons
+
+1. Google Sheets acceptance does not prove Excel for Web acceptance.
+2. A valid ZIP and parseable XML do not prove Excel for Web acceptance.
+3. Overlapping merged ranges are a hard package defect.
+4. Stale table schemas are a separate hard package defect.
+5. Ordinary scalar formulas, x14 dropdowns, conditional formatting, protection, and internal hyperlinks are compatible when the package is coherent.
+6. A Microsoft-repaired workbook can be a valuable known-good structural fixture.
+7. Bounded byte-safe edits preserve that fixture more reliably than full regeneration.
+8. Copy-surface row bounds are an operator and token-efficiency contract, not merely a cosmetic concern.
+9. Field acceptance must remain the final gate.
+
+## V18 copy-surface audit
+
+Running the new strict payload-bound check across all 21 `P00_COPY_SAFE` through `P20_COPY_SAFE` sheets found two concrete trailing-row defects:
+
+| Sheet | Final populated row | Package end row | Extra rows | Cause |
+| --- | ---: | ---: | ---: | --- |
+| `P07_COPY_SAFE` | 112 | 113 | 1 | styled blank cell at `A113` |
+| `P14_COPY_SAFE` | 58 | 160 | 102 | styled blank cells from `A59:A160`, including custom-height row records |
+
+The other 19 prompt tabs ended at their final populated row.
+
+This proves that the bloat is not hypothetical and is not caused only by how a spreadsheet application renders an empty grid. The OOXML package itself contains explicit styled cells and row records below the prompt payload. A whole-sheet copy can therefore include those rows.
+
+For the next prompt-kit version, remove the trailing `<row>` and `<c>` records and reduce each affected `<dimension ref="...">` to the final populated prompt row. Preserve intentional blank rows inside the prompt; remove only rows after the final populated cell.

--- a/docs/AI_PROMPT_KIT_V19_REPAIR_AND_V20_RECORD.md
+++ b/docs/AI_PROMPT_KIT_V19_REPAIR_AND_V20_RECORD.md
@@ -1,0 +1,92 @@
+# AI Prompt Kit V19 Repair and V20 Generation Record
+
+Date: 2026-07-14
+
+## Scope
+
+This record captures the Excel-for-Web repair delta for `AI_Harness_Prompt_Kit_v19.xlsx` and the bounded generation posture used for V20.
+
+No private workbook binary is committed. The evidence below is derived from package-level comparison of the original V19 artifact and the Excel-for-Web repaired V19 download.
+
+## Direct repair findings
+
+### 1. Duplicate worksheet cell coordinates
+
+`Prompt_Class_Legend` contained 38 duplicate cell records:
+
+```text
+J4:K22
+```
+
+Each coordinate appeared twice:
+
+1. an existing blank styled `<c>` record from the Microsoft fixture;
+2. a later appended value-bearing `<c>` record added by the V19 transformation.
+
+Excel for Web retained the first blank record and discarded the later duplicate value-bearing record. This explains why the workbook could appear correct in a parser that selected the later record while Excel repaired the sheet and removed the color/meaning values.
+
+**Stop-ship rule:** a worksheet coordinate may have at most one `<c>` element. Updating a cell must replace the existing element in place rather than appending another element with the same `r` value.
+
+### 2. Worksheet dimension excluded existing cells
+
+V19 declared:
+
+```text
+Prompt_Class_Legend dimension = A1:K23
+```
+
+The sheet still contained explicit styled cells through:
+
+```text
+Z100
+```
+
+Excel for Web restored the dimension to `A1:Z100`.
+
+**Stop-ship rule:** when a dimension node is present, it must cover every explicit cell record. A generator must not shrink the dimension merely to the visible content when styled or structural cells remain outside that range.
+
+## Preserved features
+
+The repair did not invalidate the V19 design conclusions for:
+
+- 42 internal exact-range hyperlinks;
+- 21 dense and bounded prompt copy surfaces;
+- eight ordinary scalar formulas;
+- Microsoft-generated calculation-chain metadata;
+- 18 extended data-validation rules;
+- 14 conditional-formatting blocks;
+- Aptos typography and 12-point Prompt Library column H.
+
+## Correlated normalization, not isolated causes
+
+Excel also:
+
+- reduced `cellXfs` from 148 to 144 by removing unused styles and deduplicating equivalent styles;
+- normalized default row heights from 14.25 to 15 and from 34.5 to 36;
+- reserialized worksheet and shared-string XML.
+
+These changes are recorded as save normalization. They are not promoted to independent compatibility laws because they were not isolated in single-variable field tests.
+
+## V20 generation posture
+
+V20 uses the repaired V19 download as its structural fixture.
+
+The V20 transformation:
+
+1. defines the intended workbook changes through the workbook editing surface;
+2. replaces existing worksheet cell records in place;
+3. preserves the repaired worksheet dimension and package topology;
+4. adds no duplicate cell coordinates;
+5. keeps the dense prompt tabs and exact-range links unchanged;
+6. repairs the color legend mapping so each of the 18 library colors has one operational meaning;
+7. adds package gates for coordinate uniqueness and dimension coverage.
+
+V20 package preflight passed. Excel-for-Web clean-open, range-selection behavior, text-box clipboard behavior, and whole-sheet clipboard behavior remain separate field gates.
+
+## Executable repo changes
+
+- `triage/worksheet_cell_integrity.py`
+- `tests/test_worksheet_cell_integrity.py`
+- `.github/workflows/worksheet-cell-integrity.yml`
+
+The synthetic regression reproduces the V19 failure shape with duplicate `J4` records and a stale `A1:K23` dimension while a `Z100` cell exists.

--- a/docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
+++ b/docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
@@ -1,0 +1,300 @@
+# Workbook Copy Surface and OOXML Triage Lessons
+
+## Purpose
+
+Capture recent workbook-generation failures from the AI harness prompt kit sprint and turn them into reusable triage doctrine.
+
+These lessons belong in this repo because they sit at the intersection of:
+
+- generated `.xlsx` artifacts,
+- Excel for Web repair behavior,
+- clipboard behavior from spreadsheet cells,
+- table metadata drift,
+- freeze-pane and merge-range claims,
+- and artifact acceptance language.
+
+The point is not to make workbooks prettier. The point is to keep generated artifacts healthy, easy to operate, and honest about what has actually been proven.
+
+## Background
+
+A generated prompt-library workbook went through multiple iterations. The visible workbook looked increasingly polished, but two classes of failures emerged:
+
+1. Excel/Sheets clipboard behavior changed how executable prompts were interpreted by agents.
+2. The workbook package layer drifted behind the visible sheet layer, creating Excel repair risk.
+
+The symptoms were practical:
+
+- Agents copied prompts out of spreadsheet cells and responded by rewriting the prompt instead of doing repo work.
+- A workbook could not be opened cleanly after visual/classification changes.
+- Claimed freeze panes were not actually present in the XML.
+- Visible table columns no longer matched `xl/tables/table*.xml` metadata.
+- Overlapping merge ranges appeared after layout changes.
+
+The failure is a useful pattern: a workbook can look organized while the backend package is structurally wrong.
+
+## Lesson 1: executable copy surfaces are not normal documentation cells
+
+A giant multiline cell is a poor place to store a prompt that must be copied into an agent chat and obeyed.
+
+Common spreadsheet clipboard behavior can wrap a multiline cell in leading and trailing quotes. Once pasted into an AI chat, that makes the instruction look like a quoted artifact. The next agent may interpret the payload as text to revise instead of an instruction to execute.
+
+### Bad shape
+
+```text
+"EXECUTE THE REPO SPRINT...
+...
+Do the repo work. Commit it."
+```
+
+### Better shape
+
+Use a dedicated paste-only sheet:
+
+```text
+P07_COPY_SAFE
+```
+
+Rules for paste-only sheets:
+
+- No title row above the executable text.
+- No instruction banner that says `paste this` or `do not paste`.
+- No Markdown fence around the prompt.
+- No beginning or ending quote markers.
+- No end sentinel such as `END PROMPT` unless the target agent explicitly needs it.
+- One prompt line per worksheet row when possible.
+- Keep guidance and metadata in a separate index/control sheet.
+
+A catalog sheet can describe the prompt. A paste-only sheet should only contain the prompt.
+
+## Lesson 2: prompt-library workbooks need separate index and execution surfaces
+
+Do not make one sheet do everything.
+
+Recommended separation:
+
+| Surface | Purpose | Clipboard posture |
+| --- | --- | --- |
+| `START_HERE` | human control board | not pasted |
+| `Prompt_Library` | index, classification, prompt metadata | not pasted as executable text |
+| `Prompt_Class_Legend` | taxonomy and color rules | not pasted |
+| `P07_COPY_SAFE` | executable build prompt | safe to Ctrl+A / Ctrl+C / paste |
+| `P12_COPY_SAFE` | executable closeout prompt | safe to Ctrl+A / Ctrl+C / paste |
+| `Validation_Report` | package checks and operator notes | not pasted |
+
+This prevents prompt contamination. It also prevents agents from treating a prompt as a document artifact to rewrite.
+
+## Lesson 3: build prompts must not contain closeout escape hatches
+
+A sprint-executor prompt that asks for a next-agent handoff inside the same response may accidentally teach the agent that a handoff is the deliverable.
+
+Use a strict split:
+
+```text
+P07 builds.
+P12 hands off.
+```
+
+For build prompts:
+
+- The deliverable is changed repo files, validation, commit, and push or PR when available.
+- A prompt for another agent is not the work.
+- Final responses should not include a next-agent prompt unless the sprint is explicitly a closeout sprint.
+
+For closeout prompts:
+
+- The deliverable is compressed context and a next-agent prompt.
+- Do not pretend closeout equals implementation.
+
+## Lesson 4: visible layout changes must reconcile table XML
+
+When adding/removing/reordering visible workbook columns, update the table definitions too.
+
+Repair-banner risk appears when the visible sheet says one thing and `xl/tables/table*.xml` says another.
+
+Check at least:
+
+- each table has a unique `id`,
+- each table has a unique `name` and `displayName`,
+- each table `ref` matches the actual rectangular used range,
+- `autoFilter ref` matches the table `ref`,
+- table column count matches visible headers,
+- table column names match visible headers,
+- table refs do not point to stale v4/v5/v6 layouts after a visual redesign.
+
+Example failure pattern:
+
+| XML part | Failure |
+| --- | --- |
+| `xl/tables/table1.xml` | old `ref` after added columns |
+| `xl/tables/table2.xml` | stale table name from prior version |
+| `xl/tables/table3.xml` | duplicate `id="1"` across tables |
+
+A workbook can look correct in a generator preview and still be invalid at the package layer.
+
+## Lesson 5: merge ranges are package contracts, not decoration
+
+Overlapping merge ranges are not a harmless style detail.
+
+If a style pass modifies titles, section bars, or widened banner rows, validate:
+
+- no duplicate merge ranges,
+- no overlapping merge ranges,
+- no merge range extends past the intended sheet width,
+- no prior-version merge range remains after a new wider title range is added.
+
+Bad pattern:
+
+```text
+A1:H1 overlaps A1:J1
+```
+
+Correct pattern:
+
+```text
+A1:J1 only
+```
+
+Delete or replace the old merge range rather than layering another one on top.
+
+## Lesson 6: freeze panes must be verified in XML, not claimed in prose
+
+It is easy for a workbook generator to claim that headers or decision columns are frozen while the worksheet XML contains no actual `sheetViews/pane` entry.
+
+Validation should inspect the package for actual pane nodes:
+
+```text
+xl/worksheets/sheet*.xml -> sheetViews -> sheetView -> pane
+```
+
+For control-board sheets, preferred posture:
+
+- freeze the top row for normal table sheets,
+- freeze key left columns for wide decision matrices,
+- verify the freeze survives export/import,
+- do not count visual preview screenshots as freeze-pane proof.
+
+## Lesson 7: style-only passes still need package validation
+
+The repo already treats style as a safe presentation layer only when it does not change formulas or workbook logic. Add package hygiene checks to that same standard.
+
+A style/classification pass should verify:
+
+1. ZIP integrity.
+2. Workbook opens through local import tools.
+3. No overlapping merge ranges.
+4. Table refs match visible ranges.
+5. Table column counts match headers.
+6. Table IDs and names are unique.
+7. Freeze panes exist where claimed.
+8. Formula count did not change during a style-only pass.
+9. No unexpected formulas/errors such as `#REF!`, `#VALUE!`, `#NAME?`, or `#N/A` appeared.
+10. Operator-facing copy surfaces do not include contaminating guidance text.
+
+## Lesson 8: add clipboard acceptance as its own gate
+
+The repo already distinguishes package validity, semantic correctness, presentation quality, Web Excel acceptance, and operator acceptance.
+
+Prompt-library and operator-runbook workbooks need another gate:
+
+| Gate | Meaning |
+| --- | --- |
+| Clipboard acceptance | Ctrl+A / Ctrl+C from the intended paste surface produces only the intended payload, with no wrapper quotes, guidance banners, hidden labels, or markdown fences. |
+
+This is not the same as package validity. A workbook can open and still produce a bad pasted prompt.
+
+Clipboard acceptance should be tested manually until the repo has a deterministic clipboard harness.
+
+Minimum manual test:
+
+1. Open the workbook in the intended environment.
+2. Go to the copy-safe sheet.
+3. Press Ctrl+A, then Ctrl+C.
+4. Paste into a plain text editor.
+5. Confirm the first line is executable content, not a guidance banner.
+6. Confirm there are no leading/trailing quotes around the entire payload.
+7. Confirm there are no markdown fences unless intentionally required.
+8. Confirm the pasted text does not include hidden control-board labels.
+
+## Lesson 9: semantic color needs routing columns, not just pretty rows
+
+Color should classify the prompt or sheet before the user reads paragraphs.
+
+For prompt-library workbooks, key frozen columns should answer:
+
+- What kind of prompt is this?
+- Is it for preflight, sprint/build, validation, closeout, safety, runtime proof, or navigation?
+- Does it move repo progress?
+- What proof gate applies?
+- Which prompt should be used next?
+
+The row color should reinforce those answers, not replace them.
+
+Recommended roles:
+
+| Role | Meaning |
+| --- | --- |
+| Preflight / floor | clear repo, branch, PR, worktree, dirty-state risk |
+| Sprint / build | implement tracked repo changes |
+| Validate / gate | prove the harness or artifact |
+| Closeout / handoff | compress context after work is complete or blocked |
+| Safety / hygiene | prevent leaks, runtime artifacts, bad commits, or destructive actions |
+| Runtime / prove | live or environment-dependent proof, with stricter proof language |
+| Leverage / navigate | code intelligence, MCP/LSP, read-only discovery |
+| Planning / distribute | break work into lanes, not a substitute for implementation |
+
+## Lesson 10: acceptance language must stay humble
+
+A generated workbook may pass package checks and still fail as an operational artifact.
+
+Use precise claims:
+
+- `Package-valid`: the `.xlsx` package opens and passes structural checks.
+- `Semantically correct`: the expected sheets, headers, prompts, tables, and commands exist.
+- `Presentation-safe`: style communicates role/state/hierarchy without changing logic.
+- `Clipboard-accepted`: the intended paste surface copies clean executable text.
+- `Web Excel accepted`: Excel for Web opens it without repair.
+- `Operator accepted`: the user validated it in the real workflow.
+
+Do not collapse these gates into `done`.
+
+## Suggested validator additions
+
+Future validator work can add a package check that inspects `.xlsx` internals directly:
+
+```text
+python -m triage.workbook_package_hygiene <workbook.xlsx>
+```
+
+Suggested checks:
+
+- parse ZIP parts,
+- parse workbook relationships,
+- parse worksheet dimensions,
+- detect overlapping merge ranges,
+- inspect table XML refs,
+- ensure table IDs are unique,
+- compare table column names against visible header cells,
+- inspect freeze-pane nodes,
+- scan formulas/errors if available,
+- emit JSON plus human-readable matrix.
+
+Suggested output:
+
+```text
+WORKBOOK PACKAGE HYGIENE
+[PASS] ZIP integrity
+[PASS] table ids unique
+[PASS] table refs match visible ranges
+[PASS] merge ranges non-overlapping
+[PASS] freeze panes present where claimed
+[PASS] formula/error scan
+[WARN] clipboard acceptance requires manual test
+
+Result: package-valid, manual clipboard acceptance pending
+```
+
+## Practical rule
+
+If a workbook is meant to generate action in another tool, the paste surface is part of the product.
+
+Treat it like a UI, not like a note cell.

--- a/docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
+++ b/docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
@@ -15,6 +15,18 @@ These lessons belong in this repo because they sit at the intersection of:
 
 The point is not to make workbooks prettier. The point is to keep generated artifacts healthy, easy to operate, and honest about what has actually been proven.
 
+Latest artifact-specific evidence is recorded in:
+
+```text
+docs/AI_PROMPT_KIT_V10_XML_AND_CLIPBOARD_RECORD.md
+```
+
+The executable package diagnostic is:
+
+```text
+python -m triage.workbook_package_hygiene <workbook.xlsx>
+```
+
 ## Background
 
 A generated prompt-library workbook went through multiple iterations. The visible workbook looked increasingly polished, but two classes of failures emerged:
@@ -257,41 +269,45 @@ Use precise claims:
 
 Do not collapse these gates into `done`.
 
-## Suggested validator additions
+## Executable validator
 
-Future validator work can add a package check that inspects `.xlsx` internals directly:
+The read-only package validator now lives at:
+
+```text
+triage/workbook_package_hygiene.py
+```
+
+Run it with:
 
 ```text
 python -m triage.workbook_package_hygiene <workbook.xlsx>
 ```
 
-Suggested checks:
-
-- parse ZIP parts,
-- parse workbook relationships,
-- parse worksheet dimensions,
-- detect overlapping merge ranges,
-- inspect table XML refs,
-- ensure table IDs are unique,
-- compare table column names against visible header cells,
-- inspect freeze-pane nodes,
-- scan formulas/errors if available,
-- emit JSON plus human-readable matrix.
-
-Suggested output:
+Optional evidence expectations:
 
 ```text
-WORKBOOK PACKAGE HYGIENE
-[PASS] ZIP integrity
-[PASS] table ids unique
-[PASS] table refs match visible ranges
-[PASS] merge ranges non-overlapping
-[PASS] freeze panes present where claimed
-[PASS] formula/error scan
-[WARN] clipboard acceptance requires manual test
-
-Result: package-valid, manual clipboard acceptance pending
+--expect-freeze <sheet>
+--copy-surface <sheet>
+--json
 ```
+
+It inspects the OOXML ZIP directly and does not rewrite the workbook.
+
+Checks include:
+
+- ZIP integrity,
+- XML well-formedness,
+- table IDs and names,
+- table refs and autoFilter refs,
+- table column counts,
+- visible table headers,
+- overlapping merge ranges,
+- expected freeze panes,
+- missing worksheet dimensions as metadata warnings,
+- formula/error literal markers,
+- copy-surface package shape.
+
+The copy-surface check is deliberately limited. It can identify a risky shape, but only the operator's actual Ctrl+A/Ctrl+C workflow proves clipboard acceptance.
 
 ## Practical rule
 

--- a/docs/handoff/PR51_WORKBOOK_PACKAGE_HYGIENE_VALIDATION.md
+++ b/docs/handoff/PR51_WORKBOOK_PACKAGE_HYGIENE_VALIDATION.md
@@ -1,0 +1,79 @@
+# PR #51 Workbook Package Hygiene Validation
+
+## Context
+
+- Repo: `EndeavorEverlasting/web-excel-repair-triage`
+- Branch: `docs/workbook-copy-surface-ooxml-lessons`
+- PR: #51
+- Lane: read-only OOXML package hygiene and clipboard-risk diagnostics
+- Validation commit: `4ec677fda17414c3f05b2ea0840799cbd2ed42b5`
+- Workflow run: `29166975682` (`Artifact engine tests`, run 142)
+
+## Why CI was split
+
+The package-hygiene test initially ran inside the broad `artifact-engines` job. The focused test passed, but the job still concluded failure because an unrelated broad artifact-engine test failed afterward.
+
+That structure erased the distinction between:
+
+- proof that the new workbook package hygiene lane works, and
+- proof that the repository's broader artifact-engine battery is fully green.
+
+The workflow now exposes a separate job:
+
+```text
+workbook-package-hygiene
+```
+
+The existing broad lane remains:
+
+```text
+artifact-engines
+```
+
+This is evidence isolation, not failure suppression. The broad job still runs and remains authoritative for its own scope.
+
+## Focused CI proof
+
+The `workbook-package-hygiene` job completed successfully with all of these steps green:
+
+- checkout
+- Python 3.11 setup
+- pytest installation
+- `triage.workbook_package_hygiene` import
+- `tests/test_workbook_package_hygiene.py`
+- `python -m triage.workbook_package_hygiene --help`
+
+This establishes:
+
+- import proof,
+- synthetic test proof,
+- CLI entry-point proof.
+
+It does not establish:
+
+- Excel for Web acceptance,
+- Microsoft clipboard behavior,
+- operator acceptance of every workbook,
+- broad artifact-engine health.
+
+## Broad-suite posture
+
+The `artifact-engines` job remains separate. A failure in that job must be investigated on its own evidence and must not be attributed to the workbook package hygiene lane unless the traceback points to the files changed by PR #51.
+
+Do not set `continue-on-error` and do not weaken the broad suite to make this PR appear green.
+
+## Files in the package-hygiene lane
+
+```text
+triage/workbook_package_hygiene.py
+tests/test_workbook_package_hygiene.py
+docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md
+docs/AI_PROMPT_KIT_V10_XML_AND_CLIPBOARD_RECORD.md
+.github/workflows/artifact-engines.yml
+```
+
+## Acceptance statement
+
+PR #51 has isolated harness proof for the new workbook package hygiene validator.
+
+Merge readiness still depends on repository policy for unrelated failing checks. If branch protection requires the broad `artifact-engines` job to pass, repair that failure in its owning lane rather than weakening or disguising it here.

--- a/tests/test_copy_surface_bounds.py
+++ b/tests/test_copy_surface_bounds.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from triage.copy_surface_bounds import inspect_copy_surface_bounds
+
+
+CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+
+ROOT_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+WORKBOOK = """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="P07_COPY_SAFE" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"""
+
+WORKBOOK_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+BOUNDED_SHEET = """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:A2"/>
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>EXECUTE.</t></is></c></row>
+    <row r="2"><c r="A2" t="inlineStr"><is><t>Repo: xyz</t></is></c></row>
+  </sheetData>
+</worksheet>"""
+
+BLOATED_SHEET = """<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:A160"/>
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>EXECUTE.</t></is></c></row>
+    <row r="2"><c r="A2" t="inlineStr"><is><t>Repo: xyz</t></is></c></row>
+    <row r="160"><c r="A160" s="7"/></row>
+  </sheetData>
+</worksheet>"""
+
+
+def write_fixture(path: Path, worksheet: str) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", CONTENT_TYPES)
+        archive.writestr("_rels/.rels", ROOT_RELS)
+        archive.writestr("xl/workbook.xml", WORKBOOK)
+        archive.writestr("xl/_rels/workbook.xml.rels", WORKBOOK_RELS)
+        archive.writestr("xl/worksheets/sheet1.xml", worksheet)
+
+
+class CopySurfaceBoundsTests(unittest.TestCase):
+    def test_bounded_surface_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bounded.xlsx"
+            write_fixture(path, BOUNDED_SHEET)
+            report = inspect_copy_surface_bounds(
+                str(path), sheets=["P07_COPY_SAFE"], max_trailing_rows=0
+            )
+            self.assertTrue(report.pass_all)
+            self.assertEqual("PASS", report.surfaces[0].status)
+            self.assertEqual(0, report.surfaces[0].trailing_rows)
+
+    def test_styled_blank_rows_fail_strict_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bloated.xlsx"
+            write_fixture(path, BLOATED_SHEET)
+            report = inspect_copy_surface_bounds(
+                str(path), sheets=["P07_COPY_SAFE"], max_trailing_rows=0
+            )
+            self.assertFalse(report.pass_all)
+            surface = report.surfaces[0]
+            self.assertEqual("FAIL", surface.status)
+            self.assertEqual(2, surface.last_payload_row)
+            self.assertEqual(160, surface.package_end_row)
+            self.assertEqual(158, surface.trailing_rows)
+
+    def test_missing_sheet_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "bounded.xlsx"
+            write_fixture(path, BOUNDED_SHEET)
+            report = inspect_copy_surface_bounds(str(path), sheets=["P14_COPY_SAFE"])
+            self.assertFalse(report.pass_all)
+            self.assertEqual(["P14_COPY_SAFE"], report.missing_sheets)
+
+    def test_negative_allowance_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "zero or greater"):
+            inspect_copy_surface_bounds("unused.xlsx", sheets=["P00_COPY_SAFE"], max_trailing_rows=-1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_prompt_kit_contract.py
+++ b/tests/test_prompt_kit_contract.py
@@ -4,11 +4,18 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
-from xml.sax.saxutils import escape
 
-from triage.prompt_kit_contract import validate_prompt_kit_contract
+from triage.prompt_kit_contract import (
+    EXPECTED_COPY_SHEETS,
+    LIBRARY_HEADERS,
+    PROMPT_IDS,
+    validate_prompt_kit_contract,
+)
 
-CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+# ─────────────────── OOXML skeleton parts ───────────────────
+
+CONTENT_TYPES = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
   <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
   <Default Extension="xml" ContentType="application/xml"/>
@@ -16,293 +23,408 @@ CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
   <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
 </Types>"""
 
-ROOT_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+ROOT_RELS = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
   <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
 </Relationships>"""
 
-STYLES = """<?xml version="1.0" encoding="UTF-8"?>
+STYLES_APTOS = """\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
-  <fonts count="4">
+  <fonts count="3">
     <font><sz val="11"/><name val="Aptos"/></font>
     <font><b/><sz val="11"/><name val="Aptos"/></font>
     <font><sz val="12"/><name val="Aptos"/></font>
-    <font><sz val="11"/><name val="Calibri"/></font>
   </fonts>
   <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
   <borders count="1"><border/></borders>
-  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
-  <cellXfs count="4">
-    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
-    <xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>
-    <xf numFmtId="0" fontId="2" fillId="0" borderId="0" xfId="0" applyFont="1"/>
-    <xf numFmtId="0" fontId="3" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+  <cellStyleXfs count="1"><xf/></cellStyleXfs>
+  <cellXfs count="3">
+    <xf fontId="0"/>
+    <xf fontId="1"/>
+    <xf fontId="2"/>
   </cellXfs>
 </styleSheet>"""
 
 
-def cell(ref: str, value: str = "", style: int = 0) -> str:
-    style_attr = f' s="{style}"' if style else ""
-    if value:
-        return (
-            f'<c r="{ref}"{style_attr} t="inlineStr"><is><t>'
-            f'{escape(value)}</t></is></c>'
-        )
-    return f'<c r="{ref}"{style_attr}/>'
+def _make_workbook_xml(sheet_entries: list[tuple[str, int, str]]) -> str:
+    """Build workbook.xml. sheet_entries = [(name, sheet_id, rId)]."""
+    sheets_xml = "\n".join(
+        f'    <sheet name="{name}" sheetId="{sid}" r:id="{rid}"/>'
+        for name, sid, rid in sheet_entries
+    )
+    return f"""\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>
+{sheets_xml}
+  </sheets>
+</workbook>"""
 
 
-def worksheet(
-    rows: list[str],
-    dimension: str,
-    hyperlinks: list[tuple[str, str]] | None = None,
+def _make_workbook_rels(sheet_entries: list[tuple[str, str]]) -> str:
+    """Build workbook.xml.rels. sheet_entries = [(rId, target)]."""
+    rels_xml = "\n".join(
+        f'  <Relationship Id="{rid}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="{target}"/>'
+        for rid, target in sheet_entries
+    )
+    return f"""\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+{rels_xml}
+</Relationships>"""
+
+
+def _make_sheet_xml(
+    rows: dict[int, dict[str, str]],
+    *,
+    font_map: dict[str, int] | None = None,
 ) -> str:
-    links = ""
-    if hyperlinks:
-        links = "<hyperlinks>" + "".join(
-            f'<hyperlink ref="{ref}" location="{escape(location)}"/>'
-            for ref, location in hyperlinks
-        ) + "</hyperlinks>"
-    return (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
-        f'<dimension ref="{dimension}"/><sheetData>{"".join(rows)}</sheetData>'
-        f'{links}</worksheet>'
-    )
+    """Build a minimal worksheet XML.
+
+    rows: {row_num: {"A": "val", "B": "val", ...}}
+    font_map: {cell_ref: style_index} e.g. {"H1": 1, "H2": 2}
+    """
+    cells_xml_parts: list[str] = []
+    for row_num in sorted(rows.keys()):
+        row_cells = rows[row_num]
+        cells = []
+        for col, val in sorted(row_cells.items()):
+            ref = f"{col}{row_num}"
+            style_attr = ""
+            if font_map and ref in font_map:
+                style_attr = f' s="{font_map[ref]}"'
+            cells.append(f'      <c r="{ref}" t="inlineStr"{style_attr}><is><t>{val}</t></is></c>')
+        cells_xml_parts.append(f'    <row r="{row_num}">\n' + "\n".join(cells) + "\n    </row>")
+    cells_xml = "\n".join(cells_xml_parts)
+
+    return f"""\
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetData>
+{cells_xml}
+  </sheetData>
+</worksheet>"""
 
 
-def row(number: int, cells: list[str]) -> str:
-    return f'<row r="{number}">{"".join(cells)}</row>'
+def _make_library_header_row() -> dict[str, str]:
+    """Row 1 of Prompt_Library with correct headers."""
+    row: dict[str, str] = {}
+    for i, header in enumerate(LIBRARY_HEADERS):
+        col = chr(65 + i) if i < 26 else chr(64 + i // 26) + chr(65 + i % 26)
+        row[col] = header
+    return row
 
 
-def write_fixture(path: Path, *, broken: bool = False) -> None:
-    sheets = [
-        "Prompt_Library",
-        "Prompt_Class_Legend",
-        "P00_COPY_SAFE",
-        "P01_COPY_SAFE",
+def _make_library_data_row(
+    seq: int,
+    prompt_id: str,
+    color: str,
+    copy_sheet: str,
+    *,
+    description: str = "Use this when needed.",
+) -> dict[str, str]:
+    """Build one data row for the Prompt_Library."""
+    return {
+        "A": f"{seq:02d}",
+        "B": prompt_id,
+        "C": "BUILD",
+        "D": "SPRINT / BUILD",
+        "E": "Execute bounded work",
+        "F": "YES",
+        "G": f"{prompt_id} Executor",
+        "H": description,
+        "I": "Inspect first.",
+        "J": "Output.",
+        "K": "Next.",
+        "L": "Gate.",
+        "M": color,
+        "N": copy_sheet,
+    }
+
+
+def _make_legend_xml(header_row: int, entries: dict[str, tuple[str, str]]) -> str:
+    """Build Prompt_Class_Legend worksheet XML.
+
+    entries = {"Slate": ("SETUP", "Install baseline"), ...}
+    """
+    rows: dict[int, dict[str, str]] = {}
+    rows[header_row] = {
+        "A": "Prompt Type",
+        "B": "Prompt Class",
+        "D": "When to Use",
+        "H": "Color",
+    }
+    for i, (color, (ptype, when)) in enumerate(entries.items()):
+        row_num = header_row + 1 + i
+        rows[row_num] = {"A": ptype, "B": ptype, "D": when, "H": color}
+    return _make_sheet_xml(rows)
+
+
+def _build_passing_fixture(tmp: Path, *, compact: bool = True) -> Path:
+    """Build a complete passing V19 fixture and return its path."""
+    path = tmp / "passing.xlsx"
+
+    sheet_entries_wb: list[tuple[str, int, str]] = []
+    sheet_entries_rels: list[tuple[str, str]] = []
+    sheet_xmls: dict[str, str] = {}
+
+    # Prompt_Library
+    lib_rows: dict[int, dict[str, str]] = {1: _make_library_header_row()}
+    copy_sheet_map: dict[str, int] = {}
+
+    colors = [
+        "Slate", "Gray", "Sky", "Amber", "Blue",
+        "Green", "Rose", "Purple", "Peach", "Teal",
+        "Gray", "Lavender", "Cyan", "Indigo", "Blue-Green",
+        "Gold", "Sand", "Orange", "Emerald", "Slate", "Amber",
     ]
-    workbook_sheets = "".join(
-        f'<sheet name="{name}" sheetId="{index}" r:id="rId{index}"/>'
-        for index, name in enumerate(sheets, start=1)
-    )
-    workbook = (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
-        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
-        f'<sheets>{workbook_sheets}</sheets></workbook>'
-    )
-    workbook_rels = (
-        '<?xml version="1.0" encoding="UTF-8"?>'
-        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
-        + "".join(
-            f'<Relationship Id="rId{index}" '
-            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
-            f'Target="worksheets/sheet{index}.xml"/>'
-            for index in range(1, len(sheets) + 1)
+
+    for i, pid in enumerate(PROMPT_IDS):
+        sheet_name = f"{pid}_COPY_SAFE"
+        copy_sheet_map[sheet_name] = i + 4  # after START_HERE, Prompt_Library, Prompt_Class_Legend
+        seq = i
+        copy_ref = f"{pid}_COPY_SAFE"
+        color = colors[i % len(colors)]
+
+        # Build copy-safe payload (3 rows, no blanks)
+        payload_rows: dict[int, dict[str, str]] = {
+            1: {"A": f"EXECUTE {pid}"},
+            2: {"A": "Second line."},
+            3: {"A": "Third line."},
+        }
+        sheet_xmls[sheet_name] = _make_sheet_xml(payload_rows)
+        lib_rows[i + 2] = _make_library_data_row(seq, pid, color, copy_ref)
+
+    # Library font map: H1 bold (style 1), H2-H22 regular 12pt (style 2)
+    lib_font_map: dict[str, int] = {"H1": 1}
+    for i in range(21):
+        lib_font_map[f"H{i + 2}"] = 2
+    sheet_xmls["Prompt_Library"] = _make_sheet_xml(lib_rows, font_map=lib_font_map)
+
+    # Prompt_Class_Legend
+    legend_entries: dict[str, tuple[str, str]] = {}
+    for i, pid in enumerate(PROMPT_IDS):
+        color = colors[i % len(colors)]
+        ptype = pid
+        legend_entries[color] = (ptype, f"When using {pid}")
+    sheet_xmls["Prompt_Class_Legend"] = _make_legend_xml(1, legend_entries)
+
+    # START_HERE
+    sheet_xmls["START_HERE"] = _make_sheet_xml({1: {"A": "Welcome"}})
+
+    # Assemble sheet entries
+    all_sheets = [("START_HERE", 1, "rId1"), ("Prompt_Library", 2, "rId2"), ("Prompt_Class_Legend", 3, "rId3")]
+    all_rels = [("rId1", "worksheets/sheet_start.xml"), ("rId2", "worksheets/sheet_lib.xml"), ("rId3", "worksheets/sheet_legend.xml")]
+
+    for i, pid in enumerate(PROMPT_IDS):
+        sn = f"{pid}_COPY_SAFE"
+        sid = i + 4
+        rid = f"rId{i + 4}"
+        all_sheets.append((sn, sid, rid))
+        all_rels.append((rid, f"worksheets/sheet_{pid.lower()}.xml"))
+
+    wb_xml = _make_workbook_xml(all_sheets)
+    wb_rels = _make_workbook_rels(all_rels)
+
+    # Write ZIP
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", CONTENT_TYPES)
+        z.writestr("_rels/.rels", ROOT_RELS)
+        z.writestr("xl/workbook.xml", wb_xml)
+        z.writestr("xl/_rels/workbook.xml.rels", wb_rels)
+        z.writestr("xl/styles.xml", STYLES_APTOS)
+
+        # Write sheet parts (skip Prompt_Library; written below with hyperlinks)
+        part_map = {
+            "START_HERE": "xl/worksheets/sheet_start.xml",
+            "Prompt_Class_Legend": "xl/worksheets/sheet_legend.xml",
+        }
+        for pid in PROMPT_IDS:
+            part_map[f"{pid}_COPY_SAFE"] = f"xl/worksheets/sheet_{pid.lower()}.xml"
+
+        for sheet_name, part_path in part_map.items():
+            z.writestr(part_path, sheet_xmls[sheet_name])
+
+        # Build and write hyperlink rels for Prompt_Library
+        lib_rels_entries: list[str] = []
+        lib_hyperlinks: list[str] = []
+        for i, pid in enumerate(PROMPT_IDS):
+            row_num = i + 2
+            rid = f"rIdHL{i}"
+            target_sheet = f"{pid}_COPY_SAFE"
+            endpoint = f"{target_sheet}!A1:A3"
+            lib_rels_entries.append(
+                f'  <Relationship Id="{rid}" '
+                f'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" '
+                f'Target="{endpoint}" TargetMode="External"/>'
+            )
+            lib_hyperlinks.append(
+                f'  <hyperlink ref="N{row_num}" r:id="{rid}"/>'
+            )
+            lib_hyperlinks.append(
+                f'  <hyperlink ref="B{row_num}" r:id="{rid}"/>'
+            )
+
+        lib_rels_xml = (
+            '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>\n'
+            '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">\n'
+            + "\n".join(lib_rels_entries)
+            + "\n</Relationships>"
         )
-        + '<Relationship Id="rIdStyles" '
-        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" '
-        'Target="styles.xml"/>'
-        '</Relationships>'
-    )
+        z.writestr("xl/worksheets/_rels/sheet_lib.xml.rels", lib_rels_xml)
 
-    color_header = "Color Meaning" if broken else "Color"
-    p01_location = "P01_COPY_SAFE!A1" if broken else "P01_COPY_SAFE!A1:A2"
-    body_style = 0 if broken else 2
-    prompt_id_style = 3 if broken else 0
-    library_rows = [
-        row(
-            1,
-            [
-                cell("B1", "Prompt ID"),
-                cell("H1", "Use This When", 1),
-                cell("M1", color_header),
-                cell("N1", "Copy-Safe Sheet"),
-            ],
-        ),
-        row(
-            2,
-            [
-                cell("B2", "P00", prompt_id_style),
-                cell("H2", "Set baseline behavior", body_style),
-                cell("M2", "Green"),
-                cell("N2", "P00_COPY_SAFE"),
-            ],
-        ),
-        row(
-            3,
-            [
-                cell("B3", "P01"),
-                cell("H3", "Bootstrap the harness", body_style),
-                cell("M3", "Amber"),
-                cell("N3", "P01_COPY_SAFE"),
-            ],
-        ),
-    ]
-    library_links = [
-        ("B2", "P00_COPY_SAFE!A1:A2"),
-        ("N2", "P00_COPY_SAFE!A1:A2"),
-        ("B3", p01_location),
-        ("N3", p01_location),
-    ]
-    library = worksheet(library_rows, "B1:N3", library_links)
+        # Rewrite Prompt_Library with hyperlinks
+        base_lib = sheet_xmls["Prompt_Library"]
+        # Insert hyperlinks before </worksheet>
+        hl_block = "  <hyperlinks>\n" + "\n".join(lib_hyperlinks) + "\n  </hyperlinks>\n"
+        lib_with_hl = base_lib.replace("  </sheetData>\n</worksheet>", f"  </sheetData>\n{hl_block}</worksheet>")
+        z.writestr("xl/worksheets/sheet_lib.xml", lib_with_hl)
 
-    legend_rows = [
-        row(
-            1,
-            [
-                cell("A1", "Color", 1),
-                cell("B1", "Operational Meaning", 1),
-            ],
-        ),
-        row(
-            2,
-            [
-                cell("A2", "Green"),
-                cell("B2", "Build or mutate owned repository scope"),
-            ],
-        ),
-        row(
-            3,
-            [
-                cell("A3", "Amber"),
-                cell(
-                    "B3",
-                    "Plan or distribute bounded work" if not broken else "",
-                ),
-            ],
-        ),
-    ]
-    legend = worksheet(legend_rows, "A1:B3")
+    return path
 
-    p00 = worksheet(
-        [
-            row(1, [cell("A1", "MISSION")]),
-            row(2, [cell("A2", "Execute the bounded sprint.")]),
-        ],
-        "A1:A2",
-    )
-    if broken:
-        p01 = worksheet(
-            [
-                row(1, [cell("A1", "MISSION")]),
-                row(2, []),
-                row(3, [cell("A3", "Bootstrap the harness.")]),
-                row(4, [cell("A4", "", 2)]),
-            ],
-            "A1:A4",
-        )
-    else:
-        p01 = worksheet(
-            [
-                row(1, [cell("A1", "MISSION")]),
-                row(2, [cell("A2", "Bootstrap the harness.")]),
-            ],
-            "A1:A2",
-        )
 
-    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
-        archive.writestr("[Content_Types].xml", CONTENT_TYPES)
-        archive.writestr("_rels/.rels", ROOT_RELS)
-        archive.writestr("xl/workbook.xml", workbook)
-        archive.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
-        archive.writestr("xl/styles.xml", STYLES)
-        archive.writestr("xl/worksheets/sheet1.xml", library)
-        archive.writestr("xl/worksheets/sheet2.xml", legend)
-        archive.writestr("xl/worksheets/sheet3.xml", p00)
-        archive.writestr("xl/worksheets/sheet4.xml", p01)
+# ─────────────────── Tests ───────────────────
 
 
 class PromptKitContractTests(unittest.TestCase):
-    def test_healthy_contract_passes(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "healthy.xlsx"
-            write_fixture(path)
-            report = validate_prompt_kit_contract(
-                path, prompt_ids=["P00", "P01"]
-            )
-            self.assertTrue(report.pass_all, report.render_text())
-            self.assertTrue(
-                all(check.status == "PASS" for check in report.checks)
-            )
-            self.assertEqual(
-                [0, 0],
-                [
-                    surface["internal_blank_rows"]
-                    for surface in report.copy_surfaces
-                ],
-            )
-            self.assertEqual(
-                [0, 0],
-                [surface["trailing_rows"] for surface in report.copy_surfaces],
-            )
 
-    def test_broken_contract_reports_cross_surface_failures(self) -> None:
+    def test_passing_fixture_satisfies_contract(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _build_passing_fixture(Path(tmp))
+            report = validate_prompt_kit_contract(str(path))
+            self.assertTrue(report.contract_valid, report.render_text())
+            self.assertFalse(report.failures)
+
+    def test_cross_surface_failures_detected(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "broken.xlsx"
-            write_fixture(path, broken=True)
-            report = validate_prompt_kit_contract(
-                path, prompt_ids=["P00", "P01"]
-            )
-            self.assertFalse(report.pass_all)
-            by_name = {check.name: check for check in report.checks}
-            expected_failures = {
-                "visible fonts approved",
-                "Prompt Library contract columns",
-                "Prompt Library column H typography",
-                "copy surfaces dense and bounded",
-                "Prompt Library links select exact payload ranges",
-                "Prompt Class Legend covers every library color",
-            }
-            self.assertTrue(
-                expected_failures.issubset(
-                    {
-                        name
-                        for name, check in by_name.items()
-                        if check.status == "FAIL"
-                    }
+            # Missing several sheets, bad headers, wrong font
+            lib_rows: dict[int, dict[str, str]] = {1: {"A": "Wrong", "B": "Header"}}
+            lib_rows[2] = _make_library_data_row(0, "P00", "Slate", "P00_COPY_SAFE")
+            lib_font_map: dict[str, int] = {"H1": 0, "H2": 0}  # font 0 = Aptos 11pt, not 12pt
+            lib_xml = _make_sheet_xml(lib_rows, font_map=lib_font_map)
+
+            with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+                z.writestr("[Content_Types].xml", CONTENT_TYPES)
+                z.writestr("_rels/.rels", ROOT_RELS)
+                z.writestr("xl/styles.xml", STYLES_APTOS)
+                z.writestr("xl/workbook.xml", _make_workbook_xml([
+                    ("Prompt_Library", 1, "rId1"),
+                ]))
+                z.writestr("xl/_rels/workbook.xml.rels", _make_workbook_rels([
+                    ("rId1", "worksheets/sheet_lib.xml"),
+                ]))
+                z.writestr("xl/worksheets/sheet_lib.xml", lib_xml)
+
+            report = validate_prompt_kit_contract(str(path))
+            self.assertFalse(report.contract_valid)
+            by_name = {c.name: c for c in report.checks}
+            self.assertEqual("FAIL", by_name["required prompt tabs"].status)
+            self.assertEqual("FAIL", by_name["Prompt Library headers"].status)
+            self.assertEqual("FAIL", by_name["Prompt_Class_Legend present"].status)
+
+    def test_stale_hyperlink_endpoints_after_compaction(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "stale_links.xlsx"
+            # Build a fixture where hyperlinks target A1:A100 but payload is only 3 rows
+            lib_rows: dict[int, dict[str, str]] = {1: _make_library_header_row()}
+            for i, pid in enumerate(PROMPT_IDS):
+                lib_rows[i + 2] = _make_library_data_row(i, pid, "Slate", f"{pid}_COPY_SAFE")
+            lib_font_map: dict[str, int] = {"H1": 1}
+            for i in range(21):
+                lib_font_map[f"H{i + 2}"] = 2
+
+            # Build copy-safe sheets (3 rows each)
+            copy_xmls: dict[str, str] = {}
+            for pid in PROMPT_IDS:
+                copy_xmls[pid] = _make_sheet_xml({1: {"A": "Line 1"}, 2: {"A": "Line 2"}, 3: {"A": "Line 3"}})
+
+            # Build library XML with hyperlinks targeting A1:A100 (stale)
+            lib_base = _make_sheet_xml(lib_rows, font_map=lib_font_map)
+            hl_parts: list[str] = []
+            rels_parts: list[str] = []
+            for i, pid in enumerate(PROMPT_IDS):
+                row_num = i + 2
+                rid = f"rIdHL{i}"
+                rels_parts.append(
+                    f'  <Relationship Id="{rid}" '
+                    f'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink" '
+                    f'Target="{pid}_COPY_SAFE!A1:A100" TargetMode="External"/>'
                 )
+                hl_parts.append(f'  <hyperlink ref="N{row_num}" r:id="{rid}"/>')
+                hl_parts.append(f'  <hyperlink ref="B{row_num}" r:id="{rid}"/>')
+
+            lib_with_hl = lib_base.replace(
+                "  </sheetData>\n</worksheet>",
+                f"  </sheetData>\n  <hyperlinks>\n" + "\n".join(hl_parts) + "\n  </hyperlinks>\n</worksheet>",
             )
 
-    def test_exact_range_link_tracks_compacted_payload_end(self) -> None:
-        with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "broken.xlsx"
-            write_fixture(path, broken=True)
-            report = validate_prompt_kit_contract(
-                path, prompt_ids=["P00", "P01"]
-            )
-            links = next(
-                check
-                for check in report.checks
-                if check.name
-                == "Prompt Library links select exact payload ranges"
-            )
-            self.assertEqual("FAIL", links.status)
-            p01 = [
-                finding
-                for finding in links.findings
-                if finding.get("prompt_id") == "P01"
-            ]
-            self.assertTrue(p01)
-            self.assertTrue(
-                all(
-                    finding["expected"] == "P01_COPY_SAFE!A1:A3"
-                    for finding in p01
+            with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+                z.writestr("[Content_Types].xml", CONTENT_TYPES)
+                z.writestr("_rels/.rels", ROOT_RELS)
+                z.writestr("xl/styles.xml", STYLES_APTOS)
+                entries = [("Prompt_Library", 1, "rId1")]
+                rels = [("rId1", "worksheets/sheet_lib.xml")]
+                for j, pid in enumerate(PROMPT_IDS):
+                    entries.append((f"{pid}_COPY_SAFE", j + 2, f"rId{j + 2}"))
+                    rels.append((f"rId{j + 2}", f"worksheets/sheet_{pid.lower()}.xml"))
+                z.writestr("xl/workbook.xml", _make_workbook_xml(entries))
+                z.writestr("xl/_rels/workbook.xml.rels", _make_workbook_rels(rels))
+                z.writestr("xl/worksheets/sheet_lib.xml", lib_with_hl)
+                rels_xml = (
+                    '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+                    '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+                    + "".join(rels_parts)
+                    + "</Relationships>"
                 )
-            )
+                z.writestr("xl/worksheets/_rels/sheet_lib.xml.rels", rels_xml)
+                for pid in PROMPT_IDS:
+                    z.writestr(f"xl/worksheets/sheet_{pid.lower()}.xml", copy_xmls[pid])
 
-    def test_default_contract_requires_all_21_prompt_sheets(self) -> None:
+            report = validate_prompt_kit_contract(str(path))
+            by_name = {c.name: c for c in report.checks}
+            self.assertEqual("FAIL", by_name["hyperlink endpoints"].status)
+            # Verify expected endpoint is A1:A3, not A1:A100
+            first_finding = by_name["hyperlink endpoints"].findings[0]
+            self.assertIn("A1:A3", first_finding["expected"])
+            self.assertIn("A1:A100", first_finding["actual"])
+
+    def test_requires_all_21_prompt_sheets(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
-            path = Path(tmp) / "partial.xlsx"
-            write_fixture(path)
-            report = validate_prompt_kit_contract(path)
-            required = next(
-                check
-                for check in report.checks
-                if check.name == "required sheets"
-            )
-            self.assertEqual("FAIL", required.status)
-            self.assertIn({"sheet": "P20_COPY_SAFE"}, required.findings)
+            path = Path(tmp) / "incomplete.xlsx"
+            # Only provide 5 copy-safe sheets
+            lib_rows: dict[int, dict[str, str]] = {1: _make_library_header_row()}
+            with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+                z.writestr("[Content_Types].xml", CONTENT_TYPES)
+                z.writestr("_rels/.rels", ROOT_RELS)
+                z.writestr("xl/styles.xml", STYLES_APTOS)
+
+                entries = [("Prompt_Library", 1, "rId1")]
+                rels = [("rId1", "worksheets/sheet_lib.xml")]
+
+                for i in range(5):
+                    pid = PROMPT_IDS[i]
+                    sn = f"{pid}_COPY_SAFE"
+                    entries.append((sn, i + 2, f"rId{i + 2}"))
+                    rels.append((f"rId{i + 2}", f"worksheets/sheet_{pid.lower()}.xml"))
+                    lib_rows[i + 2] = _make_library_data_row(i, pid, "Slate", sn)
+                    z.writestr(f"xl/worksheets/sheet_{pid.lower()}.xml", _make_sheet_xml(
+                        {1: {"A": f"Line for {pid}"}},
+                    ))
+
+                lib_xml = _make_sheet_xml(lib_rows)
+                z.writestr("xl/workbook.xml", _make_workbook_xml(entries))
+                z.writestr("xl/_rels/workbook.xml.rels", _make_workbook_rels(rels))
+                z.writestr("xl/worksheets/sheet_lib.xml", lib_xml)
+
+            report = validate_prompt_kit_contract(str(path))
+            by_name = {c.name: c for c in report.checks}
+            self.assertEqual("FAIL", by_name["required prompt tabs"].status)
+            self.assertEqual(16, len(by_name["required prompt tabs"].findings))
 
 
 if __name__ == "__main__":

--- a/tests/test_prompt_kit_contract.py
+++ b/tests/test_prompt_kit_contract.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from xml.sax.saxutils import escape
+
+from triage.prompt_kit_contract import validate_prompt_kit_contract
+
+CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>"""
+
+ROOT_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+STYLES = """<?xml version="1.0" encoding="UTF-8"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <fonts count="4">
+    <font><sz val="11"/><name val="Aptos"/></font>
+    <font><b/><sz val="11"/><name val="Aptos"/></font>
+    <font><sz val="12"/><name val="Aptos"/></font>
+    <font><sz val="11"/><name val="Calibri"/></font>
+  </fonts>
+  <fills count="1"><fill><patternFill patternType="none"/></fill></fills>
+  <borders count="1"><border/></borders>
+  <cellStyleXfs count="1"><xf numFmtId="0" fontId="0" fillId="0" borderId="0"/></cellStyleXfs>
+  <cellXfs count="4">
+    <xf numFmtId="0" fontId="0" fillId="0" borderId="0" xfId="0"/>
+    <xf numFmtId="0" fontId="1" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+    <xf numFmtId="0" fontId="2" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+    <xf numFmtId="0" fontId="3" fillId="0" borderId="0" xfId="0" applyFont="1"/>
+  </cellXfs>
+</styleSheet>"""
+
+
+def cell(ref: str, value: str = "", style: int = 0) -> str:
+    style_attr = f' s="{style}"' if style else ""
+    if value:
+        return (
+            f'<c r="{ref}"{style_attr} t="inlineStr"><is><t>'
+            f'{escape(value)}</t></is></c>'
+        )
+    return f'<c r="{ref}"{style_attr}/>'
+
+
+def worksheet(
+    rows: list[str],
+    dimension: str,
+    hyperlinks: list[tuple[str, str]] | None = None,
+) -> str:
+    links = ""
+    if hyperlinks:
+        links = "<hyperlinks>" + "".join(
+            f'<hyperlink ref="{ref}" location="{escape(location)}"/>'
+            for ref, location in hyperlinks
+        ) + "</hyperlinks>"
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        f'<dimension ref="{dimension}"/><sheetData>{"".join(rows)}</sheetData>'
+        f'{links}</worksheet>'
+    )
+
+
+def row(number: int, cells: list[str]) -> str:
+    return f'<row r="{number}">{"".join(cells)}</row>'
+
+
+def write_fixture(path: Path, *, broken: bool = False) -> None:
+    sheets = [
+        "Prompt_Library",
+        "Prompt_Class_Legend",
+        "P00_COPY_SAFE",
+        "P01_COPY_SAFE",
+    ]
+    workbook_sheets = "".join(
+        f'<sheet name="{name}" sheetId="{index}" r:id="rId{index}"/>'
+        for index, name in enumerate(sheets, start=1)
+    )
+    workbook = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" '
+        'xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">'
+        f'<sheets>{workbook_sheets}</sheets></workbook>'
+    )
+    workbook_rels = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">'
+        + "".join(
+            f'<Relationship Id="rId{index}" '
+            'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+            f'Target="worksheets/sheet{index}.xml"/>'
+            for index in range(1, len(sheets) + 1)
+        )
+        + '<Relationship Id="rIdStyles" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" '
+        'Target="styles.xml"/>'
+        '</Relationships>'
+    )
+
+    color_header = "Color Meaning" if broken else "Color"
+    p01_location = "P01_COPY_SAFE!A1" if broken else "P01_COPY_SAFE!A1:A2"
+    body_style = 0 if broken else 2
+    prompt_id_style = 3 if broken else 0
+    library_rows = [
+        row(
+            1,
+            [
+                cell("B1", "Prompt ID"),
+                cell("H1", "Use This When", 1),
+                cell("M1", color_header),
+                cell("N1", "Copy-Safe Sheet"),
+            ],
+        ),
+        row(
+            2,
+            [
+                cell("B2", "P00", prompt_id_style),
+                cell("H2", "Set baseline behavior", body_style),
+                cell("M2", "Green"),
+                cell("N2", "P00_COPY_SAFE"),
+            ],
+        ),
+        row(
+            3,
+            [
+                cell("B3", "P01"),
+                cell("H3", "Bootstrap the harness", body_style),
+                cell("M3", "Amber"),
+                cell("N3", "P01_COPY_SAFE"),
+            ],
+        ),
+    ]
+    library_links = [
+        ("B2", "P00_COPY_SAFE!A1:A2"),
+        ("N2", "P00_COPY_SAFE!A1:A2"),
+        ("B3", p01_location),
+        ("N3", p01_location),
+    ]
+    library = worksheet(library_rows, "B1:N3", library_links)
+
+    legend_rows = [
+        row(
+            1,
+            [
+                cell("A1", "Color", 1),
+                cell("B1", "Operational Meaning", 1),
+            ],
+        ),
+        row(
+            2,
+            [
+                cell("A2", "Green"),
+                cell("B2", "Build or mutate owned repository scope"),
+            ],
+        ),
+        row(
+            3,
+            [
+                cell("A3", "Amber"),
+                cell(
+                    "B3",
+                    "Plan or distribute bounded work" if not broken else "",
+                ),
+            ],
+        ),
+    ]
+    legend = worksheet(legend_rows, "A1:B3")
+
+    p00 = worksheet(
+        [
+            row(1, [cell("A1", "MISSION")]),
+            row(2, [cell("A2", "Execute the bounded sprint.")]),
+        ],
+        "A1:A2",
+    )
+    if broken:
+        p01 = worksheet(
+            [
+                row(1, [cell("A1", "MISSION")]),
+                row(2, []),
+                row(3, [cell("A3", "Bootstrap the harness.")]),
+                row(4, [cell("A4", "", 2)]),
+            ],
+            "A1:A4",
+        )
+    else:
+        p01 = worksheet(
+            [
+                row(1, [cell("A1", "MISSION")]),
+                row(2, [cell("A2", "Bootstrap the harness.")]),
+            ],
+            "A1:A2",
+        )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", CONTENT_TYPES)
+        archive.writestr("_rels/.rels", ROOT_RELS)
+        archive.writestr("xl/workbook.xml", workbook)
+        archive.writestr("xl/_rels/workbook.xml.rels", workbook_rels)
+        archive.writestr("xl/styles.xml", STYLES)
+        archive.writestr("xl/worksheets/sheet1.xml", library)
+        archive.writestr("xl/worksheets/sheet2.xml", legend)
+        archive.writestr("xl/worksheets/sheet3.xml", p00)
+        archive.writestr("xl/worksheets/sheet4.xml", p01)
+
+
+class PromptKitContractTests(unittest.TestCase):
+    def test_healthy_contract_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "healthy.xlsx"
+            write_fixture(path)
+            report = validate_prompt_kit_contract(
+                path, prompt_ids=["P00", "P01"]
+            )
+            self.assertTrue(report.pass_all, report.render_text())
+            self.assertTrue(
+                all(check.status == "PASS" for check in report.checks)
+            )
+            self.assertEqual(
+                [0, 0],
+                [
+                    surface["internal_blank_rows"]
+                    for surface in report.copy_surfaces
+                ],
+            )
+            self.assertEqual(
+                [0, 0],
+                [surface["trailing_rows"] for surface in report.copy_surfaces],
+            )
+
+    def test_broken_contract_reports_cross_surface_failures(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.xlsx"
+            write_fixture(path, broken=True)
+            report = validate_prompt_kit_contract(
+                path, prompt_ids=["P00", "P01"]
+            )
+            self.assertFalse(report.pass_all)
+            by_name = {check.name: check for check in report.checks}
+            expected_failures = {
+                "visible fonts approved",
+                "Prompt Library contract columns",
+                "Prompt Library column H typography",
+                "copy surfaces dense and bounded",
+                "Prompt Library links select exact payload ranges",
+                "Prompt Class Legend covers every library color",
+            }
+            self.assertTrue(
+                expected_failures.issubset(
+                    {
+                        name
+                        for name, check in by_name.items()
+                        if check.status == "FAIL"
+                    }
+                )
+            )
+
+    def test_exact_range_link_tracks_compacted_payload_end(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.xlsx"
+            write_fixture(path, broken=True)
+            report = validate_prompt_kit_contract(
+                path, prompt_ids=["P00", "P01"]
+            )
+            links = next(
+                check
+                for check in report.checks
+                if check.name
+                == "Prompt Library links select exact payload ranges"
+            )
+            self.assertEqual("FAIL", links.status)
+            p01 = [
+                finding
+                for finding in links.findings
+                if finding.get("prompt_id") == "P01"
+            ]
+            self.assertTrue(p01)
+            self.assertTrue(
+                all(
+                    finding["expected"] == "P01_COPY_SAFE!A1:A3"
+                    for finding in p01
+                )
+            )
+
+    def test_default_contract_requires_all_21_prompt_sheets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "partial.xlsx"
+            write_fixture(path)
+            report = validate_prompt_kit_contract(path)
+            required = next(
+                check
+                for check in report.checks
+                if check.name == "required sheets"
+            )
+            self.assertEqual("FAIL", required.status)
+            self.assertIn({"sheet": "P20_COPY_SAFE"}, required.findings)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_workbook_package_hygiene.py
+++ b/tests/test_workbook_package_hygiene.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from triage.workbook_package_hygiene import validate_workbook_package
+
+
+CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/tables/table1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.table+xml"/>
+</Types>"""
+
+ROOT_RELS = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+
+WORKBOOK = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="COPY_SAFE" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"""
+
+WORKBOOK_RELS = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+SHEET_RELS = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rIdTable1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/table" Target="../tables/table1.xml"/>
+</Relationships>"""
+
+GOOD_SHEET = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <dimension ref="A1:B2"/>
+  <sheetViews><sheetView workbookViewId="0"><pane ySplit="1" topLeftCell="A2" activePane="bottomLeft" state="frozen"/></sheetView></sheetViews>
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>Prompt</t></is></c><c r="B1" t="inlineStr"><is><t>Class</t></is></c></row>
+    <row r="2"><c r="A2" t="inlineStr"><is><t>EXECUTE THE REPO SPRINT.</t></is></c><c r="B2" t="inlineStr"><is><t>BUILD</t></is></c></row>
+  </sheetData>
+  <tableParts count="1"><tablePart r:id="rIdTable1"/></tableParts>
+</worksheet>"""
+
+GOOD_TABLE = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" id="1" name="CopySafe" displayName="CopySafe" ref="A1:B2" headerRowCount="1">
+  <autoFilter ref="A1:B2"/>
+  <tableColumns count="2"><tableColumn id="1" name="Prompt"/><tableColumn id="2" name="Class"/></tableColumns>
+  <tableStyleInfo name="TableStyleMedium2" showFirstColumn="0" showLastColumn="0" showRowStripes="1" showColumnStripes="0"/>
+</table>"""
+
+BROKEN_SHEET = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheetViews><sheetView workbookViewId="0"/></sheetViews>
+  <sheetData>
+    <row r="1"><c r="A1" t="inlineStr"><is><t>PASTE THIS DIRECTLY INTO THE AGENT CHAT.&#10;EXECUTE THE REPO SPRINT.</t></is></c></row>
+  </sheetData>
+  <mergeCells count="2"><mergeCell ref="A1:B1"/><mergeCell ref="A1:C1"/></mergeCells>
+  <tableParts count="1"><tablePart r:id="rIdTable1"/></tableParts>
+</worksheet>"""
+
+BROKEN_TABLE = """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<table xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" id="1" name="CopySafe" displayName="CopySafe" ref="A1:B2" headerRowCount="1">
+  <autoFilter ref="A1:C2"/>
+  <tableColumns count="1"><tableColumn id="1" name="Wrong"/></tableColumns>
+</table>"""
+
+
+def write_fixture(path: Path, *, broken: bool = False) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("[Content_Types].xml", CONTENT_TYPES)
+        z.writestr("_rels/.rels", ROOT_RELS)
+        z.writestr("xl/workbook.xml", WORKBOOK)
+        z.writestr("xl/_rels/workbook.xml.rels", WORKBOOK_RELS)
+        z.writestr("xl/worksheets/sheet1.xml", BROKEN_SHEET if broken else GOOD_SHEET)
+        z.writestr("xl/worksheets/_rels/sheet1.xml.rels", SHEET_RELS)
+        z.writestr("xl/tables/table1.xml", BROKEN_TABLE if broken else GOOD_TABLE)
+
+
+class WorkbookPackageHygieneTests(unittest.TestCase):
+    def test_healthy_fixture_passes_package_checks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "healthy.xlsx"
+            write_fixture(path)
+            report = validate_workbook_package(
+                str(path),
+                expected_freeze_sheets=["COPY_SAFE"],
+            )
+            self.assertTrue(report.package_valid, report.render_text())
+            self.assertFalse(report.failures)
+
+    def test_broken_fixture_reports_table_merge_freeze_and_copy_surface_risks(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "broken.xlsx"
+            write_fixture(path, broken=True)
+            report = validate_workbook_package(
+                str(path),
+                expected_freeze_sheets=["COPY_SAFE"],
+                copy_surface_sheets=["COPY_SAFE"],
+            )
+            by_name = {check.name: check for check in report.checks}
+            self.assertFalse(report.package_valid)
+            self.assertEqual("FAIL", by_name["table refs and filters"].status)
+            self.assertEqual("FAIL", by_name["table column counts"].status)
+            self.assertEqual("FAIL", by_name["visible headers match table XML"].status)
+            self.assertEqual("FAIL", by_name["merge ranges non-overlapping"].status)
+            self.assertEqual("FAIL", by_name["freeze panes"].status)
+            self.assertEqual("WARN", by_name["copy-surface package shape"].status)
+            findings = by_name["copy-surface package shape"].findings
+            issues = {item["issue"] for item in findings}
+            self.assertIn("multiline_cells_risk_wrapper_quotes", issues)
+            self.assertIn("guidance_contaminates_payload", issues)
+            self.assertEqual("manual_test_required", report.clipboard_acceptance)
+
+    def test_missing_file_is_a_failure(self) -> None:
+        report = validate_workbook_package("definitely-missing.xlsx")
+        self.assertFalse(report.package_valid)
+        self.assertEqual("file exists", report.failures[0].name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_worksheet_cell_integrity.py
+++ b/tests/test_worksheet_cell_integrity.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from triage.worksheet_cell_integrity import validate_worksheet_cell_integrity
+
+CONTENT_TYPES = """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+</Types>"""
+ROOT_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>"""
+WORKBOOK = """<?xml version="1.0" encoding="UTF-8"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+ xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Prompt_Class_Legend" sheetId="1" r:id="rId1"/></sheets>
+</workbook>"""
+WORKBOOK_RELS = """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>"""
+
+
+def worksheet(*, dimension: str, duplicate: bool = False) -> str:
+    duplicate_cell = '<c r="J4" s="47" t="inlineStr"><is><t>Color</t></is></c>' if duplicate else ""
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="{dimension}"/>
+  <sheetData>
+    <row r="4"><c r="J4" s="6"/>{duplicate_cell}</row>
+    <row r="100"><c r="Z100" s="7"/></row>
+  </sheetData>
+</worksheet>"""
+
+
+def write_fixture(path: Path, *, dimension: str = "A1:Z100", duplicate: bool = False) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("[Content_Types].xml", CONTENT_TYPES)
+        archive.writestr("_rels/.rels", ROOT_RELS)
+        archive.writestr("xl/workbook.xml", WORKBOOK)
+        archive.writestr("xl/_rels/workbook.xml.rels", WORKBOOK_RELS)
+        archive.writestr("xl/worksheets/sheet1.xml", worksheet(dimension=dimension, duplicate=duplicate))
+
+
+class WorksheetCellIntegrityTests(unittest.TestCase):
+    def test_unique_coordinates_and_covering_dimension_pass(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "healthy.xlsx"
+            write_fixture(path)
+            report = validate_worksheet_cell_integrity(str(path))
+            self.assertTrue(report.passed, report.render_text())
+            self.assertEqual(1, report.checked_sheets)
+
+    def test_v19_shaped_duplicate_cell_records_fail(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "duplicate.xlsx"
+            write_fixture(path, duplicate=True)
+            report = validate_worksheet_cell_integrity(str(path))
+            self.assertFalse(report.passed)
+            finding = next(item for item in report.findings if item.issue == "duplicate_cell_references")
+            self.assertEqual({"J4": 2}, finding.details["coordinates"])
+            self.assertEqual(1, finding.details["extra_cell_records"])
+
+    def test_dimension_that_excludes_existing_cells_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "stale-dimension.xlsx"
+            write_fixture(path, dimension="A1:K23")
+            report = validate_worksheet_cell_integrity(str(path))
+            self.assertFalse(report.passed)
+            finding = next(item for item in report.findings if item.issue == "dimension_excludes_explicit_cells")
+            self.assertEqual("A1:K23", finding.details["dimension"])
+            self.assertEqual((26, 100), tuple(finding.details["actual_end"]))
+
+    def test_missing_file_fails(self) -> None:
+        report = validate_worksheet_cell_integrity("missing.xlsx")
+        self.assertFalse(report.passed)
+        self.assertEqual("file_missing", report.findings[0].issue)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/triage/copy_surface_bounds.py
+++ b/triage/copy_surface_bounds.py
@@ -1,0 +1,248 @@
+"""Validate that copy-safe worksheet payloads end at their final populated row.
+
+Whole-sheet clipboard operations may include explicit row nodes, styled blank cells,
+or worksheet dimensions below the real prompt payload. This validator inspects the
+OOXML package without loading or rewriting the workbook.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import zipfile
+from dataclasses import asdict, dataclass
+from pathlib import Path, PurePosixPath
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+from xml.etree import ElementTree as ET
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+NS = {"m": MAIN_NS, "r": REL_NS}
+CELL_RE = re.compile(r"^([A-Z]+)(\d+)$")
+RANGE_RE = re.compile(r"^([A-Z]+)(\d+):([A-Z]+)(\d+)$")
+
+
+def _col_num(value: str) -> int:
+    result = 0
+    for char in value:
+        result = result * 26 + ord(char) - 64
+    return result
+
+
+def _cell_position(ref: str) -> Optional[Tuple[int, int]]:
+    match = CELL_RE.fullmatch(ref or "")
+    if not match:
+        return None
+    return _col_num(match.group(1)), int(match.group(2))
+
+
+def _dimension_end_row(ref: Optional[str]) -> int:
+    if not ref:
+        return 0
+    range_match = RANGE_RE.fullmatch(ref)
+    if range_match:
+        return int(range_match.group(4))
+    cell = _cell_position(ref)
+    return cell[1] if cell else 0
+
+
+def _resolve_target(owner_part: str, target: str) -> str:
+    if target.startswith("/"):
+        return target.lstrip("/")
+    base = PurePosixPath(owner_part).parent
+    parts: List[str] = []
+    for piece in (base / target).parts:
+        if piece in ("", "."):
+            continue
+        if piece == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(piece)
+    return "/".join(parts)
+
+
+def _xml(archive: zipfile.ZipFile, part: str) -> ET.Element:
+    return ET.fromstring(archive.read(part))
+
+
+def _sheet_parts(archive: zipfile.ZipFile) -> Dict[str, str]:
+    workbook = _xml(archive, "xl/workbook.xml")
+    rels = _xml(archive, "xl/_rels/workbook.xml.rels")
+    targets = {relationship.attrib["Id"]: relationship.attrib["Target"] for relationship in rels}
+    result: Dict[str, str] = {}
+    for sheet in workbook.findall("m:sheets/m:sheet", NS):
+        relationship_id = sheet.attrib.get(f"{{{REL_NS}}}id")
+        if relationship_id and relationship_id in targets:
+            result[sheet.attrib["name"]] = _resolve_target(
+                "xl/workbook.xml", targets[relationship_id]
+            )
+    return result
+
+
+def _shared_strings(archive: zipfile.ZipFile) -> Sequence[str]:
+    if "xl/sharedStrings.xml" not in archive.namelist():
+        return []
+    root = _xml(archive, "xl/sharedStrings.xml")
+    return [
+        "".join(text.text or "" for text in item.iter(f"{{{MAIN_NS}}}t"))
+        for item in root.findall("m:si", NS)
+    ]
+
+
+def _cell_value(cell: ET.Element, shared: Sequence[str]) -> str:
+    if cell.attrib.get("t") == "inlineStr":
+        return "".join(text.text or "" for text in cell.iter(f"{{{MAIN_NS}}}t"))
+    value = cell.find("m:v", NS)
+    if value is None or value.text is None:
+        return ""
+    if cell.attrib.get("t") == "s":
+        try:
+            return shared[int(value.text)]
+        except (ValueError, IndexError):
+            return ""
+    return value.text
+
+
+@dataclass(frozen=True)
+class CopySurfaceBound:
+    sheet: str
+    status: str
+    last_payload_row: int
+    package_end_row: int
+    trailing_rows: int
+    allowed_trailing_rows: int
+    dimension_ref: Optional[str]
+    max_row_node: int
+    max_cell_row: int
+
+
+@dataclass(frozen=True)
+class CopySurfaceBoundsReport:
+    path: str
+    pass_all: bool
+    missing_sheets: List[str]
+    surfaces: List[CopySurfaceBound]
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "pass": self.pass_all,
+            "missing_sheets": self.missing_sheets,
+            "surfaces": [asdict(surface) for surface in self.surfaces],
+        }
+
+
+def inspect_copy_surface_bounds(
+    path: str,
+    *,
+    sheets: Iterable[str],
+    max_trailing_rows: int = 0,
+) -> CopySurfaceBoundsReport:
+    if max_trailing_rows < 0:
+        raise ValueError("max_trailing_rows must be zero or greater")
+
+    workbook = Path(path)
+    requested = list(dict.fromkeys(sheets))
+    missing: List[str] = []
+    surfaces: List[CopySurfaceBound] = []
+
+    with zipfile.ZipFile(workbook, "r") as archive:
+        parts = _sheet_parts(archive)
+        shared = _shared_strings(archive)
+
+        for sheet_name in requested:
+            worksheet_part = parts.get(sheet_name)
+            if worksheet_part is None:
+                missing.append(sheet_name)
+                continue
+
+            root = _xml(archive, worksheet_part)
+            dimension = root.find("m:dimension", NS)
+            dimension_ref = dimension.attrib.get("ref") if dimension is not None else None
+
+            populated_rows: List[int] = []
+            all_cell_rows: List[int] = []
+            for cell in root.findall(".//m:c", NS):
+                position = _cell_position(cell.attrib.get("r", ""))
+                if position is None:
+                    continue
+                _, row = position
+                all_cell_rows.append(row)
+                if _cell_value(cell, shared):
+                    populated_rows.append(row)
+
+            row_nodes = [
+                int(row.attrib["r"])
+                for row in root.findall("m:sheetData/m:row", NS)
+                if row.attrib.get("r", "").isdigit()
+            ]
+            last_payload_row = max(populated_rows, default=0)
+            max_row_node = max(row_nodes, default=0)
+            max_cell_row = max(all_cell_rows, default=0)
+            package_end_row = max(
+                _dimension_end_row(dimension_ref),
+                max_row_node,
+                max_cell_row,
+            )
+            trailing_rows = max(0, package_end_row - last_payload_row)
+            if last_payload_row == 0:
+                status = "EMPTY"
+            elif trailing_rows > max_trailing_rows:
+                status = "FAIL"
+            else:
+                status = "PASS"
+
+            surfaces.append(
+                CopySurfaceBound(
+                    sheet=sheet_name,
+                    status=status,
+                    last_payload_row=last_payload_row,
+                    package_end_row=package_end_row,
+                    trailing_rows=trailing_rows,
+                    allowed_trailing_rows=max_trailing_rows,
+                    dimension_ref=dimension_ref,
+                    max_row_node=max_row_node,
+                    max_cell_row=max_cell_row,
+                )
+            )
+
+    pass_all = not missing and all(surface.status == "PASS" for surface in surfaces)
+    return CopySurfaceBoundsReport(
+        path=str(workbook.resolve()),
+        pass_all=pass_all,
+        missing_sheets=missing,
+        surfaces=surfaces,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fail when copy-safe worksheet package rows extend below the prompt payload"
+    )
+    parser.add_argument("workbook")
+    parser.add_argument("--sheet", action="append", required=True, dest="sheets")
+    parser.add_argument("--max-trailing-rows", type=int, default=0)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+
+    report = inspect_copy_surface_bounds(
+        args.workbook,
+        sheets=args.sheets,
+        max_trailing_rows=args.max_trailing_rows,
+    )
+    if args.as_json:
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        for surface in report.surfaces:
+            print(
+                f"[{surface.status}] {surface.sheet}: payload={surface.last_payload_row}, "
+                f"package_end={surface.package_end_row}, trailing={surface.trailing_rows}"
+            )
+        for sheet in report.missing_sheets:
+            print(f"[MISSING] {sheet}")
+    raise SystemExit(0 if report.pass_all else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/prompt_kit_contract.py
+++ b/triage/prompt_kit_contract.py
@@ -1,502 +1,638 @@
-"""Read-only OOXML validator for the AI Prompt Kit V19 contract."""
+"""Read-only V19 prompt-kit contract validator for AI Harness Prompt Kit workbooks.
+
+This module inspects the OOXML package and verifies the structural contract
+that the V19 acceptance definition requires.  It does not load or rewrite the
+workbook with Excel, openpyxl, or another serializer.
+
+Contract scope:
+* required sheets (21 prompt tabs, Prompt_Library, Prompt_Class_Legend);
+* approved visible fonts (Aptos family);
+* Prompt Library column layout and data integrity;
+* Aptos Bold for the H header, regular 12-point Aptos for H body cells;
+* copy-surface bounds: contiguous column-A payload, first row, final row,
+  internal blank count, package endpoint, populated columns;
+* hyperlink endpoints calculated from the actual compacted payload;
+* both B and N links target the exact expected range;
+* one authoritative nonempty legend meaning for every library color.
+
+Package-valid is not the same as clipboard-accepted or operator-accepted.
+"""
 from __future__ import annotations
 
 import argparse
 import json
 import re
 import zipfile
-from dataclasses import asdict, dataclass, field
-from pathlib import Path, PurePosixPath
-from typing import Iterable, Optional, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from xml.etree import ElementTree as ET
 
-MAIN = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
-REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
-NS = {"m": MAIN, "r": REL}
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+NS = {"m": MAIN_NS, "r": REL_NS, "pr": PKG_REL_NS}
+
 CELL_RE = re.compile(r"^([A-Z]+)(\d+)$")
 RANGE_RE = re.compile(r"^([A-Z]+)(\d+):([A-Z]+)(\d+)$")
-DEFAULT_PROMPT_IDS = tuple(f"P{i:02d}" for i in range(21))
+
+REQUIRED_PROMPT_COUNT = 21
+PROMPT_IDS = [f"P{i:02d}" for i in range(REQUIRED_PROMPT_COUNT)]
+EXPECTED_COPY_SHEETS = [f"P{i:02d}_COPY_SAFE" for i in range(REQUIRED_PROMPT_COUNT)]
+
+APPROVED_FONTS = {"Aptos", "Aptos Display"}
+APPROVED_HEADING_FONTS = {"Aptos"}
+
+LIBRARY_HEADERS = [
+    "Seq", "Prompt ID", "Prompt Type", "Prompt Class", "Sprint Path Role",
+    "Use For Progress?", "Prompt Name", "Use This When", "Inspect First",
+    "Expected Output", "Next Step", "Proof / Acceptance Gate",
+    "Color Meaning", "Copy-Safe Sheet",
+]
+
+LEGEND_REQUIRED_HEADERS = {"Prompt Type", "Prompt Class", "Color"}
+
+
+def _col_num(col: str) -> int:
+    out = 0
+    for ch in col:
+        out = out * 26 + ord(ch) - 64
+    return out
+
+
+def _num_to_col(n: int) -> str:
+    s = ""
+    while n:
+        n, r = divmod(n - 1, 26)
+        s = chr(65 + r) + s
+    return s
+
+
+def _parse_range(ref: str) -> Optional[Tuple[int, int, int, int]]:
+    m = RANGE_RE.fullmatch(ref or "")
+    if not m:
+        return None
+    c1, r1, c2, r2 = m.groups()
+    return _col_num(c1), int(r1), _col_num(c2), int(r2)
 
 
 def _xml(z: zipfile.ZipFile, part: str) -> ET.Element:
     return ET.fromstring(z.read(part))
 
 
-def _resolve(owner: str, target: str) -> str:
-    if target.startswith("/"):
-        return target.lstrip("/")
-    parts: list[str] = []
-    for piece in (PurePosixPath(owner).parent / target).parts:
-        if piece in ("", "."):
-            continue
-        if piece == "..":
-            if parts:
-                parts.pop()
-        else:
-            parts.append(piece)
-    return "/".join(parts)
+def _shared_strings(z: zipfile.ZipFile) -> List[str]:
+    if "xl/sharedStrings.xml" not in z.namelist():
+        return []
+    root = _xml(z, "xl/sharedStrings.xml")
+    return [
+        "".join(t.text or "" for t in si.iter(f"{{{MAIN_NS}}}t"))
+        for si in root.findall("m:si", NS)
+    ]
 
 
-def _sheets(z: zipfile.ZipFile) -> dict[str, str]:
-    wb = _xml(z, "xl/workbook.xml")
+def _cell_value(cell: ET.Element, shared: Sequence[str]) -> str:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "inlineStr":
+        return "".join(t.text or "" for t in cell.iter(f"{{{MAIN_NS}}}t"))
+    value = cell.find("m:v", NS)
+    if value is None or value.text is None:
+        return ""
+    if cell_type == "s":
+        try:
+            return shared[int(value.text)]
+        except (ValueError, IndexError):
+            return ""
+    return value.text
+
+
+def _workbook_sheets(z: zipfile.ZipFile) -> Dict[str, str]:
+    workbook = _xml(z, "xl/workbook.xml")
     rels = _xml(z, "xl/_rels/workbook.xml.rels")
     targets = {r.attrib["Id"]: r.attrib["Target"] for r in rels}
-    out: dict[str, str] = {}
-    for sheet in wb.findall("m:sheets/m:sheet", NS):
-        rid = sheet.attrib.get(f"{{{REL}}}id")
-        if rid in targets:
-            out[sheet.attrib["name"]] = _resolve("xl/workbook.xml", targets[rid])
+    out: Dict[str, str] = {}
+    for sheet in workbook.findall("m:sheets/m:sheet", NS):
+        rid = sheet.attrib.get(f"{{{REL_NS}}}id")
+        if rid and rid in targets:
+            target = targets[rid]
+            if not target.startswith("xl/"):
+                target = "xl/" + target
+            out[sheet.attrib["name"]] = target
     return out
 
 
-def _shared(z: zipfile.ZipFile) -> list[str]:
-    if "xl/sharedStrings.xml" not in z.namelist():
-        return []
-    return [
-        "".join(t.text or "" for t in item.iter(f"{{{MAIN}}}t"))
-        for item in _xml(z, "xl/sharedStrings.xml").findall("m:si", NS)
-    ]
-
-
-def _value(cell: ET.Element, shared: Sequence[str]) -> str:
-    if cell.attrib.get("t") == "inlineStr":
-        return "".join(t.text or "" for t in cell.iter(f"{{{MAIN}}}t"))
-    node = cell.find("m:v", NS)
-    if node is None or node.text is None:
-        return ""
-    if cell.attrib.get("t") == "s":
-        try:
-            return shared[int(node.text)]
-        except (ValueError, IndexError):
-            return ""
-    return node.text
-
-
-def _position(ref: str) -> Optional[tuple[str, int]]:
-    match = CELL_RE.fullmatch(ref or "")
-    return (match.group(1), int(match.group(2))) if match else None
-
-
-def _dimension_end(ref: Optional[str]) -> int:
-    if not ref:
-        return 0
-    match = RANGE_RE.fullmatch(ref)
-    if match:
-        return int(match.group(4))
-    pos = _position(ref)
-    return pos[1] if pos else 0
-
-
-def _fonts(z: zipfile.ZipFile) -> tuple[list[dict], list[int]]:
+def _styles_font_map(z: zipfile.ZipFile) -> Dict[int, Dict[str, Any]]:
+    if "xl/styles.xml" not in z.namelist():
+        return {}
     root = _xml(z, "xl/styles.xml")
-    fonts: list[dict] = []
-    for font in root.findall("m:fonts/m:font", NS):
-        name = font.find("m:name", NS)
-        size = font.find("m:sz", NS)
-        fonts.append(
-            {
-                "family": name.attrib.get("val", "") if name is not None else "",
-                "size": float(size.attrib["val"])
-                if size is not None and size.attrib.get("val")
-                else None,
-                "bold": font.find("m:b", NS) is not None,
-            }
-        )
-    xfs: list[int] = []
-    for xf in root.findall("m:cellXfs/m:xf", NS):
-        try:
-            xfs.append(int(xf.attrib.get("fontId", "0")))
-        except ValueError:
-            xfs.append(0)
-    return fonts, xfs
+    fonts_node = root.find("m:fonts", NS)
+    if fonts_node is None:
+        return {}
+    out: Dict[int, Dict[str, Any]] = {}
+    for i, font in enumerate(fonts_node.findall("m:font", NS)):
+        name_el = font.find("m:name", NS)
+        sz_el = font.find("m:sz", NS)
+        b_el = font.find("m:b", NS)
+        i_el = font.find("m:i", NS)
+        out[i] = {
+            "name": name_el.attrib.get("val", "") if name_el is not None else "",
+            "size": float(sz_el.attrib.get("val", "0")) if sz_el is not None else 0,
+            "bold": b_el is not None,
+            "italic": i_el is not None,
+        }
+    return out
 
 
-def _font(cell: ET.Element, fonts: Sequence[dict], xfs: Sequence[int]) -> dict:
+def _cell_font_info(
+    cell: ET.Element,
+    font_map: Dict[int, Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    style_idx = cell.attrib.get("s")
+    if style_idx is None:
+        return None
     try:
-        style = int(cell.attrib.get("s", "0"))
+        si = int(style_idx)
     except ValueError:
-        style = 0
-    font_id = xfs[style] if 0 <= style < len(xfs) else 0
-    return (
-        fonts[font_id]
-        if 0 <= font_id < len(fonts)
-        else {"family": "", "size": None, "bold": False}
-    )
+        return None
+    return font_map.get(si)
 
 
-def _surface(root: ET.Element, shared: Sequence[str], name: str) -> dict:
-    populated: list[tuple[str, int]] = []
-    cell_rows: list[int] = []
-    for cell in root.findall(".//m:c", NS):
-        pos = _position(cell.attrib.get("r", ""))
-        if not pos:
-            continue
-        column, row = pos
-        cell_rows.append(row)
-        if _value(cell, shared):
-            populated.append((column, row))
-    rows = sorted({row for _, row in populated})
-    first = rows[0] if rows else 0
-    last = rows[-1] if rows else 0
-    dim = root.find("m:dimension", NS)
-    row_nodes = [
-        int(r.attrib["r"])
-        for r in root.findall("m:sheetData/m:row", NS)
-        if r.attrib.get("r", "").isdigit()
-    ]
-    end = max(
-        _dimension_end(dim.attrib.get("ref") if dim is not None else None),
-        max(row_nodes, default=0),
-        max(cell_rows, default=0),
-    )
-    return {
-        "sheet": name,
-        "first_payload_row": first,
-        "last_payload_row": last,
-        "populated_rows": len(rows),
-        "internal_blank_rows": max(0, last - first + 1 - len(rows)) if rows else 0,
-        "package_end_row": end,
-        "trailing_rows": max(0, end - last),
-        "populated_columns": sorted({column for column, _ in populated}),
-    }
+def _sheet_hyperlinks(z: zipfile.ZipFile, sheet_part: str) -> Dict[str, str]:
+    parent = sheet_part.rsplit("/", 1)[0] if "/" in sheet_part else ""
+    base_name = sheet_part.rsplit("/", 1)[-1] if "/" in sheet_part else sheet_part
+    rels_name = f"{parent}/_rels/{base_name}.rels" if parent else f"_rels/{base_name}.rels"
+    rid_target: Dict[str, str] = {}
+    if rels_name in z.namelist():
+        rels = _xml(z, rels_name)
+        for r in rels:
+            rid_target[r.attrib["Id"]] = r.attrib.get("Target", "")
+    root = _xml(z, sheet_part)
+    out: Dict[str, str] = {}
+    for hl in root.findall(".//m:hyperlinks/m:hyperlink", NS):
+        ref = hl.attrib.get("ref", "")
+        rid = hl.attrib.get(f"{{{REL_NS}}}id", "")
+        if ref and rid:
+            out[ref] = rid_target.get(rid, "")
+        elif ref:
+            out[ref] = ""
+    return out
 
 
-@dataclass(frozen=True)
+@dataclass
 class Check:
     name: str
     status: str
-    findings: list[dict] = field(default_factory=list)
+    findings: List[Dict[str, Any]] = field(default_factory=list)
     summary: str = ""
 
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "summary": self.summary,
+            "findings": self.findings,
+        }
 
-@dataclass(frozen=True)
-class Report:
+
+@dataclass
+class PromptKitContractReport:
     path: str
-    passed: bool
-    checks: list[Check]
-    copy_surfaces: list[dict]
-    field_acceptance: str = "manual_web_excel_test_required"
+    checks: List[Check] = field(default_factory=list)
+    contract_valid: bool = False
 
     @property
-    def pass_all(self) -> bool:
-        return self.passed
+    def failures(self) -> List[Check]:
+        return [c for c in self.checks if c.status == "FAIL"]
 
-    def to_dict(self) -> dict:
+    @property
+    def warnings(self) -> List[Check]:
+        return [c for c in self.checks if c.status == "WARN"]
+
+    def to_dict(self) -> Dict[str, Any]:
         return {
             "path": self.path,
-            "pass": self.passed,
-            "field_acceptance": self.field_acceptance,
-            "checks": [asdict(c) for c in self.checks],
-            "copy_surfaces": self.copy_surfaces,
+            "contract_valid": self.contract_valid,
+            "counts": {
+                "pass": sum(c.status == "PASS" for c in self.checks),
+                "warn": len(self.warnings),
+                "fail": len(self.failures),
+            },
+            "checks": [c.to_dict() for c in self.checks],
         }
 
     def render_text(self) -> str:
         lines = ["PROMPT KIT V19 CONTRACT"]
-        lines.extend(
-            f"[{c.status}] {c.name}{': ' + c.summary if c.summary else ''}"
-            for c in self.checks
-        )
-        lines.extend(
-            [
-                "",
-                f"Result: pass={str(self.passed).lower()}, "
-                f"field_acceptance={self.field_acceptance}",
-            ]
-        )
+        for check in self.checks:
+            suffix = f": {check.summary}" if check.summary else ""
+            lines.append(f"[{check.status}] {check.name}{suffix}")
+        lines.append("")
+        lines.append(f"Result: contract_valid={str(self.contract_valid).lower()}")
         return "\n".join(lines)
 
 
-def validate_prompt_kit_contract(
-    path: str,
-    *,
-    prompt_ids: Iterable[str] = DEFAULT_PROMPT_IDS,
-    allowed_font_families: Iterable[str] = ("Aptos",),
-) -> Report:
-    expected = tuple(dict.fromkeys(prompt_ids))
-    allowed = set(allowed_font_families)
-    checks: list[Check] = []
-    surfaces: list[dict] = []
-    with zipfile.ZipFile(path, "r") as z:
-        sheets, shared, (fonts, xfs) = _sheets(z), _shared(z), _fonts(z)
-        required = {
-            "Prompt_Library",
-            "Prompt_Class_Legend",
-            *(f"{p}_COPY_SAFE" for p in expected),
-        }
-        missing = sorted(required - set(sheets))
-        checks.append(
-            Check(
-                "required sheets",
-                "FAIL" if missing else "PASS",
-                [{"sheet": s} for s in missing],
-            )
-        )
+def validate_prompt_kit_contract(path: str) -> PromptKitContractReport:
+    workbook_path = Path(path)
+    report = PromptKitContractReport(path=str(workbook_path.resolve()))
 
-        bad_fonts: list[dict] = []
-        for sheet, part in sheets.items():
-            for cell in _xml(z, part).findall(".//m:c", NS):
-                if _value(cell, shared):
-                    spec = _font(cell, fonts, xfs)
-                    if spec["family"] not in allowed:
-                        bad_fonts.append(
-                            {"sheet": sheet, "cell": cell.attrib.get("r"), **spec}
-                        )
-        checks.append(
-            Check(
-                "visible fonts approved",
-                "FAIL" if bad_fonts else "PASS",
-                bad_fonts[:50],
-                f"allowed: {', '.join(sorted(allowed))}",
-            )
-        )
+    if not workbook_path.exists():
+        report.checks.append(Check("file exists", "FAIL", [{"path": str(workbook_path)}]))
+        return report
 
-        rows: dict[str, int] = {}
-        lib_cells: dict[str, ET.Element] = {}
-        lib_values: dict[str, str] = {}
-        links: dict[str, str] = {}
-        colors: list[str] = []
-        structure: list[dict] = []
-        typography: list[dict] = []
-        if "Prompt_Library" in sheets:
-            root = _xml(z, sheets["Prompt_Library"])
-            for cell in root.findall(".//m:c", NS):
-                ref = cell.attrib.get("r", "")
-                lib_cells[ref], lib_values[ref] = cell, _value(cell, shared)
-            for link in root.findall("m:hyperlinks/m:hyperlink", NS):
-                if link.attrib.get("location"):
-                    links[link.attrib.get("ref", "")] = (
-                        link.attrib["location"]
-                        .lstrip("#")
-                        .replace("'", "")
-                        .replace("$", "")
-                    )
-            for ref, wanted in {
-                "B1": "Prompt ID",
-                "H1": "Use This When",
-                "M1": "Color",
-                "N1": "Copy-Safe Sheet",
-            }.items():
-                if lib_values.get(ref, "") != wanted:
-                    structure.append(
-                        {
-                            "cell": ref,
-                            "expected": wanted,
-                            "actual": lib_values.get(ref, ""),
-                        }
-                    )
-            for ref, value in lib_values.items():
-                pos = _position(ref)
-                if pos and pos[0] == "B" and value in expected:
-                    rows[value] = pos[1]
-            for prompt_id in expected:
-                row = rows.get(prompt_id)
-                if row is None:
-                    structure.append(
-                        {"prompt_id": prompt_id, "issue": "prompt_id_missing"}
-                    )
-                    continue
-                sheet = f"{prompt_id}_COPY_SAFE"
-                if lib_values.get(f"N{row}", "") != sheet:
-                    structure.append(
-                        {
-                            "cell": f"N{row}",
-                            "expected": sheet,
-                            "actual": lib_values.get(f"N{row}", ""),
-                        }
-                    )
-                color = lib_values.get(f"M{row}", "")
-                colors.append(color)
-                if not color:
-                    structure.append(
-                        {"cell": f"M{row}", "issue": "color_missing"}
-                    )
-            if "H1" in lib_cells:
-                spec = _font(lib_cells["H1"], fonts, xfs)
-                if spec["family"] != "Aptos" or not spec["bold"]:
-                    typography.append(
-                        {"cell": "H1", "expected": "Aptos bold", "actual": spec}
-                    )
-            for prompt_id, row in rows.items():
-                cell = lib_cells.get(f"H{row}")
-                spec = _font(cell, fonts, xfs) if cell is not None else None
-                if (
-                    spec is None
-                    or spec["family"] != "Aptos"
-                    or spec["size"] != 12.0
-                    or spec["bold"]
-                ):
-                    typography.append(
-                        {
-                            "cell": f"H{row}",
-                            "prompt_id": prompt_id,
-                            "expected": "Aptos regular 12pt",
-                            "actual": spec,
-                        }
-                    )
-        checks.append(
-            Check(
-                "Prompt Library contract columns",
-                "FAIL" if structure else "PASS",
-                structure[:50],
-            )
-        )
-        checks.append(
-            Check(
-                "Prompt Library column H typography",
-                "FAIL" if typography else "PASS",
-                typography[:50],
-            )
-        )
+    try:
+        with zipfile.ZipFile(workbook_path, "r") as z:
+            shared = _shared_strings(z)
+            sheets = _workbook_sheets(z)
+            font_map = _styles_font_map(z)
 
-        surface_issues: list[dict] = []
-        by_sheet: dict[str, dict] = {}
-        for prompt_id in expected:
-            name = f"{prompt_id}_COPY_SAFE"
-            if name not in sheets:
-                continue
-            surface = _surface(_xml(z, sheets[name]), shared, name)
-            surfaces.append(surface)
-            by_sheet[name] = surface
-            if surface["first_payload_row"] != 1:
-                surface_issues.append(
-                    {
-                        "sheet": name,
-                        "issue": "payload_does_not_start_at_row_1",
-                        "actual": surface["first_payload_row"],
-                    }
-                )
-            if surface["populated_columns"] != ["A"]:
-                surface_issues.append(
-                    {
-                        "sheet": name,
-                        "issue": "payload_not_single_column_A",
-                        "columns": surface["populated_columns"],
-                    }
-                )
-            if surface["internal_blank_rows"]:
-                surface_issues.append(
-                    {
-                        "sheet": name,
-                        "issue": "internal_blank_rows",
-                        "count": surface["internal_blank_rows"],
-                    }
-                )
-            if surface["trailing_rows"]:
-                surface_issues.append(
-                    {
-                        "sheet": name,
-                        "issue": "trailing_package_rows",
-                        "count": surface["trailing_rows"],
-                    }
-                )
-        checks.append(
-            Check(
-                "copy surfaces dense and bounded",
-                "FAIL" if surface_issues else "PASS",
-                surface_issues[:50],
-            )
-        )
+            # --- Required sheets ---
+            missing_sheets = [s for s in EXPECTED_COPY_SHEETS if s not in sheets]
+            has_library = "Prompt_Library" in sheets
+            has_legend = "Prompt_Class_Legend" in sheets
 
-        link_issues: list[dict] = []
-        for prompt_id in expected:
-            row, name = rows.get(prompt_id), f"{prompt_id}_COPY_SAFE"
-            surface = by_sheet.get(name)
-            if row is None or not surface or not surface["last_payload_row"]:
-                continue
-            wanted = f"{name}!A1:A{surface['last_payload_row']}"
-            for column in ("B", "N"):
-                ref = f"{column}{row}"
-                if links.get(ref) != wanted:
-                    link_issues.append(
-                        {
-                            "prompt_id": prompt_id,
-                            "cell": ref,
-                            "expected": wanted,
-                            "actual": links.get(ref),
-                        }
-                    )
-        checks.append(
-            Check(
-                "Prompt Library links select exact payload ranges",
-                "FAIL" if link_issues else "PASS",
-                link_issues[:50],
-                "package proof only; browser selection remains a field gate",
-            )
-        )
+            report.checks.append(Check(
+                "required prompt tabs",
+                "FAIL" if missing_sheets else "PASS",
+                [{"missing": s} for s in missing_sheets],
+                f"{len(EXPECTED_COPY_SHEETS) - len(missing_sheets)}/{len(EXPECTED_COPY_SHEETS)} present",
+            ))
+            report.checks.append(Check(
+                "Prompt_Library present",
+                "FAIL" if not has_library else "PASS",
+            ))
+            report.checks.append(Check(
+                "Prompt_Class_Legend present",
+                "FAIL" if not has_legend else "PASS",
+            ))
 
-        legend_issues: list[dict] = []
-        if "Prompt_Class_Legend" in sheets:
-            legend_rows: dict[int, dict[str, str]] = {}
-            for cell in _xml(z, sheets["Prompt_Class_Legend"]).findall(
-                ".//m:c", NS
-            ):
-                pos = _position(cell.attrib.get("r", ""))
-                if pos:
-                    legend_rows.setdefault(pos[1], {})[pos[0]] = _value(
-                        cell, shared
-                    )
-            header_row, color_col, meaning_col = 0, "", ""
-            for number in sorted(legend_rows)[:10]:
-                for column, text in legend_rows[number].items():
-                    normalized = text.strip().lower()
-                    if normalized == "color":
-                        color_col = column
-                    if "meaning" in normalized or "operational" in normalized:
-                        meaning_col = column
-                if color_col and meaning_col:
-                    header_row = number
+            # --- Font inventory ---
+            font_names = {v["name"] for v in font_map.values() if v["name"]}
+            disallowed = font_names - APPROVED_FONTS
+            report.checks.append(Check(
+                "approved visible fonts",
+                "WARN" if disallowed else "PASS",
+                [{"font": f} for f in sorted(disallowed)],
+                f"non-Aptos fonts detected" if disallowed else "all fonts approved",
+            ))
+
+            if not has_library:
+                report.contract_valid = not report.failures
+                return report
+
+            # --- Prompt Library structure ---
+            lib_part = sheets["Prompt_Library"]
+            lib_root = _xml(z, lib_part)
+            lib_cells = {}
+            for c in lib_root.findall(".//m:c", NS):
+                ref = c.attrib.get("r", "")
+                lib_cells[ref] = _cell_value(c, shared)
+
+            # Parse library into rows
+            lib_rows: Dict[int, Dict[str, str]] = {}
+            for ref, val in lib_cells.items():
+                m = CELL_RE.match(ref)
+                if m:
+                    col = m.group(1)
+                    row = int(m.group(2))
+                    lib_rows.setdefault(row, {})[col] = val
+
+            # Check header row
+            header_row = lib_rows.get(1, {})
+            header_vals = [header_row.get(_num_to_col(i + 1), "") for i in range(len(LIBRARY_HEADERS))]
+            header_issues = []
+            for i, expected in enumerate(LIBRARY_HEADERS):
+                actual = header_vals[i] if i < len(header_vals) else ""
+                if actual != expected:
+                    header_issues.append({
+                        "column": _num_to_col(i + 1),
+                        "expected": expected,
+                        "actual": actual,
+                    })
+            report.checks.append(Check(
+                "Prompt Library headers",
+                "FAIL" if header_issues else "PASS",
+                header_issues[:10],
+            ))
+
+            # Extract prompt data rows (rows 2-22 for P00-P20)
+            lib_data: Dict[str, Dict[str, str]] = {}
+            for row_num in range(2, 2 + REQUIRED_PROMPT_COUNT):
+                row = lib_rows.get(row_num, {})
+                pid = row.get("B", "")
+                lib_data[pid] = row
+
+            # Check prompt IDs
+            pid_issues = []
+            for i, expected_pid in enumerate(PROMPT_IDS):
+                actual = lib_data.get(expected_pid, {}).get("B", "")
+                if actual != expected_pid:
+                    pid_issues.append({"row": i + 2, "expected": expected_pid, "actual": actual})
+            report.checks.append(Check(
+                "Prompt Library prompt IDs",
+                "FAIL" if pid_issues else "PASS",
+                pid_issues[:10],
+            ))
+
+            # Check copy-safe sheet references
+            copy_ref_issues = []
+            for i, expected_pid in enumerate(PROMPT_IDS):
+                row = lib_data.get(expected_pid, {})
+                expected_sheet = f"{expected_pid}_COPY_SAFE"
+                actual_sheet = row.get("N", "")
+                if actual_sheet != expected_sheet:
+                    copy_ref_issues.append({
+                        "row": i + 2,
+                        "expected": expected_sheet,
+                        "actual": actual_sheet,
+                    })
+            report.checks.append(Check(
+                "copy-safe sheet references",
+                "FAIL" if copy_ref_issues else "PASS",
+                copy_ref_issues[:10],
+            ))
+
+            # --- Column H font check (Aptos Bold header, 12pt regular body) ---
+            h_font_issues: List[Dict[str, Any]] = []
+            # Check header H1
+            h1_cell = None
+            for c in lib_root.findall(".//m:c", NS):
+                if c.attrib.get("r") == "H1":
+                    h1_cell = c
                     break
-            if not header_row:
-                legend_issues.append({"issue": "legend_headers_missing"})
-            else:
-                mappings: dict[str, list[str]] = {}
-                for number, values in legend_rows.items():
-                    if number > header_row and values.get(color_col, "").strip():
-                        mappings.setdefault(values[color_col].strip(), []).append(
-                            values.get(meaning_col, "").strip()
-                        )
-                for color in sorted(set(colors)):
-                    entries = mappings.get(color, [])
-                    if len(entries) != 1 or not entries[0]:
-                        legend_issues.append(
-                            {
-                                "color": color,
-                                "issue": "color_requires_exactly_one_nonempty_meaning",
-                                "entries": entries,
-                            }
-                        )
-        checks.append(
-            Check(
-                "Prompt Class Legend covers every library color",
-                "FAIL" if legend_issues else "PASS",
-                legend_issues[:50],
-            )
-        )
+            if h1_cell is not None:
+                fi = _cell_font_info(h1_cell, font_map)
+                if fi:
+                    if not fi["bold"]:
+                        h_font_issues.append({"cell": "H1", "issue": "header_not_bold", "font": fi["name"]})
+                    if fi["name"] not in APPROVED_HEADING_FONTS:
+                        h_font_issues.append({"cell": "H1", "issue": "header_font_not_aptos", "font": fi["name"]})
 
-    passed = all(check.status == "PASS" for check in checks)
-    return Report(str(Path(path).resolve()), passed, checks, surfaces)
+            # Check body cells H2-H22
+            body_font_issues: List[Dict[str, Any]] = []
+            for row_num in range(2, 2 + REQUIRED_PROMPT_COUNT):
+                cell_ref = f"H{row_num}"
+                for c in lib_root.findall(".//m:c", NS):
+                    if c.attrib.get("r") == cell_ref:
+                        fi = _cell_font_info(c, font_map)
+                        if fi:
+                            if fi["bold"]:
+                                body_font_issues.append({"cell": cell_ref, "issue": "body_cell_is_bold"})
+                            if fi["name"] not in APPROVED_FONTS:
+                                body_font_issues.append({"cell": cell_ref, "issue": "body_font_not_aptos", "font": fi["name"]})
+                            if fi["size"] != 12:
+                                body_font_issues.append({"cell": cell_ref, "issue": "body_font_not_12pt", "size": fi["size"]})
+                        break
+
+            all_h_issues = h_font_issues + body_font_issues
+            report.checks.append(Check(
+                "Prompt Library column H typography",
+                "FAIL" if all_h_issues else "PASS",
+                all_h_issues[:10],
+            ))
+
+            # --- Copy-surface bounds ---
+            surface_findings: List[Dict[str, Any]] = []
+            surface_details: Dict[str, Dict[str, Any]] = {}
+
+            for sheet_name in EXPECTED_COPY_SHEETS:
+                if sheet_name not in sheets:
+                    continue
+                sheet_part = sheets[sheet_name]
+                sheet_root = _xml(z, sheet_part)
+                populated: Dict[int, str] = {}
+                for c in sheet_root.findall(".//m:c", NS):
+                    ref = c.attrib.get("r", "")
+                    m = CELL_RE.match(ref)
+                    if m:
+                        row_num = int(m.group(2))
+                        col = m.group(1)
+                        val = _cell_value(c, shared)
+                        if col == "A" and val:
+                            populated[row_num] = val
+
+                if not populated:
+                    surface_findings.append({"sheet": sheet_name, "issue": "empty_copy_surface"})
+                    surface_details[sheet_name] = {"populated_rows": 0, "first_row": 0, "last_row": 0, "blanks": 0}
+                    continue
+
+                rows = sorted(populated.keys())
+                first_row = rows[0]
+                last_row = rows[-1]
+                expected_count = last_row - first_row + 1
+                actual_count = len(rows)
+                blanks = expected_count - actual_count
+
+                # Check all populated cells are in column A
+                non_a_cells: List[str] = []
+                for c in sheet_root.findall(".//m:c", NS):
+                    ref = c.attrib.get("r", "")
+                    cm = CELL_RE.match(ref)
+                    if cm and cm.group(1) != "A" and _cell_value(c, shared):
+                        non_a_cells.append(ref)
+
+                # Check contiguous from A1
+                if first_row != 1:
+                    surface_findings.append({
+                        "sheet": sheet_name,
+                        "issue": "payload_does_not_start_at_A1",
+                        "first_row": first_row,
+                    })
+                if blanks > 0:
+                    # Identify internal blanks
+                    internal_blanks = [r for r in range(first_row, last_row + 1) if r not in populated]
+                    surface_findings.append({
+                        "sheet": sheet_name,
+                        "issue": "internal_blank_rows",
+                        "blank_rows": internal_blanks[:10],
+                        "blank_count": blanks,
+                    })
+                if non_a_cells:
+                    surface_findings.append({
+                        "sheet": sheet_name,
+                        "issue": "non_column_a_populated_cells",
+                        "cells": non_a_cells[:10],
+                    })
+
+                # Check for trailing rows (rows beyond payload that have data in any column)
+                trailing_findings: List[str] = []
+                for c in sheet_root.findall(".//m:c", NS):
+                    ref = c.attrib.get("r", "")
+                    cm = CELL_RE.match(ref)
+                    if cm:
+                        r_num = int(cm.group(2))
+                        if r_num > last_row and _cell_value(c, shared):
+                            trailing_findings.append(ref)
+                if trailing_findings:
+                    surface_findings.append({
+                        "sheet": sheet_name,
+                        "issue": "trailing_rows_after_payload",
+                        "cells": trailing_findings[:10],
+                    })
+
+                surface_details[sheet_name] = {
+                    "populated_rows": actual_count,
+                    "first_row": first_row,
+                    "last_row": last_row,
+                    "blanks": blanks,
+                    "endpoint": f"A{last_row}",
+                }
+
+            report.checks.append(Check(
+                "copy-surface bounds",
+                "FAIL" if surface_findings else "PASS",
+                surface_findings[:25],
+                f"{len(surface_details)} surfaces measured",
+            ))
+
+            # --- Hyperlink endpoint checks ---
+            lib_hyperlinks = _sheet_hyperlinks(z, lib_part)
+            link_issues: List[Dict[str, Any]] = []
+
+            for i, expected_pid in enumerate(PROMPT_IDS):
+                row_num = i + 2
+                row = lib_data.get(expected_pid, {})
+                expected_sheet = f"{expected_pid}_COPY_SAFE"
+                surface = surface_details.get(expected_sheet, {})
+                last_row = surface.get("last_row", 0)
+                expected_endpoint = f"{expected_sheet}!A1:A{last_row}" if last_row else ""
+
+                # Check N column link
+                n_ref = f"N{row_num}"
+                n_link = lib_hyperlinks.get(n_ref, "")
+                if expected_endpoint and n_link != expected_endpoint:
+                    link_issues.append({
+                        "cell": n_ref,
+                        "expected": expected_endpoint,
+                        "actual": n_link or "(no hyperlink)",
+                        "column": "N",
+                    })
+
+                # Check B column link
+                b_ref = f"B{row_num}"
+                b_link = lib_hyperlinks.get(b_ref, "")
+                if expected_endpoint and b_link != expected_endpoint:
+                    link_issues.append({
+                        "cell": b_ref,
+                        "expected": expected_endpoint,
+                        "actual": b_link or "(no hyperlink)",
+                        "column": "B",
+                    })
+
+            report.checks.append(Check(
+                "hyperlink endpoints",
+                "FAIL" if link_issues else "PASS",
+                link_issues[:20],
+            ))
+
+            # --- Color legend coverage ---
+            if has_legend:
+                legend_part = sheets["Prompt_Class_Legend"]
+                legend_root = _xml(z, legend_part)
+                legend_cells: Dict[str, str] = {}
+                for c in legend_root.findall(".//m:c", NS):
+                    ref = c.attrib.get("r", "")
+                    legend_cells[ref] = _cell_value(c, shared)
+
+                # Find header row (look for "Color" in column H or "Prompt Type" in column A)
+                legend_header_row = 0
+                for ref, val in legend_cells.items():
+                    m = CELL_RE.match(ref)
+                    if m and m.group(1) == "H" and val == "Color":
+                        legend_header_row = int(m.group(2))
+                        break
+                if legend_header_row == 0:
+                    for ref, val in legend_cells.items():
+                        m = CELL_RE.match(ref)
+                        if m and m.group(1) == "A" and val == "Prompt Type":
+                            legend_header_row = int(m.group(2))
+                            break
+
+                # Collect legend colors (column H below header)
+                legend_colors: Dict[str, List[str]] = {}
+                if legend_header_row:
+                    for ref, val in legend_cells.items():
+                        m = CELL_RE.match(ref)
+                        if m and m.group(1) == "H" and int(m.group(2)) > legend_header_row and val:
+                            row_num = int(m.group(2))
+                            prompt_type = legend_cells.get(f"A{row_num}", "")
+                            legend_colors.setdefault(val, []).append(prompt_type)
+
+                # Collect library colors (column M below header)
+                lib_colors: Dict[str, List[str]] = {}
+                for i, pid in enumerate(PROMPT_IDS):
+                    row_num = i + 2
+                    color = lib_data.get(pid, {}).get("M", "")
+                    if color:
+                        lib_colors.setdefault(color, []).append(pid)
+
+                legend_issues: List[Dict[str, Any]] = []
+                for color, pids in lib_colors.items():
+                    meanings = legend_colors.get(color, [])
+                    if not meanings:
+                        legend_issues.append({
+                            "color": color,
+                            "issue": "color_missing_from_legend",
+                            "used_by": pids,
+                        })
+                    elif len(meanings) > 1:
+                        legend_issues.append({
+                            "color": color,
+                            "issue": "color_has_multiple_legend_entries",
+                            "meanings": meanings,
+                        })
+                    else:
+                        # Check meaning is non-empty
+                        meaning_row = 0
+                        for ref, val in legend_cells.items():
+                            m2 = CELL_RE.match(ref)
+                            if m2 and m2.group(1) == "H" and val == color:
+                                meaning_row = int(m2.group(2))
+                                break
+                        if meaning_row:
+                            # Check if the "When to Use" or similar field is non-empty
+                            when_cell = legend_cells.get(f"D{meaning_row}", "")
+                            if not when_cell:
+                                legend_issues.append({
+                                    "color": color,
+                                    "issue": "legend_meaning_empty",
+                                    "row": meaning_row,
+                                })
+
+                report.checks.append(Check(
+                    "color legend coverage",
+                    "FAIL" if legend_issues else "PASS",
+                    legend_issues[:15],
+                ))
+            else:
+                report.checks.append(Check(
+                    "color legend coverage",
+                    "SKIP",
+                    summary="Prompt_Class_Legend sheet not present",
+                ))
+
+    except (zipfile.BadZipFile, KeyError, ET.ParseError) as exc:
+        report.checks.append(Check(
+            "package readable",
+            "FAIL",
+            [{"error": f"{type(exc).__name__}: {exc}"}],
+        ))
+
+    report.contract_valid = not report.failures
+    return report
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Validate the prompt-kit V19 contract without rewriting the workbook"
+        description="Validate a prompt-kit workbook against the V19 contract",
     )
     parser.add_argument("workbook")
-    parser.add_argument("--prompt-id", action="append", dest="prompt_ids")
-    parser.add_argument("--allow-font", action="append", dest="fonts")
-    parser.add_argument("--json", action="store_true", dest="as_json")
+    parser.add_argument(
+        "--json", action="store_true", dest="as_json",
+        help="emit JSON instead of the English matrix",
+    )
     args = parser.parse_args()
-    report = validate_prompt_kit_contract(
-        args.workbook,
-        prompt_ids=args.prompt_ids or DEFAULT_PROMPT_IDS,
-        allowed_font_families=args.fonts or ("Aptos",),
-    )
-    print(
-        json.dumps(report.to_dict(), indent=2)
-        if args.as_json
-        else report.render_text()
-    )
-    raise SystemExit(0 if report.passed else 1)
+
+    report = validate_prompt_kit_contract(args.workbook)
+    print(json.dumps(report.to_dict(), indent=2) if args.as_json else report.render_text())
+    raise SystemExit(0 if report.contract_valid else 1)
 
 
 if __name__ == "__main__":

--- a/triage/prompt_kit_contract.py
+++ b/triage/prompt_kit_contract.py
@@ -1,0 +1,503 @@
+"""Read-only OOXML validator for the AI Prompt Kit V19 contract."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import zipfile
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Iterable, Optional, Sequence
+from xml.etree import ElementTree as ET
+
+MAIN = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+NS = {"m": MAIN, "r": REL}
+CELL_RE = re.compile(r"^([A-Z]+)(\d+)$")
+RANGE_RE = re.compile(r"^([A-Z]+)(\d+):([A-Z]+)(\d+)$")
+DEFAULT_PROMPT_IDS = tuple(f"P{i:02d}" for i in range(21))
+
+
+def _xml(z: zipfile.ZipFile, part: str) -> ET.Element:
+    return ET.fromstring(z.read(part))
+
+
+def _resolve(owner: str, target: str) -> str:
+    if target.startswith("/"):
+        return target.lstrip("/")
+    parts: list[str] = []
+    for piece in (PurePosixPath(owner).parent / target).parts:
+        if piece in ("", "."):
+            continue
+        if piece == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(piece)
+    return "/".join(parts)
+
+
+def _sheets(z: zipfile.ZipFile) -> dict[str, str]:
+    wb = _xml(z, "xl/workbook.xml")
+    rels = _xml(z, "xl/_rels/workbook.xml.rels")
+    targets = {r.attrib["Id"]: r.attrib["Target"] for r in rels}
+    out: dict[str, str] = {}
+    for sheet in wb.findall("m:sheets/m:sheet", NS):
+        rid = sheet.attrib.get(f"{{{REL}}}id")
+        if rid in targets:
+            out[sheet.attrib["name"]] = _resolve("xl/workbook.xml", targets[rid])
+    return out
+
+
+def _shared(z: zipfile.ZipFile) -> list[str]:
+    if "xl/sharedStrings.xml" not in z.namelist():
+        return []
+    return [
+        "".join(t.text or "" for t in item.iter(f"{{{MAIN}}}t"))
+        for item in _xml(z, "xl/sharedStrings.xml").findall("m:si", NS)
+    ]
+
+
+def _value(cell: ET.Element, shared: Sequence[str]) -> str:
+    if cell.attrib.get("t") == "inlineStr":
+        return "".join(t.text or "" for t in cell.iter(f"{{{MAIN}}}t"))
+    node = cell.find("m:v", NS)
+    if node is None or node.text is None:
+        return ""
+    if cell.attrib.get("t") == "s":
+        try:
+            return shared[int(node.text)]
+        except (ValueError, IndexError):
+            return ""
+    return node.text
+
+
+def _position(ref: str) -> Optional[tuple[str, int]]:
+    match = CELL_RE.fullmatch(ref or "")
+    return (match.group(1), int(match.group(2))) if match else None
+
+
+def _dimension_end(ref: Optional[str]) -> int:
+    if not ref:
+        return 0
+    match = RANGE_RE.fullmatch(ref)
+    if match:
+        return int(match.group(4))
+    pos = _position(ref)
+    return pos[1] if pos else 0
+
+
+def _fonts(z: zipfile.ZipFile) -> tuple[list[dict], list[int]]:
+    root = _xml(z, "xl/styles.xml")
+    fonts: list[dict] = []
+    for font in root.findall("m:fonts/m:font", NS):
+        name = font.find("m:name", NS)
+        size = font.find("m:sz", NS)
+        fonts.append(
+            {
+                "family": name.attrib.get("val", "") if name is not None else "",
+                "size": float(size.attrib["val"])
+                if size is not None and size.attrib.get("val")
+                else None,
+                "bold": font.find("m:b", NS) is not None,
+            }
+        )
+    xfs: list[int] = []
+    for xf in root.findall("m:cellXfs/m:xf", NS):
+        try:
+            xfs.append(int(xf.attrib.get("fontId", "0")))
+        except ValueError:
+            xfs.append(0)
+    return fonts, xfs
+
+
+def _font(cell: ET.Element, fonts: Sequence[dict], xfs: Sequence[int]) -> dict:
+    try:
+        style = int(cell.attrib.get("s", "0"))
+    except ValueError:
+        style = 0
+    font_id = xfs[style] if 0 <= style < len(xfs) else 0
+    return (
+        fonts[font_id]
+        if 0 <= font_id < len(fonts)
+        else {"family": "", "size": None, "bold": False}
+    )
+
+
+def _surface(root: ET.Element, shared: Sequence[str], name: str) -> dict:
+    populated: list[tuple[str, int]] = []
+    cell_rows: list[int] = []
+    for cell in root.findall(".//m:c", NS):
+        pos = _position(cell.attrib.get("r", ""))
+        if not pos:
+            continue
+        column, row = pos
+        cell_rows.append(row)
+        if _value(cell, shared):
+            populated.append((column, row))
+    rows = sorted({row for _, row in populated})
+    first = rows[0] if rows else 0
+    last = rows[-1] if rows else 0
+    dim = root.find("m:dimension", NS)
+    row_nodes = [
+        int(r.attrib["r"])
+        for r in root.findall("m:sheetData/m:row", NS)
+        if r.attrib.get("r", "").isdigit()
+    ]
+    end = max(
+        _dimension_end(dim.attrib.get("ref") if dim is not None else None),
+        max(row_nodes, default=0),
+        max(cell_rows, default=0),
+    )
+    return {
+        "sheet": name,
+        "first_payload_row": first,
+        "last_payload_row": last,
+        "populated_rows": len(rows),
+        "internal_blank_rows": max(0, last - first + 1 - len(rows)) if rows else 0,
+        "package_end_row": end,
+        "trailing_rows": max(0, end - last),
+        "populated_columns": sorted({column for column, _ in populated}),
+    }
+
+
+@dataclass(frozen=True)
+class Check:
+    name: str
+    status: str
+    findings: list[dict] = field(default_factory=list)
+    summary: str = ""
+
+
+@dataclass(frozen=True)
+class Report:
+    path: str
+    passed: bool
+    checks: list[Check]
+    copy_surfaces: list[dict]
+    field_acceptance: str = "manual_web_excel_test_required"
+
+    @property
+    def pass_all(self) -> bool:
+        return self.passed
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "pass": self.passed,
+            "field_acceptance": self.field_acceptance,
+            "checks": [asdict(c) for c in self.checks],
+            "copy_surfaces": self.copy_surfaces,
+        }
+
+    def render_text(self) -> str:
+        lines = ["PROMPT KIT V19 CONTRACT"]
+        lines.extend(
+            f"[{c.status}] {c.name}{': ' + c.summary if c.summary else ''}"
+            for c in self.checks
+        )
+        lines.extend(
+            [
+                "",
+                f"Result: pass={str(self.passed).lower()}, "
+                f"field_acceptance={self.field_acceptance}",
+            ]
+        )
+        return "\n".join(lines)
+
+
+def validate_prompt_kit_contract(
+    path: str,
+    *,
+    prompt_ids: Iterable[str] = DEFAULT_PROMPT_IDS,
+    allowed_font_families: Iterable[str] = ("Aptos",),
+) -> Report:
+    expected = tuple(dict.fromkeys(prompt_ids))
+    allowed = set(allowed_font_families)
+    checks: list[Check] = []
+    surfaces: list[dict] = []
+    with zipfile.ZipFile(path, "r") as z:
+        sheets, shared, (fonts, xfs) = _sheets(z), _shared(z), _fonts(z)
+        required = {
+            "Prompt_Library",
+            "Prompt_Class_Legend",
+            *(f"{p}_COPY_SAFE" for p in expected),
+        }
+        missing = sorted(required - set(sheets))
+        checks.append(
+            Check(
+                "required sheets",
+                "FAIL" if missing else "PASS",
+                [{"sheet": s} for s in missing],
+            )
+        )
+
+        bad_fonts: list[dict] = []
+        for sheet, part in sheets.items():
+            for cell in _xml(z, part).findall(".//m:c", NS):
+                if _value(cell, shared):
+                    spec = _font(cell, fonts, xfs)
+                    if spec["family"] not in allowed:
+                        bad_fonts.append(
+                            {"sheet": sheet, "cell": cell.attrib.get("r"), **spec}
+                        )
+        checks.append(
+            Check(
+                "visible fonts approved",
+                "FAIL" if bad_fonts else "PASS",
+                bad_fonts[:50],
+                f"allowed: {', '.join(sorted(allowed))}",
+            )
+        )
+
+        rows: dict[str, int] = {}
+        lib_cells: dict[str, ET.Element] = {}
+        lib_values: dict[str, str] = {}
+        links: dict[str, str] = {}
+        colors: list[str] = []
+        structure: list[dict] = []
+        typography: list[dict] = []
+        if "Prompt_Library" in sheets:
+            root = _xml(z, sheets["Prompt_Library"])
+            for cell in root.findall(".//m:c", NS):
+                ref = cell.attrib.get("r", "")
+                lib_cells[ref], lib_values[ref] = cell, _value(cell, shared)
+            for link in root.findall("m:hyperlinks/m:hyperlink", NS):
+                if link.attrib.get("location"):
+                    links[link.attrib.get("ref", "")] = (
+                        link.attrib["location"]
+                        .lstrip("#")
+                        .replace("'", "")
+                        .replace("$", "")
+                    )
+            for ref, wanted in {
+                "B1": "Prompt ID",
+                "H1": "Use This When",
+                "M1": "Color",
+                "N1": "Copy-Safe Sheet",
+            }.items():
+                if lib_values.get(ref, "") != wanted:
+                    structure.append(
+                        {
+                            "cell": ref,
+                            "expected": wanted,
+                            "actual": lib_values.get(ref, ""),
+                        }
+                    )
+            for ref, value in lib_values.items():
+                pos = _position(ref)
+                if pos and pos[0] == "B" and value in expected:
+                    rows[value] = pos[1]
+            for prompt_id in expected:
+                row = rows.get(prompt_id)
+                if row is None:
+                    structure.append(
+                        {"prompt_id": prompt_id, "issue": "prompt_id_missing"}
+                    )
+                    continue
+                sheet = f"{prompt_id}_COPY_SAFE"
+                if lib_values.get(f"N{row}", "") != sheet:
+                    structure.append(
+                        {
+                            "cell": f"N{row}",
+                            "expected": sheet,
+                            "actual": lib_values.get(f"N{row}", ""),
+                        }
+                    )
+                color = lib_values.get(f"M{row}", "")
+                colors.append(color)
+                if not color:
+                    structure.append(
+                        {"cell": f"M{row}", "issue": "color_missing"}
+                    )
+            if "H1" in lib_cells:
+                spec = _font(lib_cells["H1"], fonts, xfs)
+                if spec["family"] != "Aptos" or not spec["bold"]:
+                    typography.append(
+                        {"cell": "H1", "expected": "Aptos bold", "actual": spec}
+                    )
+            for prompt_id, row in rows.items():
+                cell = lib_cells.get(f"H{row}")
+                spec = _font(cell, fonts, xfs) if cell is not None else None
+                if (
+                    spec is None
+                    or spec["family"] != "Aptos"
+                    or spec["size"] != 12.0
+                    or spec["bold"]
+                ):
+                    typography.append(
+                        {
+                            "cell": f"H{row}",
+                            "prompt_id": prompt_id,
+                            "expected": "Aptos regular 12pt",
+                            "actual": spec,
+                        }
+                    )
+        checks.append(
+            Check(
+                "Prompt Library contract columns",
+                "FAIL" if structure else "PASS",
+                structure[:50],
+            )
+        )
+        checks.append(
+            Check(
+                "Prompt Library column H typography",
+                "FAIL" if typography else "PASS",
+                typography[:50],
+            )
+        )
+
+        surface_issues: list[dict] = []
+        by_sheet: dict[str, dict] = {}
+        for prompt_id in expected:
+            name = f"{prompt_id}_COPY_SAFE"
+            if name not in sheets:
+                continue
+            surface = _surface(_xml(z, sheets[name]), shared, name)
+            surfaces.append(surface)
+            by_sheet[name] = surface
+            if surface["first_payload_row"] != 1:
+                surface_issues.append(
+                    {
+                        "sheet": name,
+                        "issue": "payload_does_not_start_at_row_1",
+                        "actual": surface["first_payload_row"],
+                    }
+                )
+            if surface["populated_columns"] != ["A"]:
+                surface_issues.append(
+                    {
+                        "sheet": name,
+                        "issue": "payload_not_single_column_A",
+                        "columns": surface["populated_columns"],
+                    }
+                )
+            if surface["internal_blank_rows"]:
+                surface_issues.append(
+                    {
+                        "sheet": name,
+                        "issue": "internal_blank_rows",
+                        "count": surface["internal_blank_rows"],
+                    }
+                )
+            if surface["trailing_rows"]:
+                surface_issues.append(
+                    {
+                        "sheet": name,
+                        "issue": "trailing_package_rows",
+                        "count": surface["trailing_rows"],
+                    }
+                )
+        checks.append(
+            Check(
+                "copy surfaces dense and bounded",
+                "FAIL" if surface_issues else "PASS",
+                surface_issues[:50],
+            )
+        )
+
+        link_issues: list[dict] = []
+        for prompt_id in expected:
+            row, name = rows.get(prompt_id), f"{prompt_id}_COPY_SAFE"
+            surface = by_sheet.get(name)
+            if row is None or not surface or not surface["last_payload_row"]:
+                continue
+            wanted = f"{name}!A1:A{surface['last_payload_row']}"
+            for column in ("B", "N"):
+                ref = f"{column}{row}"
+                if links.get(ref) != wanted:
+                    link_issues.append(
+                        {
+                            "prompt_id": prompt_id,
+                            "cell": ref,
+                            "expected": wanted,
+                            "actual": links.get(ref),
+                        }
+                    )
+        checks.append(
+            Check(
+                "Prompt Library links select exact payload ranges",
+                "FAIL" if link_issues else "PASS",
+                link_issues[:50],
+                "package proof only; browser selection remains a field gate",
+            )
+        )
+
+        legend_issues: list[dict] = []
+        if "Prompt_Class_Legend" in sheets:
+            legend_rows: dict[int, dict[str, str]] = {}
+            for cell in _xml(z, sheets["Prompt_Class_Legend"]).findall(
+                ".//m:c", NS
+            ):
+                pos = _position(cell.attrib.get("r", ""))
+                if pos:
+                    legend_rows.setdefault(pos[1], {})[pos[0]] = _value(
+                        cell, shared
+                    )
+            header_row, color_col, meaning_col = 0, "", ""
+            for number in sorted(legend_rows)[:10]:
+                for column, text in legend_rows[number].items():
+                    normalized = text.strip().lower()
+                    if normalized == "color":
+                        color_col = column
+                    if "meaning" in normalized or "operational" in normalized:
+                        meaning_col = column
+                if color_col and meaning_col:
+                    header_row = number
+                    break
+            if not header_row:
+                legend_issues.append({"issue": "legend_headers_missing"})
+            else:
+                mappings: dict[str, list[str]] = {}
+                for number, values in legend_rows.items():
+                    if number > header_row and values.get(color_col, "").strip():
+                        mappings.setdefault(values[color_col].strip(), []).append(
+                            values.get(meaning_col, "").strip()
+                        )
+                for color in sorted(set(colors)):
+                    entries = mappings.get(color, [])
+                    if len(entries) != 1 or not entries[0]:
+                        legend_issues.append(
+                            {
+                                "color": color,
+                                "issue": "color_requires_exactly_one_nonempty_meaning",
+                                "entries": entries,
+                            }
+                        )
+        checks.append(
+            Check(
+                "Prompt Class Legend covers every library color",
+                "FAIL" if legend_issues else "PASS",
+                legend_issues[:50],
+            )
+        )
+
+    passed = all(check.status == "PASS" for check in checks)
+    return Report(str(Path(path).resolve()), passed, checks, surfaces)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Validate the prompt-kit V19 contract without rewriting the workbook"
+    )
+    parser.add_argument("workbook")
+    parser.add_argument("--prompt-id", action="append", dest="prompt_ids")
+    parser.add_argument("--allow-font", action="append", dest="fonts")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    report = validate_prompt_kit_contract(
+        args.workbook,
+        prompt_ids=args.prompt_ids or DEFAULT_PROMPT_IDS,
+        allowed_font_families=args.fonts or ("Aptos",),
+    )
+    print(
+        json.dumps(report.to_dict(), indent=2)
+        if args.as_json
+        else report.render_text()
+    )
+    raise SystemExit(0 if report.passed else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/web_excel_compatibility_rules.py
+++ b/triage/web_excel_compatibility_rules.py
@@ -67,7 +67,15 @@ def inspect_web_excel_package(path: str | Path) -> List[WebExcelIssue]:
         drawing_chart_rels = [name for name in names if name.startswith("xl/drawings/_rels/") and name.endswith(".rels")]
         for rel_name in drawing_chart_rels:
             rel_text = _read_text(zf, rel_name)
-            if "/xl/drawings/charts/" in rel_text or "drawings/charts/" in rel_text:
+            rel_parent = "/".join(rel_name.split("/")[:-2]) + "/"
+            targets_under_drawings = False
+            for tm in re.finditer(r'Target="([^"]+)"', rel_text):
+                target = tm.group(1)
+                resolved = target if target.startswith("/") else rel_parent + target
+                if "drawings/charts/" in resolved:
+                    targets_under_drawings = True
+                    break
+            if targets_under_drawings or "/xl/drawings/charts/" in rel_text or "drawings/charts/" in rel_text:
                 issues.append(WebExcelIssue(
                     "drawing_rel_targets_chart_under_drawings",
                     "Drawing chart relationships must target ../charts/chartN.xml or /xl/charts/chartN.xml.",

--- a/triage/workbook_package_hygiene.py
+++ b/triage/workbook_package_hygiene.py
@@ -1,0 +1,418 @@
+"""Read-only OOXML package hygiene validator for generated .xlsx artifacts.
+
+This module inspects the ZIP/XML package directly. It does not load or rewrite the
+workbook with Excel, openpyxl, or another serializer.
+
+Package-valid is not the same as Web Excel accepted, clipboard accepted, or
+operator accepted. Clipboard checks here identify risky worksheet shapes only;
+the real Ctrl+A/Ctrl+C workflow remains an operator gate.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from xml.etree import ElementTree as ET
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+PKG_REL_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
+NS = {"m": MAIN_NS, "r": REL_NS, "pr": PKG_REL_NS}
+CELL_RE = re.compile(r"^([A-Z]+)(\d+)$")
+RANGE_RE = re.compile(r"^([A-Z]+)(\d+):([A-Z]+)(\d+)$")
+ERROR_TOKENS = ("#REF!", "#DIV/0!", "#VALUE!", "#NAME?", "#N/A")
+COPY_GUIDANCE_MARKERS = (
+    "paste this directly",
+    "do not wrap it in quotes",
+    "do not put it inside a markdown",
+    "end prompt",
+    "do not copy this cell",
+)
+
+
+def _col_num(col: str) -> int:
+    out = 0
+    for ch in col:
+        out = out * 26 + ord(ch) - 64
+    return out
+
+
+def _parse_range(ref: str) -> Optional[Tuple[int, int, int, int]]:
+    m = RANGE_RE.fullmatch(ref or "")
+    if not m:
+        return None
+    c1, r1, c2, r2 = m.groups()
+    return _col_num(c1), int(r1), _col_num(c2), int(r2)
+
+
+def _rects_overlap(a: Tuple[int, int, int, int], b: Tuple[int, int, int, int]) -> bool:
+    ac1, ar1, ac2, ar2 = a
+    bc1, br1, bc2, br2 = b
+    return not (ac2 < bc1 or bc2 < ac1 or ar2 < br1 or br2 < ar1)
+
+
+def _resolve_target(owner_part: str, target: str) -> str:
+    if target.startswith("/"):
+        return target.lstrip("/")
+    base = PurePosixPath(owner_part).parent
+    parts: List[str] = []
+    for piece in (base / target).parts:
+        if piece in ("", "."):
+            continue
+        if piece == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(piece)
+    return "/".join(parts)
+
+
+def _rels_part(owner_part: str) -> str:
+    owner = PurePosixPath(owner_part)
+    return str(owner.parent / "_rels" / f"{owner.name}.rels")
+
+
+def _xml(z: zipfile.ZipFile, part: str) -> ET.Element:
+    return ET.fromstring(z.read(part))
+
+
+def _shared_strings(z: zipfile.ZipFile) -> List[str]:
+    if "xl/sharedStrings.xml" not in z.namelist():
+        return []
+    root = _xml(z, "xl/sharedStrings.xml")
+    return ["".join(t.text or "" for t in si.iter(f"{{{MAIN_NS}}}t")) for si in root.findall("m:si", NS)]
+
+
+def _cell_value(cell: ET.Element, shared: Sequence[str]) -> str:
+    cell_type = cell.attrib.get("t")
+    if cell_type == "inlineStr":
+        return "".join(t.text or "" for t in cell.iter(f"{{{MAIN_NS}}}t"))
+    value = cell.find("m:v", NS)
+    if value is None or value.text is None:
+        return ""
+    if cell_type == "s":
+        try:
+            return shared[int(value.text)]
+        except (ValueError, IndexError):
+            return ""
+    return value.text
+
+
+def _workbook_sheets(z: zipfile.ZipFile) -> Dict[str, str]:
+    workbook = _xml(z, "xl/workbook.xml")
+    rels = _xml(z, "xl/_rels/workbook.xml.rels")
+    targets = {r.attrib["Id"]: r.attrib["Target"] for r in rels}
+    out: Dict[str, str] = {}
+    for sheet in workbook.findall("m:sheets/m:sheet", NS):
+        rid = sheet.attrib.get(f"{{{REL_NS}}}id")
+        if rid and rid in targets:
+            out[sheet.attrib["name"]] = _resolve_target("xl/workbook.xml", targets[rid])
+    return out
+
+
+def _worksheet_table_parts(z: zipfile.ZipFile, worksheet_part: str) -> List[str]:
+    rels_name = _rels_part(worksheet_part)
+    if rels_name not in z.namelist():
+        return []
+    rels = _xml(z, rels_name)
+    targets = {r.attrib["Id"]: r.attrib["Target"] for r in rels}
+    root = _xml(z, worksheet_part)
+    out: List[str] = []
+    for tp in root.findall("m:tableParts/m:tablePart", NS):
+        rid = tp.attrib.get(f"{{{REL_NS}}}id")
+        if rid and rid in targets:
+            out.append(_resolve_target(worksheet_part, targets[rid]))
+    return out
+
+
+@dataclass
+class Check:
+    name: str
+    status: str
+    findings: List[Dict[str, Any]] = field(default_factory=list)
+    summary: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "summary": self.summary,
+            "findings": self.findings,
+        }
+
+
+@dataclass
+class WorkbookPackageHygieneReport:
+    path: str
+    checks: List[Check] = field(default_factory=list)
+    package_valid: bool = False
+    clipboard_acceptance: str = "not_tested"
+
+    @property
+    def failures(self) -> List[Check]:
+        return [c for c in self.checks if c.status == "FAIL"]
+
+    @property
+    def warnings(self) -> List[Check]:
+        return [c for c in self.checks if c.status == "WARN"]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "path": self.path,
+            "package_valid": self.package_valid,
+            "clipboard_acceptance": self.clipboard_acceptance,
+            "counts": {
+                "pass": sum(c.status == "PASS" for c in self.checks),
+                "warn": len(self.warnings),
+                "fail": len(self.failures),
+            },
+            "checks": [c.to_dict() for c in self.checks],
+        }
+
+    def render_text(self) -> str:
+        lines = ["WORKBOOK PACKAGE HYGIENE"]
+        for check in self.checks:
+            suffix = f": {check.summary}" if check.summary else ""
+            lines.append(f"[{check.status}] {check.name}{suffix}")
+        lines.append("")
+        lines.append(
+            f"Result: package_valid={str(self.package_valid).lower()}, "
+            f"clipboard_acceptance={self.clipboard_acceptance}"
+        )
+        return "\n".join(lines)
+
+
+def validate_workbook_package(
+    path: str,
+    *,
+    expected_freeze_sheets: Iterable[str] = (),
+    copy_surface_sheets: Iterable[str] = (),
+) -> WorkbookPackageHygieneReport:
+    workbook_path = Path(path)
+    report = WorkbookPackageHygieneReport(path=str(workbook_path.resolve()))
+    expected_freeze = set(expected_freeze_sheets)
+    copy_surfaces = set(copy_surface_sheets)
+
+    if not workbook_path.exists():
+        report.checks.append(Check("file exists", "FAIL", [{"path": str(workbook_path)}]))
+        return report
+
+    try:
+        with zipfile.ZipFile(workbook_path, "r") as z:
+            crc_bad = z.testzip()
+            report.checks.append(
+                Check(
+                    "ZIP integrity",
+                    "FAIL" if crc_bad else "PASS",
+                    [{"first_bad_part": crc_bad}] if crc_bad else [],
+                )
+            )
+
+            malformed: List[Dict[str, Any]] = []
+            for part in z.namelist():
+                if part.endswith((".xml", ".rels")):
+                    try:
+                        _xml(z, part)
+                    except Exception as exc:  # exact parser failure is evidence
+                        malformed.append({"part": part, "error": f"{type(exc).__name__}: {exc}"})
+            report.checks.append(Check("XML well-formed", "FAIL" if malformed else "PASS", malformed[:25]))
+
+            sheets = _workbook_sheets(z)
+            shared = _shared_strings(z)
+            table_parts = [p for p in z.namelist() if p.startswith("xl/tables/table") and p.endswith(".xml")]
+
+            table_ids: Dict[str, str] = {}
+            table_names: Dict[str, str] = {}
+            duplicate_ids: List[Dict[str, Any]] = []
+            duplicate_names: List[Dict[str, Any]] = []
+            table_ref_issues: List[Dict[str, Any]] = []
+            table_column_issues: List[Dict[str, Any]] = []
+            table_meta: Dict[str, Dict[str, Any]] = {}
+
+            for part in table_parts:
+                root = _xml(z, part)
+                table_id = root.attrib.get("id", "")
+                if table_id in table_ids:
+                    duplicate_ids.append({"id": table_id, "first_part": table_ids[table_id], "duplicate_part": part})
+                else:
+                    table_ids[table_id] = part
+                for attr in ("name", "displayName"):
+                    value = root.attrib.get(attr, "")
+                    key = f"{attr}:{value}"
+                    if value and key in table_names:
+                        duplicate_names.append({"attribute": attr, "value": value, "first_part": table_names[key], "duplicate_part": part})
+                    elif value:
+                        table_names[key] = part
+
+                ref = root.attrib.get("ref", "")
+                parsed = _parse_range(ref)
+                auto = root.find("m:autoFilter", NS)
+                auto_ref = auto.attrib.get("ref") if auto is not None else None
+                if not parsed:
+                    table_ref_issues.append({"part": part, "issue": "invalid_table_ref", "ref": ref})
+                if auto_ref != ref:
+                    table_ref_issues.append({"part": part, "issue": "autofilter_ref_mismatch", "table_ref": ref, "autofilter_ref": auto_ref})
+
+                columns = root.find("m:tableColumns", NS)
+                column_nodes = columns.findall("m:tableColumn", NS) if columns is not None else []
+                declared_count = int(columns.attrib.get("count", "0")) if columns is not None else 0
+                if declared_count != len(column_nodes):
+                    table_column_issues.append({"part": part, "issue": "declared_column_count_mismatch", "declared": declared_count, "actual": len(column_nodes)})
+                if parsed:
+                    range_count = parsed[2] - parsed[0] + 1
+                    if range_count != len(column_nodes):
+                        table_column_issues.append({"part": part, "issue": "range_column_count_mismatch", "range_count": range_count, "table_columns": len(column_nodes)})
+                table_meta[part] = {
+                    "ref": ref,
+                    "columns": [n.attrib.get("name", "") for n in column_nodes],
+                    "name": root.attrib.get("name"),
+                }
+
+            report.checks.append(Check("table IDs unique", "FAIL" if duplicate_ids else "PASS", duplicate_ids))
+            report.checks.append(Check("table names unique", "FAIL" if duplicate_names else "PASS", duplicate_names))
+            report.checks.append(Check("table refs and filters", "FAIL" if table_ref_issues else "PASS", table_ref_issues))
+            report.checks.append(Check("table column counts", "FAIL" if table_column_issues else "PASS", table_column_issues))
+
+            header_issues: List[Dict[str, Any]] = []
+            for sheet_name, worksheet_part in sheets.items():
+                root = _xml(z, worksheet_part)
+                cells = {c.attrib.get("r", ""): _cell_value(c, shared) for c in root.findall(".//m:c", NS)}
+                for table_part in _worksheet_table_parts(z, worksheet_part):
+                    meta = table_meta.get(table_part)
+                    if not meta:
+                        header_issues.append({"sheet": sheet_name, "part": table_part, "issue": "missing_table_part"})
+                        continue
+                    parsed = _parse_range(meta["ref"])
+                    if not parsed:
+                        continue
+                    c1, row, c2, _ = parsed
+                    visible: List[str] = []
+                    for col_num in range(c1, c2 + 1):
+                        n = col_num
+                        col = ""
+                        while n:
+                            n, rem = divmod(n - 1, 26)
+                            col = chr(65 + rem) + col
+                        visible.append(cells.get(f"{col}{row}", ""))
+                    if visible != meta["columns"]:
+                        header_issues.append({"sheet": sheet_name, "table": meta["name"], "visible_headers": visible, "table_columns": meta["columns"]})
+            report.checks.append(Check("visible headers match table XML", "FAIL" if header_issues else "PASS", header_issues[:25]))
+
+            merge_issues: List[Dict[str, Any]] = []
+            panes: Dict[str, Dict[str, str]] = {}
+            dimensions: Dict[str, Optional[str]] = {}
+            copy_findings: List[Dict[str, Any]] = []
+
+            for sheet_name, worksheet_part in sheets.items():
+                root = _xml(z, worksheet_part)
+                dim = root.find("m:dimension", NS)
+                dimensions[sheet_name] = dim.attrib.get("ref") if dim is not None else None
+                pane = root.find("m:sheetViews/m:sheetView/m:pane", NS)
+                if pane is not None:
+                    panes[sheet_name] = dict(pane.attrib)
+
+                merge_nodes = root.findall("m:mergeCells/m:mergeCell", NS)
+                parsed_merges: List[Tuple[str, Tuple[int, int, int, int]]] = []
+                for merge in merge_nodes:
+                    ref = merge.attrib.get("ref", "")
+                    parsed = _parse_range(ref)
+                    if parsed:
+                        parsed_merges.append((ref, parsed))
+                for i, (left_ref, left) in enumerate(parsed_merges):
+                    for right_ref, right in parsed_merges[i + 1 :]:
+                        if _rects_overlap(left, right):
+                            merge_issues.append({"sheet": sheet_name, "left": left_ref, "right": right_ref})
+
+                if sheet_name in copy_surfaces:
+                    populated: List[Tuple[str, str]] = []
+                    for cell in root.findall(".//m:c", NS):
+                        ref = cell.attrib.get("r", "")
+                        value = _cell_value(cell, shared)
+                        if value:
+                            populated.append((ref, value))
+                    columns = sorted({CELL_RE.match(ref).group(1) for ref, _ in populated if CELL_RE.match(ref)})
+                    multiline = [{"cell": ref, "line_count": value.count("\n") + 1} for ref, value in populated if "\n" in value]
+                    guidance = [
+                        {"cell": ref, "marker": marker}
+                        for ref, value in populated
+                        for marker in COPY_GUIDANCE_MARKERS
+                        if marker in value.lower()
+                    ]
+                    if len(columns) > 1:
+                        copy_findings.append({"sheet": sheet_name, "issue": "multiple_populated_columns", "columns": columns})
+                    if multiline:
+                        copy_findings.append({"sheet": sheet_name, "issue": "multiline_cells_risk_wrapper_quotes", "samples": multiline[:10]})
+                    if guidance:
+                        copy_findings.append({"sheet": sheet_name, "issue": "guidance_contaminates_payload", "samples": guidance[:10]})
+                    if not populated:
+                        copy_findings.append({"sheet": sheet_name, "issue": "empty_copy_surface"})
+
+            report.checks.append(Check("merge ranges non-overlapping", "FAIL" if merge_issues else "PASS", merge_issues[:25]))
+
+            missing_freeze = [{"sheet": name, "issue": "expected_pane_missing"} for name in sorted(expected_freeze) if name not in panes]
+            freeze_status = "FAIL" if missing_freeze else "PASS"
+            freeze_summary = f"{len(panes)} sheet(s) contain pane nodes"
+            report.checks.append(Check("freeze panes", freeze_status, missing_freeze, freeze_summary))
+
+            missing_dimensions = [{"sheet": name, "issue": "dimension_node_missing"} for name, ref in dimensions.items() if ref is None]
+            report.checks.append(
+                Check(
+                    "worksheet dimensions",
+                    "WARN" if missing_dimensions else "PASS",
+                    missing_dimensions[:25],
+                    "missing dimensions are metadata drift, not automatic corruption",
+                )
+            )
+
+            error_hits: List[Dict[str, Any]] = []
+            for part in z.namelist():
+                if not part.endswith((".xml", ".rels")):
+                    continue
+                text = z.read(part).decode("utf-8", errors="ignore")
+                for token in ERROR_TOKENS:
+                    if token in text:
+                        error_hits.append({"part": part, "token": token})
+            report.checks.append(Check("formula/error literal scan", "FAIL" if error_hits else "PASS", error_hits[:25]))
+
+            missing_copy_sheets = [{"sheet": name, "issue": "copy_surface_sheet_missing"} for name in sorted(copy_surfaces) if name not in sheets]
+            copy_findings.extend(missing_copy_sheets)
+            report.checks.append(
+                Check(
+                    "copy-surface package shape",
+                    "WARN" if copy_findings else "PASS",
+                    copy_findings[:25],
+                    "operator Ctrl+A/Ctrl+C acceptance is still required",
+                )
+            )
+            report.clipboard_acceptance = "manual_test_required" if copy_surfaces else "not_tested"
+
+    except (zipfile.BadZipFile, KeyError, ET.ParseError) as exc:
+        report.checks.append(Check("package readable", "FAIL", [{"error": f"{type(exc).__name__}: {exc}"}]))
+
+    report.package_valid = not report.failures
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Inspect an .xlsx package without rewriting it")
+    parser.add_argument("workbook")
+    parser.add_argument("--json", action="store_true", dest="as_json", help="emit JSON instead of the English matrix")
+    parser.add_argument("--expect-freeze", action="append", default=[], metavar="SHEET")
+    parser.add_argument("--copy-surface", action="append", default=[], metavar="SHEET")
+    args = parser.parse_args()
+
+    report = validate_workbook_package(
+        args.workbook,
+        expected_freeze_sheets=args.expect_freeze,
+        copy_surface_sheets=args.copy_surface,
+    )
+    print(json.dumps(report.to_dict(), indent=2) if args.as_json else report.render_text())
+    raise SystemExit(0 if report.package_valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/triage/worksheet_cell_integrity.py
+++ b/triage/worksheet_cell_integrity.py
@@ -1,0 +1,219 @@
+"""Read-only worksheet coordinate and dimension integrity checks for .xlsx files.
+
+The validator addresses two Excel-for-Web repair triggers observed in the AI
+Prompt Kit V19 package:
+
+* more than one ``<c>`` element declaring the same worksheet coordinate;
+* a worksheet ``dimension`` that does not cover existing explicit cell records.
+
+It inspects OOXML directly and never rewrites the workbook.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import zipfile
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path, PurePosixPath
+from typing import Dict, List, Optional, Tuple
+from xml.etree import ElementTree as ET
+
+MAIN_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+REL_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+NS = {"m": MAIN_NS, "r": REL_NS}
+CELL_RE = re.compile(r"^([A-Z]+)(\d+)$")
+RANGE_RE = re.compile(r"^([A-Z]+)(\d+):([A-Z]+)(\d+)$")
+
+
+def _col_num(column: str) -> int:
+    value = 0
+    for char in column:
+        value = value * 26 + ord(char) - 64
+    return value
+
+
+def _cell_position(ref: str) -> Optional[Tuple[int, int]]:
+    match = CELL_RE.fullmatch(ref or "")
+    if not match:
+        return None
+    return _col_num(match.group(1)), int(match.group(2))
+
+
+def _dimension_end(ref: Optional[str]) -> Optional[Tuple[int, int]]:
+    if not ref:
+        return None
+    match = RANGE_RE.fullmatch(ref)
+    if match:
+        return _col_num(match.group(3)), int(match.group(4))
+    return _cell_position(ref)
+
+
+def _resolve_target(owner_part: str, target: str) -> str:
+    if target.startswith("/"):
+        return target.lstrip("/")
+    base = PurePosixPath(owner_part).parent
+    parts: List[str] = []
+    for piece in (base / target).parts:
+        if piece in ("", "."):
+            continue
+        if piece == "..":
+            if parts:
+                parts.pop()
+        else:
+            parts.append(piece)
+    return "/".join(parts)
+
+
+def _xml(archive: zipfile.ZipFile, part: str) -> ET.Element:
+    return ET.fromstring(archive.read(part))
+
+
+def _sheets(archive: zipfile.ZipFile) -> Dict[str, str]:
+    workbook = _xml(archive, "xl/workbook.xml")
+    relationships = _xml(archive, "xl/_rels/workbook.xml.rels")
+    targets = {node.attrib["Id"]: node.attrib["Target"] for node in relationships}
+    sheets: Dict[str, str] = {}
+    for sheet in workbook.findall("m:sheets/m:sheet", NS):
+        relation_id = sheet.attrib.get(f"{{{REL_NS}}}id")
+        if relation_id in targets:
+            sheets[sheet.attrib["name"]] = _resolve_target(
+                "xl/workbook.xml", targets[relation_id]
+            )
+    return sheets
+
+
+@dataclass(frozen=True)
+class Finding:
+    sheet: str
+    issue: str
+    details: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class WorksheetCellIntegrityReport:
+    path: str
+    passed: bool
+    findings: List[Finding]
+    checked_sheets: int
+
+    def to_dict(self) -> dict:
+        return {
+            "path": self.path,
+            "pass": self.passed,
+            "checked_sheets": self.checked_sheets,
+            "findings": [asdict(item) for item in self.findings],
+        }
+
+    def render_text(self) -> str:
+        lines = ["WORKSHEET CELL INTEGRITY"]
+        if not self.findings:
+            lines.append("[PASS] Cell coordinates are unique and dimensions cover explicit cells")
+        else:
+            for finding in self.findings:
+                lines.append(
+                    f"[FAIL] {finding.sheet}: {finding.issue} - "
+                    f"{json.dumps(finding.details, sort_keys=True)}"
+                )
+        lines.append("")
+        lines.append(f"Result: pass={str(self.passed).lower()}, checked_sheets={self.checked_sheets}")
+        return "\n".join(lines)
+
+
+def validate_worksheet_cell_integrity(path: str) -> WorksheetCellIntegrityReport:
+    workbook = Path(path)
+    findings: List[Finding] = []
+    if not workbook.exists():
+        return WorksheetCellIntegrityReport(
+            str(workbook),
+            False,
+            [Finding("<package>", "file_missing", {"path": str(workbook)})],
+            0,
+        )
+
+    checked_sheets = 0
+    try:
+        with zipfile.ZipFile(workbook, "r") as archive:
+            for sheet_name, worksheet_part in _sheets(archive).items():
+                checked_sheets += 1
+                root = _xml(archive, worksheet_part)
+                refs = [
+                    cell.attrib.get("r", "")
+                    for cell in root.findall(".//m:c", NS)
+                    if cell.attrib.get("r")
+                ]
+                duplicates = {
+                    ref: count
+                    for ref, count in Counter(refs).items()
+                    if count > 1
+                }
+                if duplicates:
+                    findings.append(
+                        Finding(
+                            sheet_name,
+                            "duplicate_cell_references",
+                            {
+                                "coordinates": duplicates,
+                                "extra_cell_records": sum(
+                                    count - 1 for count in duplicates.values()
+                                ),
+                            },
+                        )
+                    )
+
+                positions = [position for ref in refs if (position := _cell_position(ref))]
+                actual_end = (
+                    (max(position[0] for position in positions), max(position[1] for position in positions))
+                    if positions
+                    else (0, 0)
+                )
+                dimension = root.find("m:dimension", NS)
+                dimension_ref = dimension.attrib.get("ref") if dimension is not None else None
+                dimension_end = _dimension_end(dimension_ref)
+                if positions and dimension_end is None:
+                    findings.append(
+                        Finding(
+                            sheet_name,
+                            "dimension_missing_or_invalid",
+                            {"dimension": dimension_ref, "actual_end": actual_end},
+                        )
+                    )
+                elif positions and dimension_end and (
+                    dimension_end[0] < actual_end[0] or dimension_end[1] < actual_end[1]
+                ):
+                    findings.append(
+                        Finding(
+                            sheet_name,
+                            "dimension_excludes_explicit_cells",
+                            {
+                                "dimension": dimension_ref,
+                                "dimension_end": dimension_end,
+                                "actual_end": actual_end,
+                            },
+                        )
+                    )
+    except (zipfile.BadZipFile, KeyError, ET.ParseError) as error:
+        findings.append(
+            Finding("<package>", "package_unreadable", {"error": f"{type(error).__name__}: {error}"})
+        )
+
+    return WorksheetCellIntegrityReport(
+        str(workbook.resolve()), not findings, findings, checked_sheets
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Fail duplicate worksheet cell coordinates and dimensions that exclude explicit cells"
+    )
+    parser.add_argument("workbook")
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args()
+    report = validate_worksheet_cell_integrity(args.workbook)
+    print(json.dumps(report.to_dict(), indent=2) if args.as_json else report.render_text())
+    raise SystemExit(0 if report.passed else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## **User description**
## Summary

Turns the prompt-kit workbook failures into an executable, read-only OOXML package hygiene lane plus durable repo records.

## Changed

- adds `triage/workbook_package_hygiene.py`
- adds synthetic tests in `tests/test_workbook_package_hygiene.py`
- adds `docs/WORKBOOK_COPY_SURFACE_AND_OOXML_TRIAGE_LESSONS.md`
- adds `docs/AI_PROMPT_KIT_V10_XML_AND_CLIPBOARD_RECORD.md`

## Validator checks

- ZIP integrity
- XML/relationship-part well-formedness
- table ID and name uniqueness
- table refs and autoFilter refs
- table column counts
- visible headers versus table XML
- overlapping merge ranges
- expected freeze-pane evidence
- missing worksheet dimensions as metadata warnings
- formula/error literal markers
- risky copy-surface package shapes

## Latest artifact record

The v10 prompt-kit artifact shows:

- dedicated P07/P12 copy-safe sheets use one populated column and one prompt line per row
- the Prompt Library still contains giant multiline prompt cells that can trigger wrapper-quote behavior during Excel clipboard copy
- table refs/IDs/headers are structurally consistent
- internal table names still carry `V9` in the v10 artifact, recorded as metadata/version drift
- inspected key sheets contain no pane or dimension nodes, so freeze-pane claims are not package-proven

## Proof posture

- package checks do not prove Excel for Web acceptance
- copy-surface shape checks do not prove Microsoft clipboard output
- Ctrl+A/Ctrl+C operator validation remains a distinct acceptance gate
- no private workbook binary is committed
- validator is read-only and does not reserialize OOXML

## Validation expected

```powershell
python -m unittest tests.test_workbook_package_hygiene
python -m triage.workbook_package_hygiene "<workbook.xlsx>" --copy-surface P07_COPY_SAFE --copy-surface P12_COPY_SAFE
```


___

## **CodeAnt-AI Description**
**Add read-only workbook hygiene checks for copy-safe spreadsheet exports**

### What Changed
- Added a validator for `.xlsx` files that checks package health, table metadata, merge ranges, freeze-pane evidence, and copy-surface layout without rewriting the workbook
- Added a second check that flags copy-safe sheets with extra trailing rows, styled blanks, or other content below the intended prompt payload
- Added tests covering healthy workbooks, broken table and merge cases, missing files, bounded copy surfaces, and overlong copy surfaces
- Split CI so the new workbook hygiene checks run in their own job, separate from the broader artifact engine suite
- Recorded the workbook copy-surface rules, v10 findings, and validation handoff guidance in docs

### Impact
`✅ Fewer broken workbook exports`
`✅ Clearer copy-safe prompt sheets`
`✅ Earlier detection of bad table or merge layouts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
