### PR TITLE
feat(roster-review): implement blank workbook shell mode (clean replacement for #56)

### DIFF
--- a/tests/test_roster_log_review_queue.py
+++ b/tests/test_roster_log_review_queue.py
@@ -7,6 +7,9 @@ import zipfile
 from pathlib import Path
 from unittest import mock
 
+import openpyxl
+import pytest
+
 from tests.fixtures.roster_log_review_queue.builders import (
     build_mini_roster,
     build_roster_with_legacy_cf,
@@ -26,6 +29,50 @@ def _marker_present(xlsx_bytes: bytes, sheet: str) -> bool:
         part = [p for p, n in sheet_name_map(z).items() if n == sheet][0]
         xml = read_text(z, part)
     return any(m in xml for m in markers)
+
+
+def test_blank_mode_builds_review_first_shell(tmp_path: Path) -> None:
+    out = tmp_path / "blank.xlsx"
+    prov = tmp_path / "blank.provenance.json"
+
+    result = run(
+        mode="blank",
+        output_path=str(out),
+        provenance_out=str(prov),
+        months=["2026-04", "2026-05"],
+    )
+
+    assert result.preflight_pass, result.errors
+    assert result.review_queue_rows == 0
+    wb = openpyxl.load_workbook(out, read_only=True)
+    assert wb.sheetnames[:4] == [
+        "Review Dashboard",
+        "Review Queue",
+        "Review Rules",
+        "CF Dictionary",
+    ]
+    assert wb.sheetnames[4:] == ["Live - April 2026", "Live - May 2026"]
+    assert wb["Review Queue"]["A1"].value == "Review ID"
+    assert wb["Review Rules"].max_row == 8
+    assert wb["CF Dictionary"].max_row == 7
+    assert wb["Live - April 2026"]["C2"].value == "Apr 01 - Clock In"
+    assert wb["Live - April 2026"]["D2"].value == "Apr 01 - Clock Out"
+    assert wb["Live - April 2026"].max_column == 62
+    assert wb["Live - May 2026"].max_column == 64
+    wb.close()
+
+    data = json.loads(prov.read_text(encoding="utf-8"))
+    assert data["mode"] == "blank"
+    assert data["input_workbook"] == "<generated blank roster shell>"
+    assert data["repair_safety"]["openpyxl_save_used"] is True
+    assert data["verification"]["review_dashboard_first"] is True
+    assert data["verification"]["all_live_tabs_patched"] is True
+    assert data["verification"]["live_tabs_patched_count"] == 2
+
+
+def test_blank_mode_requires_months(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="--months is required for blank mode"):
+        run(mode="blank", output_path=str(tmp_path / "blank.xlsx"))
 
 
 def test_live_cf_patcher_adds_markers(tmp_path: Path) -> None:

--- a/tests/test_roster_log_review_queue.py
+++ b/tests/test_roster_log_review_queue.py
@@ -14,6 +14,8 @@ from tests.fixtures.roster_log_review_queue.builders import (
     build_mini_roster,
     build_roster_with_legacy_cf,
 )
+from triage.one_marcus_recon import path_guard
+from triage.one_marcus_recon.path_guard import SourcePathWriteForbiddenError
 from triage.roster_log_review_queue.priority_allocator import (
     count_cf_groups,
     load_cf_markers,
@@ -53,7 +55,15 @@ def test_blank_mode_builds_review_first_shell(tmp_path: Path) -> None:
     ]
     assert wb.sheetnames[4:] == ["Live - April 2026", "Live - May 2026"]
     assert wb["Review Queue"]["A1"].value == "Review ID"
-    assert wb["Review Rules"].max_row == 8
+    assert wb["Review Rules"].max_row == 18
+    review_rule_codes = [
+        wb["Review Rules"].cell(row=row, column=1).value
+        for row in range(2, wb["Review Rules"].max_row + 1)
+    ]
+    assert review_rule_codes[0] == "MISSING_PROJECT_CORRECTION"
+    assert "PROJECT_CONFLICT" in review_rule_codes
+    assert "UNASSIGNED_WORKED_HOURS" in review_rule_codes
+    assert review_rule_codes[-1] == "MISSING_REZAUL_NEURON_ATTRIBUTION"
     assert wb["CF Dictionary"].max_row == 7
     assert wb["Live - April 2026"]["C2"].value == "Apr 01 - Clock In"
     assert wb["Live - April 2026"]["D2"].value == "Apr 01 - Clock Out"
@@ -73,6 +83,19 @@ def test_blank_mode_builds_review_first_shell(tmp_path: Path) -> None:
 def test_blank_mode_requires_months(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="--months is required for blank mode"):
         run(mode="blank", output_path=str(tmp_path / "blank.xlsx"))
+
+
+@pytest.mark.parametrize("readonly_root", ["Candidates", "Active"])
+def test_blank_mode_refuses_operator_input_folders(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, readonly_root: str
+) -> None:
+    monkeypatch.setattr(path_guard, "_REPO_ROOT", tmp_path)
+    out = tmp_path / readonly_root / "blank.xlsx"
+
+    with pytest.raises(SourcePathWriteForbiddenError):
+        run(mode="blank", output_path=str(out), months=["2026-04"])
+
+    assert not out.exists()
 
 
 def test_live_cf_patcher_adds_markers(tmp_path: Path) -> None:

--- a/triage/roster_log_review_queue/blank_builder.py
+++ b/triage/roster_log_review_queue/blank_builder.py
@@ -1,11 +1,19 @@
 """Build a new roster review workbook shell for ``--mode blank``."""
 from __future__ import annotations
 
+import json
 from calendar import month_abbr, month_name, monthrange
 from pathlib import Path
 from typing import Dict, Iterable, List, Tuple
 
 from triage.month_validation import validate_month_key
+
+_REVIEW_RULES_SEED = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "roster_log_review_queue"
+    / "review_rules_seed.json"
+)
 
 REVIEW_QUEUE_HEADERS = [
     "Review ID",
@@ -27,24 +35,60 @@ REVIEW_QUEUE_HEADERS = [
     "Notes",
 ]
 
-REVIEW_RULES: List[Tuple[str, str, str, str]] = [
-    ("MISSING_PROJECT", "Red", "Staff row has no project", "Assign or confirm the project."),
-    ("INCOMPLETE_PUNCH", "Red", "Only one punch is present", "Confirm the missing clock value."),
-    ("NON_WORK_MARKER", "Green", "Punch contains PTO, sick, N/A, or day-off text", "Confirm the non-work marker."),
-    ("LONG_SHIFT_12_PLUS", "Blue", "Gross punch span is at least 12 hours", "Review the shift and confirm the hours."),
-    ("EXTENDED_SHIFT_8_TO_12", "Purple", "Gross punch span is over 8 and under 12 hours", "Review for lunch or split-shift context."),
-    ("SHORT_SHIFT_UNDER_8", "Amber", "Gross punch span is over 0 and under 8 hours", "Confirm the partial shift."),
-    ("NOTE_BEARING_PUNCH", "Light Blue", "Punch contains a note delimiter", "Review and preserve the note as evidence."),
+CF_DICTIONARY: List[Tuple[str, str, str]] = [
+    (
+        "Red",
+        "Missing project or invalid punch pair",
+        "MISSING_PROJECT_CORRECTION, INVALID_PUNCH_PAIR",
+    ),
+    (
+        "Green",
+        "Documented non-work marker",
+        "PTO_ACCEPTED, OFF_DAY_ACCEPTED, DAY_OFF_EVIDENCE_ACCEPTED, "
+        "CASR_DAY_OFF_ACCEPTED",
+    ),
+    ("Blue", "Shift is 12 hours or longer", "LONG_SHIFT_REVIEW"),
+    ("Purple", "Potential overtime or extended shift", "OT_REVIEW"),
+    ("Amber", "Partial shift requires review", "PARTIAL_HOURS_REVIEW"),
+    (
+        "Light Blue",
+        "Punch contains reviewable note text",
+        "NOTE_BEARING_PUNCH",
+    ),
 ]
 
-CF_DICTIONARY: List[Tuple[str, str, str]] = [
-    ("Red", "Missing project or incomplete punch", "MISSING_PROJECT, INCOMPLETE_PUNCH"),
-    ("Green", "Documented non-work marker", "NON_WORK_MARKER"),
-    ("Blue", "Shift is 12 hours or longer", "LONG_SHIFT_12_PLUS"),
-    ("Purple", "Shift is over 8 and under 12 hours", "EXTENDED_SHIFT_8_TO_12"),
-    ("Amber", "Shift is under 8 hours", "SHORT_SHIFT_UNDER_8"),
-    ("Light Blue", "Punch contains reviewable note text", "NOTE_BEARING_PUNCH"),
-]
+
+def _load_review_rules() -> List[Tuple[str, str, str, str]]:
+    """Load the canonical review-rule contract without inventing rule codes."""
+    payload = json.loads(_REVIEW_RULES_SEED.read_text(encoding="utf-8"))
+    codes = [str(code).strip() for code in payload.get("rule_codes", []) if str(code).strip()]
+    if not codes:
+        raise ValueError(f"review rule seed has no rule_codes: {_REVIEW_RULES_SEED}")
+
+    rows_by_code: Dict[str, dict] = {}
+    for row in payload.get("rows", []):
+        if not isinstance(row, dict):
+            continue
+        code = str(row.get("rule_code") or row.get("Rule Code") or "").strip()
+        if code:
+            rows_by_code[code] = row
+
+    rules: List[Tuple[str, str, str, str]] = []
+    for code in codes:
+        row = rows_by_code.get(code, {})
+        rules.append(
+            (
+                code,
+                str(row.get("severity") or row.get("Severity") or ""),
+                str(row.get("trigger") or row.get("Trigger") or ""),
+                str(
+                    row.get("suggested_resolution")
+                    or row.get("Suggested Resolution")
+                    or ""
+                ),
+            )
+        )
+    return rules
 
 
 def _normalize_months(months: Iterable[str]) -> List[Tuple[str, int, int, str]]:
@@ -84,6 +128,7 @@ def build_blank_roster(path: str | Path, months: Iterable[str]) -> Dict[str, obj
     from openpyxl.utils import get_column_letter
 
     month_specs = _normalize_months(months)
+    review_rules = _load_review_rules()
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
 
@@ -103,10 +148,13 @@ def build_blank_roster(path: str | Path, months: Iterable[str]) -> Dict[str, obj
     dashboard.append(["Workbook State", "Blank operator shell"])
     dashboard.append(["Months", ", ".join(spec[0] for spec in month_specs)])
     dashboard.append(["Review Queue", "No source rows loaded"])
-    dashboard.append([
-        "Instructions",
-        "Enter staff, project, and punches on the Live tabs. Run full or review-only mode against a populated roster to build review evidence.",
-    ])
+    dashboard.append(
+        [
+            "Instructions",
+            "Enter staff, project, and punches on the Live tabs. Run full or "
+            "review-only mode against a populated roster to build review evidence.",
+        ]
+    )
     dashboard.column_dimensions["A"].width = 22
     dashboard.column_dimensions["B"].width = 92
     dashboard.freeze_panes = "A3"
@@ -116,25 +164,28 @@ def build_blank_roster(path: str | Path, months: Iterable[str]) -> Dict[str, obj
     _style_header(queue, 1, fill=header_fill, font=header_font, alignment=header_alignment)
     queue.freeze_panes = "A2"
     queue.auto_filter.ref = f"A1:{get_column_letter(len(REVIEW_QUEUE_HEADERS))}1"
-    for idx, width in enumerate([16, 14, 14, 24, 24, 18, 24, 12, 16, 24, 24, 34, 24, 24, 20, 18, 40], 1):
+    widths = [16, 14, 14, 24, 24, 18, 24, 12, 16, 24, 24, 34, 24, 24, 20, 18, 40]
+    for idx, width in enumerate(widths, 1):
         queue.column_dimensions[get_column_letter(idx)].width = width
 
     rules = wb.create_sheet("Review Rules")
     rules.append(["Rule Code", "Severity", "Trigger", "Suggested Resolution"])
-    for row in REVIEW_RULES:
+    for row in review_rules:
         rules.append(row)
     _style_header(rules, 1, fill=header_fill, font=header_font, alignment=header_alignment)
     rules.freeze_panes = "A2"
-    for col, width in zip("ABCD", [28, 14, 52, 52]):
+    for col, width in zip("ABCD", [34, 14, 52, 52]):
         rules.column_dimensions[col].width = width
 
     dictionary = wb.create_sheet("CF Dictionary")
     dictionary.append(["Color", "Meaning", "Rule Codes"])
     for row in CF_DICTIONARY:
         dictionary.append(row)
-    _style_header(dictionary, 1, fill=header_fill, font=header_font, alignment=header_alignment)
+    _style_header(
+        dictionary, 1, fill=header_fill, font=header_font, alignment=header_alignment
+    )
     dictionary.freeze_panes = "A2"
-    for col, width in zip("ABC", [18, 44, 48]):
+    for col, width in zip("ABC", [18, 44, 72]):
         dictionary.column_dimensions[col].width = width
 
     live_sheets: List[str] = []
@@ -161,6 +212,6 @@ def build_blank_roster(path: str | Path, months: Iterable[str]) -> Dict[str, obj
     return {
         "months": [spec[0] for spec in month_specs],
         "live_sheets": live_sheets,
-        "review_rules_rows": len(REVIEW_RULES),
+        "review_rules_rows": len(review_rules),
         "cf_dictionary_rows": len(CF_DICTIONARY),
     }

--- a/triage/roster_log_review_queue/blank_builder.py
+++ b/triage/roster_log_review_queue/blank_builder.py
@@ -1,0 +1,166 @@
+"""Build a new roster review workbook shell for ``--mode blank``."""
+from __future__ import annotations
+
+from calendar import month_abbr, month_name, monthrange
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+from triage.month_validation import validate_month_key
+
+REVIEW_QUEUE_HEADERS = [
+    "Review ID",
+    "Month",
+    "Date",
+    "Staff",
+    "Source Sheet",
+    "Source Cells",
+    "Rule Code",
+    "Severity",
+    "Current Status",
+    "Detected Value",
+    "Expected Value",
+    "Suggested Resolution",
+    "Resolution Value",
+    "Resolution Source",
+    "Owner",
+    "Last Reviewed",
+    "Notes",
+]
+
+REVIEW_RULES: List[Tuple[str, str, str, str]] = [
+    ("MISSING_PROJECT", "Red", "Staff row has no project", "Assign or confirm the project."),
+    ("INCOMPLETE_PUNCH", "Red", "Only one punch is present", "Confirm the missing clock value."),
+    ("NON_WORK_MARKER", "Green", "Punch contains PTO, sick, N/A, or day-off text", "Confirm the non-work marker."),
+    ("LONG_SHIFT_12_PLUS", "Blue", "Gross punch span is at least 12 hours", "Review the shift and confirm the hours."),
+    ("EXTENDED_SHIFT_8_TO_12", "Purple", "Gross punch span is over 8 and under 12 hours", "Review for lunch or split-shift context."),
+    ("SHORT_SHIFT_UNDER_8", "Amber", "Gross punch span is over 0 and under 8 hours", "Confirm the partial shift."),
+    ("NOTE_BEARING_PUNCH", "Light Blue", "Punch contains a note delimiter", "Review and preserve the note as evidence."),
+]
+
+CF_DICTIONARY: List[Tuple[str, str, str]] = [
+    ("Red", "Missing project or incomplete punch", "MISSING_PROJECT, INCOMPLETE_PUNCH"),
+    ("Green", "Documented non-work marker", "NON_WORK_MARKER"),
+    ("Blue", "Shift is 12 hours or longer", "LONG_SHIFT_12_PLUS"),
+    ("Purple", "Shift is over 8 and under 12 hours", "EXTENDED_SHIFT_8_TO_12"),
+    ("Amber", "Shift is under 8 hours", "SHORT_SHIFT_UNDER_8"),
+    ("Light Blue", "Punch contains reviewable note text", "NOTE_BEARING_PUNCH"),
+]
+
+
+def _normalize_months(months: Iterable[str]) -> List[Tuple[str, int, int, str]]:
+    values = list(months or [])
+    if not values:
+        raise ValueError("--months is required for blank mode")
+
+    result: List[Tuple[str, int, int, str]] = []
+    seen: set[str] = set()
+    for key in values:
+        year, month = validate_month_key(key)
+        normalized = f"{year:04d}-{month:02d}"
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        result.append((normalized, year, month, f"{month_name[month]} {year}"))
+    return result
+
+
+def _style_header(ws, row: int, *, fill, font, alignment) -> None:
+    for cell in ws[row]:
+        if cell.value is None:
+            continue
+        cell.fill = fill
+        cell.font = font
+        cell.alignment = alignment
+
+
+def build_blank_roster(path: str | Path, months: Iterable[str]) -> Dict[str, object]:
+    """Create a review-first blank roster shell and return build metadata.
+
+    The new workbook is intentionally generated with openpyxl. Existing workbook
+    modes remain package/XML-only and never pass through an openpyxl save.
+    """
+    from openpyxl import Workbook
+    from openpyxl.styles import Alignment, Font, PatternFill
+    from openpyxl.utils import get_column_letter
+
+    month_specs = _normalize_months(months)
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    wb = Workbook()
+    wb.remove(wb.active)
+
+    header_fill = PatternFill("solid", fgColor="1F4E78")
+    header_font = Font(bold=True, color="FFFFFF")
+    header_alignment = Alignment(horizontal="center", vertical="center", wrap_text=True)
+
+    dashboard = wb.create_sheet("Review Dashboard")
+    dashboard["A1"] = "Roster Log Review Dashboard"
+    dashboard["A1"].font = Font(bold=True, size=16, color="FFFFFF")
+    dashboard["A1"].fill = header_fill
+    dashboard.merge_cells("A1:D1")
+    dashboard.append([])
+    dashboard.append(["Workbook State", "Blank operator shell"])
+    dashboard.append(["Months", ", ".join(spec[0] for spec in month_specs)])
+    dashboard.append(["Review Queue", "No source rows loaded"])
+    dashboard.append([
+        "Instructions",
+        "Enter staff, project, and punches on the Live tabs. Run full or review-only mode against a populated roster to build review evidence.",
+    ])
+    dashboard.column_dimensions["A"].width = 22
+    dashboard.column_dimensions["B"].width = 92
+    dashboard.freeze_panes = "A3"
+
+    queue = wb.create_sheet("Review Queue")
+    queue.append(REVIEW_QUEUE_HEADERS)
+    _style_header(queue, 1, fill=header_fill, font=header_font, alignment=header_alignment)
+    queue.freeze_panes = "A2"
+    queue.auto_filter.ref = f"A1:{get_column_letter(len(REVIEW_QUEUE_HEADERS))}1"
+    for idx, width in enumerate([16, 14, 14, 24, 24, 18, 24, 12, 16, 24, 24, 34, 24, 24, 20, 18, 40], 1):
+        queue.column_dimensions[get_column_letter(idx)].width = width
+
+    rules = wb.create_sheet("Review Rules")
+    rules.append(["Rule Code", "Severity", "Trigger", "Suggested Resolution"])
+    for row in REVIEW_RULES:
+        rules.append(row)
+    _style_header(rules, 1, fill=header_fill, font=header_font, alignment=header_alignment)
+    rules.freeze_panes = "A2"
+    for col, width in zip("ABCD", [28, 14, 52, 52]):
+        rules.column_dimensions[col].width = width
+
+    dictionary = wb.create_sheet("CF Dictionary")
+    dictionary.append(["Color", "Meaning", "Rule Codes"])
+    for row in CF_DICTIONARY:
+        dictionary.append(row)
+    _style_header(dictionary, 1, fill=header_fill, font=header_font, alignment=header_alignment)
+    dictionary.freeze_panes = "A2"
+    for col, width in zip("ABC", [18, 44, 48]):
+        dictionary.column_dimensions[col].width = width
+
+    live_sheets: List[str] = []
+    for _, year, month, label in month_specs:
+        title = f"Live - {label}"
+        ws = wb.create_sheet(title)
+        live_sheets.append(title)
+        ws.append([f"{label} - Attendance"])
+        headers = ["Staff Name", "Project"]
+        for day in range(1, monthrange(year, month)[1] + 1):
+            prefix = f"{month_abbr[month]} {day:02d}"
+            headers.extend([f"{prefix} - Clock In", f"{prefix} - Clock Out"])
+        ws.append(headers)
+        _style_header(ws, 2, fill=header_fill, font=header_font, alignment=header_alignment)
+        ws.freeze_panes = "C3"
+        ws.column_dimensions["A"].width = 24
+        ws.column_dimensions["B"].width = 28
+        for col in range(3, len(headers) + 1):
+            ws.column_dimensions[get_column_letter(col)].width = 17
+        ws.auto_filter.ref = f"A2:{get_column_letter(len(headers))}202"
+
+    wb.save(out)
+    wb.close()
+    return {
+        "months": [spec[0] for spec in month_specs],
+        "live_sheets": live_sheets,
+        "review_rules_rows": len(REVIEW_RULES),
+        "cf_dictionary_rows": len(CF_DICTIONARY),
+    }

--- a/triage/roster_log_review_queue/provenance.py
+++ b/triage/roster_log_review_queue/provenance.py
@@ -34,6 +34,7 @@ def build_provenance(
     review_rules_rows: int = 17,
     cf_dictionary_rows_after: int = 0,
     mode: str = "full",
+    openpyxl_save_used: bool = False,
 ) -> Dict[str, Any]:
     live_cf = {name: st.to_dict() for name, st in live_cf_stats.items() if st.patched}
     live_cf_counts_after = {
@@ -53,7 +54,7 @@ def build_provenance(
         "output_workbook": output_workbook,
         "output_zip": output_zip,
         "repair_safety": {
-            "openpyxl_save_used": False,
+            "openpyxl_save_used": openpyxl_save_used,
             "structured_tables_added": False,
         },
         "verification": verification,

--- a/triage/roster_log_review_queue/run.py
+++ b/triage/roster_log_review_queue/run.py
@@ -6,6 +6,8 @@ import zipfile
 from pathlib import Path
 from typing import Optional
 
+from triage.one_marcus_recon.path_guard import assert_output_path_allowed
+
 from .blank_builder import build_blank_roster
 from .live_cf_patcher import patch_live_cf
 from .models import GraftResult
@@ -48,9 +50,12 @@ def run(
     """Run graft pipeline for *mode* (blank|full|graft|review-only|live-cf-only)."""
     mode = mode.replace("graft", "full") if mode == "graft" else mode
     out = Path(output_path)
-    out.parent.mkdir(parents=True, exist_ok=True)
 
     if mode == "blank":
+        # Blank mode has no source workbook, but it still must obey the repo's
+        # Candidates/ and Active/ source-immutability contract before any mkdir/save.
+        assert_output_path_allowed(__file__, str(out))
+        out.parent.mkdir(parents=True, exist_ok=True)
         shell = build_blank_roster(out, months or [])
         data = out.read_bytes()
         data, live_stats = patch_live_cf(data, scan_path=str(out))
@@ -75,7 +80,10 @@ def run(
         provenance = build_provenance(
             input_workbook="<generated blank roster shell>",
             output_workbook=out.name,
-            method="new workbook generation: openpyxl shell + package/XML conditional-formatting append",
+            method=(
+                "new workbook generation: openpyxl shell + package/XML "
+                "conditional-formatting append"
+            ),
             live_cf_stats=live_stats,
             verification=verification,
             output_zip=Path(zip_out).name if zip_out else None,
@@ -103,7 +111,6 @@ def run(
         raise ValueError("--input is required for this mode")
 
     input_name = Path(input_path).name
-    out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
 
     pkg = Package.from_path(input_path)
@@ -112,7 +119,9 @@ def run(
     if mode in ("full", "review-only"):
         pkg = graft_review_layer(pkg, input_path)
 
-    queue_rows = build_review_queue(input_path) if mode in ("full", "review-only") else []
+    queue_rows = (
+        build_review_queue(input_path) if mode in ("full", "review-only") else []
+    )
 
     data = pkg.to_bytes()
     if mode in ("full", "live-cf-only"):
@@ -140,9 +149,14 @@ def run(
         )
 
     method = {
-        "full": "zip/xml surgical patch: review graft + append standard CF to every Live month tab",
+        "full": (
+            "zip/xml surgical patch: review graft + append standard CF "
+            "to every Live month tab"
+        ),
         "review-only": "zip/xml surgical patch: review layer graft only",
-        "live-cf-only": "zip/xml surgical patch: append standard CF to every Live month tab",
+        "live-cf-only": (
+            "zip/xml surgical patch: append standard CF to every Live month tab"
+        ),
     }.get(mode, mode)
 
     provenance = build_provenance(
@@ -155,12 +169,12 @@ def run(
         review_queue_rows=len(queue_rows),
         mode=mode,
     )
-
-    prov_path = provenance_out or str(out.with_suffix(".provenance.json"))
-    Path(prov_path).write_text(json.dumps(provenance, indent=2), encoding="utf-8")
-
-    if zip_out:
-        _write_zip(out, provenance, Path(zip_out))
+    _write_provenance_and_zip(
+        out=out,
+        provenance=provenance,
+        provenance_out=provenance_out,
+        zip_out=zip_out,
+    )
 
     return GraftResult(
         output_path=str(out),

--- a/triage/roster_log_review_queue/run.py
+++ b/triage/roster_log_review_queue/run.py
@@ -6,6 +6,7 @@ import zipfile
 from pathlib import Path
 from typing import Optional
 
+from .blank_builder import build_blank_roster
 from .live_cf_patcher import patch_live_cf
 from .models import GraftResult
 from .package_io import Package, remove_calc_chain, remove_external_links
@@ -22,6 +23,19 @@ def _write_zip(xlsx_path: Path, provenance: dict, zip_path: Path) -> None:
         z.writestr(prov_name, json.dumps(provenance, indent=2))
 
 
+def _write_provenance_and_zip(
+    *,
+    out: Path,
+    provenance: dict,
+    provenance_out: Optional[str],
+    zip_out: Optional[str],
+) -> None:
+    prov_path = provenance_out or str(out.with_suffix(".provenance.json"))
+    Path(prov_path).write_text(json.dumps(provenance, indent=2), encoding="utf-8")
+    if zip_out:
+        _write_zip(out, provenance, Path(zip_out))
+
+
 def run(
     *,
     mode: str,
@@ -32,12 +46,57 @@ def run(
     months: Optional[list] = None,
 ) -> GraftResult:
     """Run graft pipeline for *mode* (blank|full|graft|review-only|live-cf-only)."""
-    _ = months
     mode = mode.replace("graft", "full") if mode == "graft" else mode
+    out = Path(output_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
 
     if mode == "blank":
-        raise NotImplementedError(
-            "blank mode requires Stage A workbook shell builder (follow-up)"
+        shell = build_blank_roster(out, months or [])
+        data = out.read_bytes()
+        data, live_stats = patch_live_cf(data, scan_path=str(out))
+        pkg = Package.from_bytes(data)
+        remove_calc_chain(pkg)
+        remove_external_links(pkg)
+        pkg.write(str(out))
+
+        data = out.read_bytes()
+        try:
+            verification = run_preflight(data, require_review_layer=True)
+        except ValueError as exc:
+            return GraftResult(
+                output_path=str(out),
+                provenance={},
+                live_cf_stats=live_stats,
+                review_queue_rows=0,
+                preflight_pass=False,
+                errors=[str(exc)],
+            )
+
+        provenance = build_provenance(
+            input_workbook="<generated blank roster shell>",
+            output_workbook=out.name,
+            method="new workbook generation: openpyxl shell + package/XML conditional-formatting append",
+            live_cf_stats=live_stats,
+            verification=verification,
+            output_zip=Path(zip_out).name if zip_out else None,
+            review_queue_rows=0,
+            review_rules_rows=int(shell["review_rules_rows"]),
+            cf_dictionary_rows_after=int(shell["cf_dictionary_rows"]),
+            mode=mode,
+            openpyxl_save_used=True,
+        )
+        _write_provenance_and_zip(
+            out=out,
+            provenance=provenance,
+            provenance_out=provenance_out,
+            zip_out=zip_out,
+        )
+        return GraftResult(
+            output_path=str(out),
+            provenance=provenance,
+            live_cf_stats=live_stats,
+            review_queue_rows=0,
+            preflight_pass=True,
         )
 
     if not input_path:


### PR DESCRIPTION
## Sprint

sprint/pr56-clean-replacement-and-floor-ledger — clean replacement for PR #56.

## Supersedes

PR #56 (eat/roster-review-blank-shell) accumulated 25 changed files across harness, validator, docs, CI, and One Marcus fixture lanes that did not belong to the blank-shell scope. This PR reconstructs only the blank-shell functionality on a clean branch from origin/main.

## Owned scope

- Implement python -m triage.roster_log_review_queue --mode blank pipeline.
- Generate a review-first workbook shell for requested months.
- Reuse the existing global Live-tab conditional-formatting pack and preflight.
- Preserve package/XML-only behavior for existing graft modes.
- Record honest provenance for openpyxl use during new-workbook generation.
- Add fixture-only regression coverage.

## Forbidden scope

- No Bonita or Neuron business-rule changes.
- No Prompt Kit changes.
- No harness expansion.
- No .ai schema work.
- No task-distribution changes.
- No relationship-validator rewrite.
- No One Marcus fixture duplication.
- No private workbook commits.
- No generated workbook commits.
- No Excel for Web acceptance claim.

## Changed files

- 	riage/roster_log_review_queue/blank_builder.py (new)
- 	riage/roster_log_review_queue/run.py
- 	riage/roster_log_review_queue/provenance.py
- 	ests/test_roster_log_review_queue.py

4 files, +277 / -4.

## Behavior

\\\powershell
python -m triage.roster_log_review_queue 
  --mode blank 
  --months 2026-04 2026-05 
  --output Outputs/roster_review_blank.xlsx
\\\

The generated workbook contains, in order:

1. \Review Dashboard\
2. \Review Queue\
3. \Review Rules\
4. \CF Dictionary\
5. one \Live - {Month YYYY}\ sheet per requested month

Each Live sheet contains the full month of Clock In / Clock Out columns and receives the existing operator conditional-formatting pack. Preflight requires the review dashboard to remain first, all Live tabs to be patched, inserted review sheets to remain free of fragile package objects, and external links to be absent.

## Validation

### Branch-focused checks

\\\	ext
python -m py_compile \\
  triage/roster_log_review_queue/blank_builder.py \\
  triage/roster_log_review_queue/provenance.py \\
  triage/roster_log_review_queue/run.py \\
  tests/test_roster_log_review_queue.py

PY_COMPILE_OK
\\\

\\\	ext
tests/test_roster_log_review_queue.py
7 passed in 2.53s
\\\

### Protected-suite output (pre-existing failures only)

\\\	ext
12 failed, 408 passed, 63 skipped in 18.19s
\\\

All 12 failures are pre-existing and outside this PR's files:
- 8 in \	ests/test_one_marcus_recon.py\ (PR #55 One Marcus namespace defect)
- 3 in \	ests/test_one_marcus_immutability.py\ (PR #55 fixture dependency)
- 1 in \	ests/test_web_excel_compatibility_rules.py\ (PR #53/#57 validator scope)

### Additional checks

\\\	ext
gitignore hygiene: OK
git diff --check: clean
git status --short: clean tree
\\\

## Proof ceiling

This PR proves fixture-level workbook generation, package preflight, conditional-formatting injection, provenance behavior, and non-regression of existing roster-review paths. Excel for Web and operator acceptance remain separate manual gates.

## File-ownership ledger

| File | Owner | Status |
|------|-------|--------|
| \	riage/roster_log_review_queue/blank_builder.py\ | This PR | New |
| \	riage/roster_log_review_queue/run.py\ | This PR | Modified |
| \	riage/roster_log_review_queue/provenance.py\ | This PR | Modified |
| \	ests/test_roster_log_review_queue.py\ | This PR | Modified |

### Files explicitly NOT included (owned by other PRs)

| File | Owner |
|------|-------|
| \	ests/fixtures/one_marcus_recon/fixtures.py\ | PR #55 |
| \	riage/web_excel_compatibility_rules.py\ | PR #53/#57 |
| \	ests/test_web_excel_compatibility_rules.py\ | PR #53/#57 |
| \	riage/output_policy.py\ | PR #46 |
| \	riage/neuron_task_hour_distribution_rules.py\ | PR #55 |
| \.ai/**\, \	riage/harness/**\, \scripts/harness.ps1\ | Planned harness lane |
| \docs/ROSTER_WORKBOOK_GENERATION_DOCTRINE.md\ | Planned docs extraction |