### PR TITLE
feat: codify Bonita Neuron Track Hours submission rules

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -41,6 +41,8 @@ jobs:
             tests/test_cybernet_targets.py \
             tests/test_nw_prj_neuron_track_hours.py \
             tests/test_nw_prj_neuron_track_hours_bonita.py \
+            tests/test_bonita_source_hierarchy.py \
+            tests/test_neuron_work_context_rules.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \

--- a/configs/artifact_profiles/bonita_neuron_track_hours.json
+++ b/configs/artifact_profiles/bonita_neuron_track_hours.json
@@ -7,7 +7,7 @@
     {"sheet": "Apr 26", "cell": "B1", "check": "contains", "contains": "TECH"},
     {"sheet": "May 26", "cell": "G1", "check": "contains", "contains": "ASSIGNMENT"}
   ],
-  "required_nonblank_columns": ["TECH", "PROJECT", "ASSIGNMENT", "TOTAL"],
+  "required_nonblank_columns": ["TECH", "START", "END", "PROJECT", "ASSIGNMENT", "TOTAL"],
   "forbidden_values": [
     "Bonita-friendly", "Column1", "Column2", "Column3", "Column4", "Column5",
     "confidence", "heuristic", "raw note", "private note",

--- a/docs/BONITA_NEURON_TRACK_HOURS_CONTRACT.md
+++ b/docs/BONITA_NEURON_TRACK_HOURS_CONTRACT.md
@@ -2,58 +2,119 @@
 
 ## Purpose
 
-Produce a clean, **submission-grade** Bonita workbook from the Active Roster
-Log: exactly two tabs (`Apr 26` / `May 26`), two-line headers, one row per
-included Neuron shift, values only. This is the **Roster Log → Admin Sheet**
-one-shot output path — admin-facing, narrow, and clean. No private notes, no
-confidence fields, no internal exception machinery leak into the workbook.
+Produce a clean, **submission-grade** Bonita workbook from the Active Roster Log:
+exactly two tabs (`Apr 26` / `May 26`), two-line headers, one row per included
+Neuron shift, values only. This is the **Roster Log → Admin Sheet** one-shot
+output path. No private notes, confidence fields, or internal review machinery
+may leak into the workbook.
 
-The generator lives in-package at `triage/nw_prj_neuron_track_hours/` and reuses
-the proven reader (note-aware punch parsing, clock helpers) and the private
-inlineStr repair, adding three new modules:
+This contract reflects the submitted April/May 2026 color-coded candidate. The
+hard lesson is: **attendance and assignment are separate facts**.
 
-| Module | Role |
-| --- | --- |
-| `bonita_resolver.py` | Per-date Neuron-project resolver + classification + review trail |
-| `bonita_exporter.py` | Clean two-tab `Apr 26` / `May 26` workbook (values only) |
-| `bonita_cli.py` | CLI + manifest / review-queue / preflight sidecars |
+- Live tabs prove clock-in / clock-out truth.
+- Worked Projects and Assignments prove whether that day belonged to Neurons.
+- Assignment classification rules map included Neuron time into Bonita umbrella
+  categories.
 
-## Inclusion rule (project-driven)
+## Final source hierarchy
 
-A tech/date shift enters the workbook **only** when the resolved project for
-that date is the Neuron project. Resolution precedence:
+A tech/date shift enters the workbook **only** when the final source hierarchy
+says that specific person/date belongs to the Neuron project.
 
 ```text
-Worked Projects cell  >  Assignments override  >  Live default project
+1. Live - {Month}
+   Source of clock truth only.
+   Use it for start/end times and gross hours.
+   Do not use the Live default project as proof when better assignment data exists.
+
+2. Assignments - {Month} override table
+   Highest-priority reviewed correction.
+   This can include a day that Worked Projects/default would exclude, or exclude
+   a day that a default project would otherwise pull into Neurons.
+
+3. Worked Projects - {Month}
+   Primary per-tech/per-date project assignment when no override exists.
+   This is what prevents stale broad-team/default labels from becoming Neuron hours.
+
+4. Assignments - {Month} main grid
+   Fallback project context behind Worked Projects.
+
+5. Live default project column
+   Last-resort fallback only.
+   Never enough by itself when Worked Projects or an override exists.
+
+6. Punch-note project tags
+   Conflict evidence. Tags like / Neha, / Bonita, or / Josh exclude the row from
+   Neuron submission unless the Assignments override table explicitly confirms
+   Neuron work.
 ```
 
-- The default project counts unless that day is overwritten to a non-Neuron
-  project; a default non-Neuron day counts only when overwritten to Neuron.
-- `ASSIGNMENT TYPE` (e.g. `Neuron Installation`, `Delivery / Transport /
-  Disposal`) is an activity sub-label **within** the Neuron project and still
-  counts.
-- April spans the full month (Apr 1–30) and May spans the roster-supported
-  range, derived from the `Live - {Month}` date headers — never a stale tracker
-  tab.
+### Canonical failure this prevents
 
-## Exclusions (parsed, recorded in review, never counted)
+A person can have valid punches on a date and still be off-Neuron. Patricia
+Marrero on 2026-04-23 had roster punches, but the day was Neha work, not Neuron
+work. A generator that trusts the Live/default Neuron label produces a false
+Bonita row. The correct generator excludes the row and keeps the reason in the
+review sidecar.
+
+## Exclusions
+
+Parsed, recorded in review where useful, never counted in the submitted month
+tabs:
 
 | Case | Behavior |
 | --- | --- |
-| `/ Bonita` and other off-project coverage punches | Parse time, keep note in review sidecar, do not count |
+| `/ Neha`, `/ Bonita`, `/ Josh` and similar off-project punch tags | Parse time, keep note in review sidecar, do not count unless explicit Neuron override exists |
 | Non-work markers (`PTO` / `NON-PTO` / `N/A` / `out sick` / `vacation` / `off …`) | Skipped to review |
-| Excluded names (`Yostinn Minaya`, `Steven Marques` / `Inventory`) | Never counted; recorded for traceability |
+| Excluded names (`Yostinn Minaya`, `Steven Marques` / `Inventory`) | Never counted; recorded for traceability when they otherwise resolve to Neuron |
 
 ## Project + assignment classification
 
-- `PROJECT NAME` is a **display alias**: internal `Neuron Deployments` →
-  client-facing `Northwell - Neurons`.
-- `ASSIGNMENT TYPE` is **operator-classified** and is *not* reliably encoded in
-  the per-date tabs. The engine defaults to `Neuron Installation`, accepts an
-  explicit `Delivery / Transport / Disposal` signal from worked-project activity
-  text or a punch note, and routes anything ambiguous to the review sidecar
-  rather than fabricating a Delivery/Transport label. This is the main fidelity
-  gap vs the hand-made tracker.
+`PROJECT NAME` is a display alias:
+
+```text
+internal: Neuron Deployments
+client-facing: Northwell - Neurons
+```
+
+`ASSIGNMENT TYPE` is derived after a row is already included as Neuron work. It
+must not decide Neuron eligibility.
+
+Use only the agreed Bonita umbrella labels:
+
+- Configurations
+- Inventory Management
+- Logistics
+- Deployments
+- Ticket Forwarding
+- Client Coordination
+- Documentation
+- Troubleshooting / Incident Response
+
+### April / May distribution rules
+
+These rules fill classification gaps when the activity sample timing does not
+line up cleanly with roster punches.
+
+| Context | Classification rule |
+| --- | --- |
+| April evening hours | Most often Deployments, secondarily Logistics |
+| April weekend hours | Deployments, occasionally Logistics |
+| May weekend hours | Mostly Configurations and Inventory Management |
+| May evening hours | Mostly Configurations; occasionally Inventory Management; least often Deployments or Logistics, with May 6 as a known exception pattern |
+| Daily hours | Generally Configurations, Inventory Management, Ticket Forwarding, Client Coordination, and Logistics, in that practical order unless stronger evidence exists |
+
+### Client Coordination and Ticket Forwarding restrictions
+
+- Geoff Gerber may receive Client Coordination in April.
+- Geoff was pulled to another project in May.
+- In May, only these people may receive Client Coordination or Ticket Forwarding:
+  - Khadejah Harrison
+  - Alejandro Perales
+  - Rich Perez / Richard Perez
+- Other May Client Coordination or Ticket Forwarding evidence routes to a safer
+  operational fallback and low-confidence review, unless an approved override
+  explicitly says otherwise.
 
 ## Workbook layout
 
@@ -66,15 +127,21 @@ DATE  | TECH | START | END  | TOTAL | PROJECT | ASSIGNMENT
 ```
 
 - Values only — no formulas, no notes/commentary in cells.
-- inlineStr repair applied for Web Excel safety.
+- Start and End are real Excel time values with `h:mm AM/PM` formatting.
+- Total Hours is numeric.
+- No populated row may have blank TECH, START, END, TOTAL, PROJECT, or ASSIGNMENT.
+- No `########` time overflow and no negative time serials.
+- inlineStr repair is applied for Web Excel safety.
 
-## Sidecars (next to the workbook, all gitignored)
+## Sidecars
+
+Sidecars live next to the workbook under `Outputs/` and are gitignored.
 
 ```text
 Bonita_Neuron_Track_Hours_April_May_2026.xlsx
-Neuron_Track_Hours_April_May_2026_manifest.json     # inputs, sheets used, per-month rows+totals, timestamp
-Neuron_Track_Hours_April_May_2026_review_queue.csv  # off-project, markers, excluded names, long shifts, source cells
-Neuron_Track_Hours_April_May_2026_preflight.json    # zip/package + Web Excel checks
+Neuron_Track_Hours_April_May_2026_manifest.json
+Neuron_Track_Hours_April_May_2026_review_queue.csv
+Neuron_Track_Hours_April_May_2026_preflight.json
 ```
 
 ## CLI
@@ -89,24 +156,27 @@ python -m triage.nw_prj_neuron_track_hours.bonita_cli `
   --websafe
 ```
 
-## Preflight pass criteria (Bonita)
+## Protected tests
 
-The Bonita workbook is intentionally minimal (values-only), so its preflight is
-focused rather than the richer dashboard preflight:
+Protected fixture-only coverage includes:
 
-- Valid zip package
-- No `inlineStr`, no `ns0:` / `xmlns:ns0`
-- No `calcChain.xml`
-- No external links
+- `tests/test_nw_prj_neuron_track_hours_bonita.py`
+- `tests/test_bonita_source_hierarchy.py`
+- `tests/test_neuron_work_context_rules.py`
 
-## Tests
+Required behavior:
 
-`tests/test_nw_prj_neuron_track_hours_bonita.py` — 13 fixture-only cases
-covering both tabs, full-month April span, note-bearing punches, non-work
-markers, worked-project and Assignments overrides, long shift, excluded names,
-populated-row completeness, manifest counts/totals, preflight, and `/ Bonita`
-off-project exclusion.
+- April spans full month, not Apr 1-4.
+- Note-bearing punches parse start/end but do not leak notes into the workbook.
+- Non-work markers route to review.
+- Assignments override table can include a reviewed Neuron correction.
+- Worked Projects can exclude a stale Live/default Neuron label.
+- Off-project punch tags exclude unless an explicit Neuron override exists.
+- Long shifts are included and review-flagged.
+- Excluded names never count.
+- Start/end/total/project/assignment cannot be blank on populated rows.
+- Start/end cells are real time values.
 
 ```powershell
-python -m pytest tests/test_nw_prj_neuron_track_hours_bonita.py -q
+python -m pytest tests/test_nw_prj_neuron_track_hours_bonita.py tests/test_bonita_source_hierarchy.py tests/test_neuron_work_context_rules.py -q
 ```

--- a/tests/fixtures/one_marcus_recon/fixtures.py
+++ b/tests/fixtures/one_marcus_recon/fixtures.py
@@ -5,10 +5,13 @@ No real client data. Workbooks are generated at test time and gitignored.
 from __future__ import annotations
 
 import io
+import re
 import zipfile
 from pathlib import Path
 
 from openpyxl import Workbook
+
+_R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
 
 _EXT_LINK_XML = (
     '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
@@ -98,7 +101,9 @@ def _inject_defects(data: bytes, *, add_external: bool, add_calc_chain: bool) ->
                 '</sheets><externalReferences><externalReference r:id="rIdExt1"/>'
                 "</externalReferences>",
             )
-            parts["xl/workbook.xml"] = wb.encode("utf-8")
+        if not re.search(r"<workbook\s[^>]*xmlns:r\s*=", wb):
+            wb = wb.replace("<workbook ", f'<workbook xmlns:r="{_R_NS}" ', 1)
+        parts["xl/workbook.xml"] = wb.encode("utf-8")
 
     if add_calc_chain:
         parts["xl/calcChain.xml"] = _CALC_CHAIN.encode("utf-8")

--- a/tests/test_bonita_source_hierarchy.py
+++ b/tests/test_bonita_source_hierarchy.py
@@ -1,0 +1,84 @@
+"""Regression tests for the submitted Bonita Neuron Track Hours source hierarchy.
+
+These tests encode the billing-submission lesson that made this path tedious:
+Live tabs provide clocks, but monthly Assignments overrides and Worked Projects
+determine whether a tech/date belongs to Neurons.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+import openpyxl
+
+from triage.nw_prj_neuron_track_hours.bonita_resolver import resolve_bonita_shifts
+
+
+def _save_roster(path):
+    wb = openpyxl.Workbook()
+    wb.remove(wb.active)
+
+    live = wb.create_sheet("Live - April 2026")
+    live.append(["April 2026 - Attendance"])
+    live.append(["Staff Name", "Project", "Apr 23 - Clock In", "Apr 23 - Clock Out"])
+    live.append(["Patricia Marrero", "Neuron Deployments", "9:00 AM / Neha", "5:00 PM / Neha"])
+    live.append(["Zulu Tech", "Delivery / Transport", "8:00 AM", "4:00 PM"])
+    live.append(["Echo Tech", "Neuron Deployments", "8:00 AM", "4:00 PM"])
+    live.append(["Override Note Tech", "Delivery / Transport", "8:00 AM / Neha", "4:00 PM / Neha"])
+
+    worked = wb.create_sheet("Worked Projects - April 2026")
+    worked.append(["April 2026 - Worked Projects"])
+    worked.append(["Staff Name", "Default Project", datetime(2026, 4, 23)])
+    worked.append(["Patricia Marrero", "Neuron Deployments", "Neha / Other Project"])
+    worked.append(["Zulu Tech", "Delivery / Transport", "Delivery / Transport"])
+    worked.append(["Echo Tech", "Neuron Deployments", "Neha / Other Project"])
+    worked.append(["Override Note Tech", "Delivery / Transport", "Delivery / Transport"])
+
+    assign = wb.create_sheet("Assignments - April 2026")
+    assign.append(["April 2026 - Project Assignments"])
+    assign.append(["Staff Name", "Default Project", datetime(2026, 4, 23)])
+    assign.append(["Patricia Marrero", "Neuron Deployments", "Neha / Other Project"])
+    assign.append(["Zulu Tech", "Delivery / Transport", "Delivery / Transport"])
+    assign.append(["Echo Tech", "Neuron Deployments", "Neuron Deployments"])
+    assign.append(["Override Note Tech", "Delivery / Transport", "Delivery / Transport"])
+    assign.append([])
+    assign.append(["Overrides (only if different from Default Project)"])
+    assign.append(["Override Staff Name", "Override Date", "Override Project", "Notes"])
+    assign.append(["Zulu Tech", datetime(2026, 4, 23), "Neuron Deployments", "reviewed Neuron correction"])
+    assign.append(["Override Note Tech", datetime(2026, 4, 23), "Neuron Deployments", "explicit Neuron override beats stale / Neha note"])
+
+    wb.save(path)
+
+
+def test_worked_projects_excludes_stale_live_neuron_default(tmp_path):
+    roster = tmp_path / "roster.xlsx"
+    _save_roster(roster)
+
+    resolution = resolve_bonita_shifts(roster, ["2026-04"])
+
+    assert all(s.tech != "Patricia Marrero" for s in resolution.shifts)
+    assert all(s.tech != "Echo Tech" for s in resolution.shifts)
+
+
+def test_assignments_override_table_can_include_neuron_day(tmp_path):
+    roster = tmp_path / "roster.xlsx"
+    _save_roster(roster)
+
+    resolution = resolve_bonita_shifts(roster, ["2026-04"])
+    zulu = [s for s in resolution.shifts if s.tech == "Zulu Tech"]
+
+    assert len(zulu) == 1
+    assert zulu[0].total_hours == 8.0
+    assert zulu[0].project_name == "Northwell - Neurons"
+
+
+def test_off_project_punch_note_excludes_unless_explicit_override(tmp_path):
+    roster = tmp_path / "roster.xlsx"
+    _save_roster(roster)
+
+    resolution = resolve_bonita_shifts(roster, ["2026-04"])
+
+    assert all(s.tech != "Patricia Marrero" for s in resolution.shifts)
+    override_note = [s for s in resolution.shifts if s.tech == "Override Note Tech"]
+    assert len(override_note) == 1
+    assert override_note[0].total_hours == 8.0
+    assert any(r.category == "off_project" and r.tech == "Patricia Marrero" for r in resolution.review)

--- a/tests/test_neuron_work_context_rules.py
+++ b/tests/test_neuron_work_context_rules.py
@@ -21,7 +21,7 @@ from triage.neuron_work_context_rules import (
 )
 
 
-def _c(work_date, start, end, notes="", worked_label="", resolved_project=""):
+def _c(work_date, start, end, notes="", worked_label="", resolved_project="", tech_name=""):
     return classify_neuron_work_context(
         work_date=work_date,
         start_hour=start,
@@ -29,10 +29,9 @@ def _c(work_date, start, end, notes="", worked_label="", resolved_project=""):
         notes=notes,
         worked_label=worked_label,
         resolved_project=resolved_project,
+        tech_name=tech_name,
     )
 
-
-# ── explicit text signals (highest precedence) ─────────────────────────────────
 
 def test_daytime_logistics_signal():
     d = _c(date(2026, 3, 3), 8.0, 16.0, notes="logistics relay")
@@ -57,13 +56,10 @@ def test_explicit_documentation_signal():
 
 
 def test_explicit_deploy_note_beats_time_heuristic():
-    # Wednesday morning would otherwise be ticket forwarding.
     d = _c(date(2026, 3, 4), 10.0, 14.0, notes="go-live cutover")
     assert d.assignment_type == DEPLOYMENTS
     assert d.rule == "explicit-deployment"
 
-
-# ── April month rules ──────────────────────────────────────────────────────────
 
 def test_april_saturday_is_deployments():
     d = _c(date(2026, 4, 4), 9.0, 17.0)
@@ -82,13 +78,23 @@ def test_april_wednesday_evening_is_deployments():
     assert d.assignment_type == DEPLOYMENTS
 
 
-def test_april_tuesday_evening_is_configurations():
+def test_april_tuesday_evening_is_deployment_dominant():
     d = _c(date(2026, 4, 7), 17.0, 21.0)
-    assert d.assignment_type == CONFIGURATIONS
-    assert d.rule == "april-evening-configuration"
+    assert d.assignment_type == DEPLOYMENTS
+    assert d.rule == "april-evening-deployment-dominant"
 
 
-# ── May month rules ──────────────────────────────────────────────────────────
+def test_april_geoff_can_receive_client_coordination():
+    d = _c(
+        date(2026, 4, 23),
+        12.0,
+        16.0,
+        notes="client coordination status updates",
+        tech_name="Geoff Gerber",
+    )
+    assert d.assignment_type == CLIENT_COORDINATION
+    assert d.rule == "explicit-client-coordination"
+
 
 def test_may_weekend_morning_is_inventory():
     d = _c(date(2026, 5, 2), 8.0, 12.0)
@@ -108,7 +114,43 @@ def test_may_weekday_evening_is_configurations():
     assert d.rule == "may-evening-configuration"
 
 
-# ── time-of-day fallback (non-April/May) ───────────────────────────────────────
+def test_may_authorized_lead_can_receive_client_coordination():
+    d = _c(
+        date(2026, 5, 12),
+        12.0,
+        16.0,
+        notes="client coordination and email updates",
+        tech_name="Khadejah Harrison",
+    )
+    assert d.assignment_type == CLIENT_COORDINATION
+    assert d.rule == "explicit-client-coordination"
+
+
+def test_may_unauthorized_client_coordination_falls_back_to_reviewable_config():
+    d = _c(
+        date(2026, 5, 12),
+        12.0,
+        16.0,
+        notes="client coordination and email updates",
+        tech_name="Geoff Gerber",
+    )
+    assert d.assignment_type == CONFIGURATIONS
+    assert d.confidence == "low"
+    assert d.rule.startswith("restricted-client-coordination-fallback")
+
+
+def test_may_unauthorized_ticket_forwarding_falls_back_to_inventory():
+    d = _c(
+        date(2026, 5, 12),
+        8.0,
+        9.5,
+        notes="ticket forwarding queue",
+        tech_name="Patricia Marrero",
+    )
+    assert d.assignment_type == INVENTORY_MANAGEMENT
+    assert d.confidence == "low"
+    assert d.rule.startswith("restricted-ticket-forwarding-fallback")
+
 
 def test_weekday_morning_is_ticket_forwarding():
     d = _c(date(2026, 3, 3), 8.0, 9.5)

--- a/triage/neuron_work_context_rules.py
+++ b/triage/neuron_work_context_rules.py
@@ -1,9 +1,9 @@
 """Rule-based Neuron work-context classification.
 
 These rules preserve the operational memory behind Neuron Track Hours artifacts so
-future generators do not flatten every included Neuron shift into
-``Neuron Installation``. The classifier is intentionally deterministic and
-explainable: it uses explicit text signals first, then month/day/time rules.
+future generators do not flatten every included Neuron shift into a generic label.
+The classifier is intentionally deterministic and explainable: it uses explicit
+text signals first, then month/day/time rules.
 
 Submission workbooks should receive the resulting assignment/task label only.
 Rule explanations and uncertainty belong in internal audit sidecars, not in the
@@ -52,6 +52,17 @@ EVENING_START_HOUR = 16.0
 DAYTIME_LOGISTICS_START = 7.0
 DAYTIME_LOGISTICS_END = 17.5
 
+# May coordination / ticket-forwarding became a named lead/coordinator lane.
+_MAY_COORDINATION_NAMES = {
+    "khadejah harrison",
+    "alejandro perales",
+    "rich perez",
+    "richard perez",
+}
+_APRIL_COORDINATION_EXTRA_NAMES = {
+    "geoff gerber",
+}
+
 
 @dataclass(frozen=True)
 class WorkContextDecision:
@@ -60,6 +71,40 @@ class WorkContextDecision:
     assignment_type: str
     rule: str
     confidence: str = "medium"
+
+
+def _normalize_name(name: str) -> str:
+    return re.sub(r"\s+", " ", str(name or "").strip().lower())
+
+
+def can_use_coordination_lane(work_date: date, tech_name: str, assignment_type: str) -> bool:
+    """Return True when *tech_name* may receive a coordination/ticket lane."""
+
+    name = _normalize_name(tech_name)
+    if assignment_type == TICKET_FORWARDING and work_date.month == 5:
+        return name in _MAY_COORDINATION_NAMES
+    if assignment_type == CLIENT_COORDINATION:
+        if work_date.month == 5:
+            return name in _MAY_COORDINATION_NAMES
+        if work_date.month == 4:
+            return name in _MAY_COORDINATION_NAMES or name in _APRIL_COORDINATION_EXTRA_NAMES
+    return True
+
+
+def _restricted_coordination_fallback(
+    work_date: date,
+    tech_name: str,
+    assignment_type: str,
+    rule: str,
+) -> Optional[WorkContextDecision]:
+    if can_use_coordination_lane(work_date, tech_name, assignment_type):
+        return None
+    safe = INVENTORY_MANAGEMENT if assignment_type == TICKET_FORWARDING else CONFIGURATIONS
+    return WorkContextDecision(
+        safe,
+        f"restricted-{assignment_type.lower().replace(' ', '-')}-fallback:{rule}",
+        "low",
+    )
 
 
 def _normalize_hour(value: Optional[float]) -> Optional[float]:
@@ -122,6 +167,19 @@ def _explicit_signal(text: str) -> Optional[str]:
     return None
 
 
+def _decision_with_person_gate(
+    work_date: date,
+    tech_name: str,
+    assignment_type: str,
+    rule: str,
+    confidence: str = "medium",
+) -> WorkContextDecision:
+    blocked = _restricted_coordination_fallback(work_date, tech_name, assignment_type, rule)
+    if blocked is not None:
+        return blocked
+    return WorkContextDecision(assignment_type, rule, confidence)
+
+
 def classify_neuron_work_context(
     work_date: date,
     start_hour: Optional[float],
@@ -129,16 +187,9 @@ def classify_neuron_work_context(
     notes: str = "",
     worked_label: str = "",
     resolved_project: str = "",
+    tech_name: str = "",
 ) -> WorkContextDecision:
-    """Classify a Neuron shift into a realistic task lane.
-
-    Precedence:
-    1. Explicit text signals from notes/worked label/resolved project.
-    2. Logistics is allowed only during daytime material movement / cleanup.
-    3. April-specific deployment windows.
-    4. May weekend configuration/inventory behavior.
-    5. Time-of-day fallback with configurations as the dominant default.
-    """
+    """Classify a Neuron shift into a realistic task lane."""
 
     text = " ".join(x for x in (notes, worked_label, resolved_project) if x).strip()
     explicit = _explicit_signal(text)
@@ -149,7 +200,13 @@ def classify_neuron_work_context(
         return WorkContextDecision(CONFIGURATIONS, "logistics-signal-outside-daytime-config-fallback", "medium")
 
     if explicit and explicit != DEPLOYMENTS:
-        return WorkContextDecision(explicit, f"explicit-{explicit.lower().replace(' ', '-')}", "high")
+        return _decision_with_person_gate(
+            work_date,
+            tech_name,
+            explicit,
+            f"explicit-{explicit.lower().replace(' ', '-')}",
+            "high",
+        )
 
     month = work_date.month
     weekday = work_date.weekday()  # Mon=0, Sat=5
@@ -163,10 +220,12 @@ def classify_neuron_work_context(
     if month == 4:
         if weekday == 5:  # April Saturdays.
             return WorkContextDecision(DEPLOYMENTS, "april-saturday-deployment", "high")
-        if weekday in (0, 2) and evening:  # April Monday/Wednesday evening windows.
+        if weekday >= 5:
+            return WorkContextDecision(DEPLOYMENTS, "april-weekend-deployment", "medium")
+        if weekday in (0, 2) and evening:
             return WorkContextDecision(DEPLOYMENTS, "april-mon-wed-evening-deployment", "medium")
         if evening:
-            return WorkContextDecision(CONFIGURATIONS, "april-evening-configuration", "high")
+            return WorkContextDecision(DEPLOYMENTS, "april-evening-deployment-dominant", "medium")
 
     if month == 5:
         if weekday >= 5:
@@ -176,17 +235,27 @@ def classify_neuron_work_context(
         if evening:
             return WorkContextDecision(CONFIGURATIONS, "may-evening-configuration", "high")
 
-    # A full weekday shift usually includes configuration work and should not be
-    # reduced to logistics or a narrow admin activity without explicit evidence.
     if span >= 7.0 and evening:
         return WorkContextDecision(CONFIGURATIONS, "full-shift-overlaps-configuration-window", "medium")
 
     if mid is not None:
         if mid < 10.0:
-            return WorkContextDecision(TICKET_FORWARDING, "morning-ticket-forwarding", "medium")
+            return _decision_with_person_gate(
+                work_date,
+                tech_name,
+                TICKET_FORWARDING,
+                "morning-ticket-forwarding",
+                "medium",
+            )
         if mid < 14.0:
             return WorkContextDecision(INVENTORY_MANAGEMENT, "daytime-inventory-management", "medium")
         if mid < EVENING_START_HOUR:
-            return WorkContextDecision(CLIENT_COORDINATION, "afternoon-client-coordination", "medium")
+            return _decision_with_person_gate(
+                work_date,
+                tech_name,
+                CLIENT_COORDINATION,
+                "afternoon-client-coordination",
+                "medium",
+            )
 
     return WorkContextDecision(CONFIGURATIONS, "default-configuration-dominant", "low")

--- a/triage/nw_prj_neuron_track_hours/bonita_resolver.py
+++ b/triage/nw_prj_neuron_track_hours/bonita_resolver.py
@@ -6,22 +6,19 @@ Assignments loader from ``roster_parser``; it adds project resolution,
 classification (include / off-project / non-work-marker / excluded-name) and a
 review trail so nothing is silently dropped.
 
-Inclusion rule (project-driven):
-  A tech/date shift enters the Bonita workbook only when the resolved project
-  for that date is the Neuron project. Resolution precedence:
-      Worked Projects cell  >  Assignments override  >  Live default project.
-  The default project counts unless that day is overwritten to a non-Neuron
-  project; a default non-Neuron day counts only when overwritten to Neuron.
+Final submitted-artifact source hierarchy:
+  1. ``Live - {Month}`` provides clock truth only.
+  2. Monthly Assignments override table is the highest-priority project fix.
+  3. ``Worked Projects - {Month}`` provides per-tech/per-date project scope.
+  4. Assignments main grid fills behind Worked Projects.
+  5. Live default project is a last-resort fallback only.
+  6. Punch-note tags such as ``/ Neha``, ``/ Bonita``, and ``/ Josh`` are
+     off-Neuron conflict evidence unless an explicit Assignments override
+     confirms Neuron work.
 
-Work-context rule:
-  Included Neuron shifts are classified through ``triage.neuron_work_context_rules``.
-  The submission workbook receives the resulting task lane only. Rule reasons and
-  confidence belong in the internal review/audit sidecars, not the clean tracker.
-
-Exclusions (parsed, recorded in review, never counted):
-  - ``/ Bonita`` and other off-project coverage punches.
-  - Non-work markers: PTO / NON-PTO / N/A / out sick / vacation / off ...
-  - Excluded names: Yostinn Minaya, Steven Marques / Inventory.
+A tech/date shift enters the Bonita workbook only when that resolved source
+hierarchy says the work belongs to Neurons. This prevents stale/default Neuron
+labels from pulling in off-project days such as Patricia / Neha work.
 """
 from __future__ import annotations
 
@@ -51,24 +48,14 @@ from triage.nw_prj_neuron_track_hours.reader import (
     split_note_bearing_punch,
 )
 
-# ── Project display + classification config ─────────────────────────────────
 NEURON_INTERNAL_PROJECT = "Neuron Deployments"
-# Client-facing rename of the internal project (display alias).
 NEURON_DISPLAY_NAME = "Northwell - Neurons"
-
-# Backward-compatible constant name. This is no longer a universal default.
 DEFAULT_ASSIGNMENT_TYPE = CONFIGURATIONS
 DELIVERY_ASSIGNMENT_TYPE = LOGISTICS
-
 LONG_SHIFT_HOURS = 12.0
 
-# Off-project coverage signals seen in punch notes (parsed but not counted).
-_OFF_PROJECT_NOTE = re.compile(r"\bbonita\b", re.IGNORECASE)
-
-# Excluded names (never counted, recorded in review).
+_OFF_PROJECT_NOTE = re.compile(r"\b(bonita|neha|josh)\b", re.IGNORECASE)
 EXCLUDED_NAMES = {"yostinn minaya", "steven marques", "inventory"}
-
-# Non-work markers (whole-cell text instead of a punch time).
 _NON_WORK_MARKER = re.compile(
     r"^\s*(pto|non[\s-]*pto|n/?a|out\s*sick|sick|vacation|off\b.*|holiday|"
     r"unpaid|leave|absent)\s*$",
@@ -78,21 +65,19 @@ _NON_WORK_MARKER = re.compile(
 
 @dataclass
 class BonitaShift:
-    """One included Neuron shift destined for the clean workbook."""
-
-    month_key: str            # "2026-04"
-    month_name: str           # "April"
+    month_key: str
+    month_name: str
     date: date
-    day: str                  # "Tue"
+    day: str
     tech: str
-    clock_in: str             # display, e.g. "9:00 AM"
+    clock_in: str
     clock_out: str
     total_hours: float
     project_name: str = NEURON_DISPLAY_NAME
     assignment_type: str = DEFAULT_ASSIGNMENT_TYPE
     note: str = ""
     long_shift: bool = False
-    start_time: Optional[time] = None   # real time for h:mm AM/PM cells
+    start_time: Optional[time] = None
     end_time: Optional[time] = None
     assignment_rule: str = ""
     assignment_confidence: str = ""
@@ -100,10 +85,7 @@ class BonitaShift:
 
 @dataclass
 class BonitaReviewItem:
-    """A parsed-but-not-counted observation (or a counted-but-flagged one)."""
-
-    category: str             # off_project | non_work_marker | excluded_name
-                              # | long_shift | unparsed | assignment_ambiguous
+    category: str
     month_name: str
     date: Optional[date]
     day: str
@@ -143,9 +125,7 @@ class BonitaResolution:
         return [s for s in self.shifts if s.month_name == month_name_]
 
     def month_total(self, month_name_: str) -> float:
-        return round(
-            sum(round(s.total_hours, 2) for s in self.shifts_for_month(month_name_)), 2
-        )
+        return round(sum(round(s.total_hours, 2) for s in self.shifts_for_month(month_name_)), 2)
 
     def grand_total(self) -> float:
         return round(sum(round(s.total_hours, 2) for s in self.shifts), 2)
@@ -163,14 +143,44 @@ def _is_non_work_marker(text: str) -> bool:
 
 
 def _col_letter(idx0: int) -> str:
-    """0-based column index -> spreadsheet letter (for review source cell refs)."""
-
     idx = idx0 + 1
     out = ""
     while idx:
         idx, rem = divmod(idx - 1, 26)
         out = chr(65 + rem) + out
     return out
+
+
+def _add_review(
+    resolution: BonitaResolution,
+    *,
+    category: str,
+    month_name: str,
+    work_date: Optional[date],
+    day: str,
+    tech: str,
+    clock_in: str = "",
+    clock_out: str = "",
+    total_hours: float = 0.0,
+    project: str = "",
+    note: str = "",
+    source_cell: str = "",
+    detail: str = "",
+) -> None:
+    resolution.review.append(BonitaReviewItem(
+        category=category,
+        month_name=month_name,
+        date=work_date,
+        day=day,
+        tech=tech,
+        clock_in=clock_in,
+        clock_out=clock_out,
+        total_hours=total_hours,
+        project=project,
+        note=note,
+        source_cell=source_cell,
+        detail=detail,
+    ))
 
 
 def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
@@ -183,19 +193,13 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
 
     worked_ws = _find_sheet(wb, "Worked Projects", label)
     if worked_ws is None:
-        resolution.warnings.append(
-            f"worked_projects_missing:{label}:falling_back_to_default_and_assignments"
-        )
+        resolution.warnings.append(f"worked_projects_missing:{label}:falling_back_to_default_and_assignments")
     worked = _worked_project_lookup(worked_ws)
 
     assignments: Dict[tuple[date, str], str] = {}
     overrides: Dict[tuple[date, str], str] = {}
     try:
-        from triage.roster_parser import (
-            _find_assignments_sheet,
-            _load_assignments,
-            _load_overrides_only,
-        )
+        from triage.roster_parser import _find_assignments_sheet, _load_assignments, _load_overrides_only
         assignments_sheet = _find_assignments_sheet(wb, label)
         assignments = _load_assignments(assignments_sheet)
         overrides = _load_overrides_only(assignments_sheet)
@@ -246,17 +250,18 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
             if ci is None and co is None:
                 marker = (note_in or note_out or "").strip()
                 if _is_non_work_marker(marker):
-                    resolution.review.append(BonitaReviewItem(
+                    _add_review(
+                        resolution,
                         category="non_work_marker",
                         month_name=short,
-                        date=d,
+                        work_date=d,
                         day=d.strftime("%a"),
                         tech=staff,
                         project=default_proj,
                         note=marker,
                         source_cell=f"{_col_letter(in_idx or out_idx or 0)}{r}",
                         detail="non-work marker, not counted",
-                    ))
+                    )
                 continue
 
             note = " ".join(n for n in (note_in, note_out) if n).strip()
@@ -267,13 +272,15 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
             assign_label = assignments.get((d, staff), "")
             override_label = overrides.get((d, staff), "")
             resolved = override_label or worked_label or assign_label or default_proj
+            explicit_neuron_override = bool(override_label and _is_neuron(override_label))
 
             if _excluded_name(staff):
                 if _is_neuron(resolved):
-                    resolution.review.append(BonitaReviewItem(
+                    _add_review(
+                        resolution,
                         category="excluded_name",
                         month_name=short,
-                        date=d,
+                        work_date=d,
                         day=day,
                         tech=staff,
                         clock_in=_format_clock(ci),
@@ -283,14 +290,15 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                         note=note,
                         source_cell=cell_ref,
                         detail="excluded name, not counted",
-                    ))
+                    )
                 continue
 
-            if _OFF_PROJECT_NOTE.search(note):
-                resolution.review.append(BonitaReviewItem(
+            if _OFF_PROJECT_NOTE.search(note) and not explicit_neuron_override:
+                _add_review(
+                    resolution,
                     category="off_project",
                     month_name=short,
-                    date=d,
+                    work_date=d,
                     day=day,
                     tech=staff,
                     clock_in=_format_clock(ci),
@@ -299,8 +307,8 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                     project=resolved,
                     note=note,
                     source_cell=cell_ref,
-                    detail="off-project coverage punch, excluded from totals",
-                ))
+                    detail="off-project punch note, excluded from Neuron totals",
+                )
                 continue
 
             if not _is_neuron(resolved):
@@ -314,6 +322,7 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                 notes=note,
                 worked_label=worked_label or assign_label,
                 resolved_project=resolved,
+                tech_name=staff,
             )
             long_shift = gross >= LONG_SHIFT_HOURS
 
@@ -338,10 +347,11 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
             resolution.shifts.append(shift)
 
             if long_shift:
-                resolution.review.append(BonitaReviewItem(
+                _add_review(
+                    resolution,
                     category="long_shift",
                     month_name=short,
-                    date=d,
+                    work_date=d,
                     day=day,
                     tech=staff,
                     clock_in=shift.clock_in,
@@ -351,12 +361,13 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                     note=note,
                     source_cell=cell_ref,
                     detail=f"long shift {gross:g}h included; verify",
-                ))
+                )
             if decision.confidence == "low":
-                resolution.review.append(BonitaReviewItem(
+                _add_review(
+                    resolution,
                     category="assignment_heuristic_low_confidence",
                     month_name=short,
-                    date=d,
+                    work_date=d,
                     day=day,
                     tech=staff,
                     clock_in=shift.clock_in,
@@ -366,13 +377,10 @@ def _resolve_month(wb, month_key: str, resolution: BonitaResolution) -> None:
                     note="",
                     source_cell=cell_ref,
                     detail=f"assignment resolved by heuristic rule: {decision.rule}",
-                ))
+                )
 
 
-def resolve_bonita_shifts(
-    roster_path: str | Path,
-    months: List[str],
-) -> BonitaResolution:
+def resolve_bonita_shifts(roster_path: str | Path, months: List[str]) -> BonitaResolution:
     try:
         import openpyxl
     except ImportError as e:  # pragma: no cover
@@ -388,7 +396,5 @@ def resolve_bonita_shifts(
     finally:
         wb.close()
     resolution.shifts.sort(key=lambda s: (s.month_key, s.date, s.tech))
-    resolution.review.sort(
-        key=lambda x: (x.category, x.date or date.min, x.tech)
-    )
+    resolution.review.sort(key=lambda x: (x.category, x.date or date.min, x.tech))
     return resolution


### PR DESCRIPTION
## Summary

Codifies the submitted Bonita Neuron Track Hours behavior so the April/May billing reconstruction does not repeat.

This PR locks in the operating contract:

- Live tabs provide clock truth only.
- Monthly Assignments override table wins first.
- Worked Projects determines per-tech/per-date Neuron scope when no override exists.
- Assignments main grid fills behind Worked Projects.
- Live default project is fallback only.
- Punch-note tags such as `/ Neha`, `/ Bonita`, and `/ Josh` exclude from Neuron unless an explicit Neuron override exists.
- May Client Coordination and Ticket Forwarding are restricted to Khadejah, Alejandro, and Rich/Richard.
- April still allows Geoff for Client Coordination.

## Changed files

- `.github/workflows/artifact-engines.yml`
- `configs/artifact_profiles/bonita_neuron_track_hours.json`
- `docs/BONITA_NEURON_TRACK_HOURS_CONTRACT.md`
- `tests/fixtures/one_marcus_recon/fixtures.py`
- `tests/test_bonita_source_hierarchy.py`
- `tests/test_neuron_work_context_rules.py`
- `triage/neuron_work_context_rules.py`
- `triage/nw_prj_neuron_track_hours/bonita_resolver.py`

The One Marcus fixture change is a shared test-harness compatibility repair: it ensures the generated workbook fixture declares `xmlns:r` before injecting an external relationship, allowing the protected artifact suite to parse the fixture consistently.

## Validation evidence

GitHub Actions completed successfully on head `63722e951cd38ba35dc536b2217da738edcde896`:

- Workflow: `Artifact engine tests`
- Run: `147`
- Job: `artifact-engines`
- Engine import smoke: PASS
- Gitignore hygiene: PASS
- Protected artifact-engine pytest suite: PASS

The protected suite includes the new Bonita source-hierarchy and work-context tests alongside the existing artifact-engine, compare, roster-review, and hygiene suites.

## Proof ceiling and remaining blockers

This proves fixture-level source hierarchy, classification behavior, engine imports, and repository hygiene. It does **not** prove private workbook parity or final browser/operator acceptance.

Still required before declaring the submitted workflow fully closed:

- Generate from the current private roster log.
- Compare against the submitted color-coded Bonita workbook.
- Confirm source-hour conservation and the intended one-row-versus-split-allocation model.
- Confirm time cells, widths, color mapping, and workbook behavior in Excel for Web.
- Keep all private workbooks, references, and generated evidence under ignored local paths.

## Privacy and output posture

No private roster logs, submitted workbooks, generated outputs, or private reference workbooks are committed.