### PR TITLE
feat(harness): automate Excel recovery-log and OOXML triage

### DIFF
--- a/.github/workflows/excel-recovery-triage.yml
+++ b/.github/workflows/excel-recovery-triage.yml
@@ -1,0 +1,46 @@
+name: Excel recovery triage tests
+
+on:
+  pull_request:
+    paths:
+      - "triage/excel_recovery_triage.py"
+      - "tests/test_excel_recovery_triage.py"
+      - "scripts/Invoke-ExcelDesktopRepairProbe.ps1"
+      - "docs/EXCEL_DESKTOP_RECOVERY_TRIAGE.md"
+      - ".github/workflows/excel-recovery-triage.yml"
+  push:
+    branches: [main]
+    paths:
+      - "triage/excel_recovery_triage.py"
+      - "tests/test_excel_recovery_triage.py"
+      - "scripts/Invoke-ExcelDesktopRepairProbe.ps1"
+      - ".github/workflows/excel-recovery-triage.yml"
+
+jobs:
+  recovery-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependency
+        run: python -m pip install pytest
+
+      - name: Compile and import
+        run: |
+          python -m py_compile triage/excel_recovery_triage.py tests/test_excel_recovery_triage.py
+          python -c "import triage.excel_recovery_triage; print('excel recovery triage import ok')"
+
+      - name: Run focused tests
+        run: python -m pytest tests/test_excel_recovery_triage.py -q
+
+      - name: Parse PowerShell probe
+        shell: pwsh
+        run: |
+          [scriptblock]::Create((Get-Content -Raw scripts/Invoke-ExcelDesktopRepairProbe.ps1)) | Out-Null
+          Write-Host "PowerShell syntax ok"

--- a/docs/EXCEL_DESKTOP_RECOVERY_TRIAGE.md
+++ b/docs/EXCEL_DESKTOP_RECOVERY_TRIAGE.md
@@ -1,0 +1,51 @@
+# Excel Desktop Recovery Triage Harness
+
+This harness removes the manual step of reading an Excel repair prompt, locating
+its `recoveryLog` XML, and then opening the referenced OOXML parts by hand.
+
+## Static or supplied-log triage
+
+```powershell
+python -m triage.excel_recovery_triage `
+  "Outputs/roster_blank_runtime/roster_review_blank.xlsx" `
+  --recovery-log "C:\path\to\error588520_01.xml" `
+  --json-out "Outputs/roster_blank_runtime/excel_recovery_triage.json" `
+  --markdown-out "Outputs/roster_blank_runtime/excel_recovery_triage.md"
+```
+
+The command:
+
+- parses removed parts, removed records, and repaired records;
+- extracts and normalizes referenced OOXML part paths;
+- parses every `.xml` and `.rels` package part;
+- records part size and SHA-256;
+- verifies `xl/styles.xml` and conditional-formatting `dxfId` references;
+- correlates recovery actions with package failures;
+- returns `STOP_SHIP` when Excel repair actions or XML failures are present.
+
+It does not mutate or repair the workbook.
+
+## Automated Windows desktop probe
+
+```powershell
+.\scripts\Invoke-ExcelDesktopRepairProbe.ps1 `
+  -Workbook "Outputs\roster_blank_runtime\roster_review_blank.xlsx" `
+  -OutDir "Outputs\roster_blank_runtime\desktop_probe"
+```
+
+The PowerShell probe:
+
+1. snapshots existing Excel `error*.xml` logs;
+2. opens the workbook read-only through Excel COM with alerts suppressed;
+3. closes without saving;
+4. copies newly generated recovery logs into the run directory;
+5. runs the Python triage command;
+6. emits `desktop_probe.json`, `excel_recovery_triage.json`, and
+   `excel_recovery_triage.md`.
+
+## Proof ceiling
+
+A captured recovery log proves that desktop Excel repaired or removed content
+from that exact workbook. Static OOXML inspection can identify package failures
+and strong root-cause candidates. Neither result proves that a replacement
+workbook is accepted in Excel for Web or approved for delivery.

--- a/scripts/ExcelWindowContext.ps1
+++ b/scripts/ExcelWindowContext.ps1
@@ -1,0 +1,337 @@
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$script:ExcelWindowSelectionThreshold = 50
+
+function Test-ExcelWindowsHost {
+    return ($env:OS -eq 'Windows_NT')
+}
+
+function Initialize-ExcelWindowNative {
+    if (-not (Test-ExcelWindowsHost)) { return }
+    if ('ExcelWindowNative' -as [type]) { return }
+
+    Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class ExcelWindowNative
+{
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+    public class WindowInfo
+    {
+        public long Hwnd;
+        public int ProcessId;
+        public string Title;
+        public string ClassName;
+        public bool Visible;
+        public bool Enabled;
+        public RECT Rect;
+    }
+
+    [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+    [DllImport("user32.dll")] private static extern int GetWindowTextLength(IntPtr hWnd);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int maxCount);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassName(IntPtr hWnd, StringBuilder text, int maxCount);
+    [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+    [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern bool IsWindowEnabled(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+    [DllImport("user32.dll")] public static extern bool IsWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] public static extern bool PostMessage(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+    private static string ReadText(IntPtr hWnd)
+    {
+        int length = GetWindowTextLength(hWnd);
+        var sb = new StringBuilder(Math.Max(512, length + 2));
+        GetWindowText(hWnd, sb, sb.Capacity);
+        return sb.ToString();
+    }
+
+    private static string ReadClass(IntPtr hWnd)
+    {
+        var sb = new StringBuilder(512);
+        GetClassName(hWnd, sb, sb.Capacity);
+        return sb.ToString();
+    }
+
+    public static List<WindowInfo> Enumerate()
+    {
+        var result = new List<WindowInfo>();
+        EnumWindows((hWnd, lParam) =>
+        {
+            uint pid;
+            GetWindowThreadProcessId(hWnd, out pid);
+            RECT rect;
+            GetWindowRect(hWnd, out rect);
+            result.Add(new WindowInfo {
+                Hwnd = hWnd.ToInt64(),
+                ProcessId = (int)pid,
+                Title = ReadText(hWnd),
+                ClassName = ReadClass(hWnd),
+                Visible = IsWindowVisible(hWnd),
+                Enabled = IsWindowEnabled(hWnd),
+                Rect = rect
+            });
+            return true;
+        }, IntPtr.Zero);
+        return result;
+    }
+}
+'@ -ErrorAction Stop
+}
+
+function Get-ExcelWindowRecords {
+    param([int]$ProcessId = 0)
+
+    if (-not (Test-ExcelWindowsHost)) { return @() }
+    Initialize-ExcelWindowNative
+
+    $records = New-Object System.Collections.Generic.List[object]
+    foreach ($window in @([ExcelWindowNative]::Enumerate())) {
+        if ($ProcessId -gt 0 -and [int]$window.ProcessId -ne $ProcessId) { continue }
+        try {
+            $process = Get-Process -Id ([int]$window.ProcessId) -ErrorAction Stop
+        }
+        catch { continue }
+        if ([string]$process.ProcessName -notmatch '^EXCEL$') { continue }
+        if (-not [bool]$window.Visible -and [string]::IsNullOrWhiteSpace([string]$window.Title)) { continue }
+
+        $records.Add([pscustomobject][ordered]@{
+            pid = [int]$window.ProcessId
+            hwnd = [Int64]$window.Hwnd
+            title = [string]$window.Title
+            className = [string]$window.ClassName
+            visible = [bool]$window.Visible
+            enabled = [bool]$window.Enabled
+            rect = [pscustomobject][ordered]@{
+                left = [int]$window.Rect.Left
+                top = [int]$window.Rect.Top
+                right = [int]$window.Rect.Right
+                bottom = [int]$window.Rect.Bottom
+                width = [int]$window.Rect.Right - [int]$window.Rect.Left
+                height = [int]$window.Rect.Bottom - [int]$window.Rect.Top
+            }
+        }) | Out-Null
+    }
+    return @($records.ToArray())
+}
+
+function Get-ExcelProcessSnapshot {
+    param([string]$Label = '')
+
+    $windowRecords = @(Get-ExcelWindowRecords)
+    $records = New-Object System.Collections.Generic.List[object]
+    foreach ($process in @(Get-Process -Name EXCEL -ErrorAction SilentlyContinue)) {
+        try { $process.Refresh() } catch { }
+        $startTimeUtc = $null
+        $path = $null
+        try { $startTimeUtc = $process.StartTime.ToUniversalTime().ToString('o') } catch { }
+        try { $path = [string]$process.Path } catch { }
+        $pidWindows = @($windowRecords | Where-Object { [int]$_.pid -eq [int]$process.Id })
+        $records.Add([pscustomobject][ordered]@{
+            pid = [int]$process.Id
+            processName = [string]$process.ProcessName
+            executablePath = $path
+            startTimeUtc = $startTimeUtc
+            mainWindowHandle = [Int64]$process.MainWindowHandle
+            mainWindowTitle = [string]$process.MainWindowTitle
+            windows = $pidWindows
+        }) | Out-Null
+    }
+
+    return [pscustomobject][ordered]@{
+        schema = 'ExcelProcessSnapshot.v1'
+        label = $Label
+        capturedAtUtc = [DateTime]::UtcNow.ToString('o')
+        processes = @($records.ToArray())
+    }
+}
+
+function Get-ExcelProcessFingerprint {
+    param([Parameter(Mandatory = $true)]$ProcessRecord)
+    $windows = @($ProcessRecord.windows | ForEach-Object {
+        '{0}|{1}|{2}|{3}' -f [Int64]$_.hwnd, [string]$_.title, [string]$_.className, [bool]$_.visible
+    } | Sort-Object)
+    return ('{0}|{1}|{2}' -f [Int64]$ProcessRecord.mainWindowHandle, [string]$ProcessRecord.mainWindowTitle, ($windows -join ';'))
+}
+
+function Compare-ExcelProcessSnapshots {
+    param(
+        [Parameter(Mandatory = $true)]$Before,
+        [Parameter(Mandatory = $true)]$After
+    )
+
+    $beforeByPid = @{}
+    foreach ($record in @($Before.processes)) { $beforeByPid[[int]$record.pid] = $record }
+    $new = New-Object System.Collections.Generic.List[object]
+    $changed = New-Object System.Collections.Generic.List[object]
+
+    foreach ($record in @($After.processes)) {
+        $pid = [int]$record.pid
+        if (-not $beforeByPid.ContainsKey($pid)) {
+            $new.Add($record) | Out-Null
+            continue
+        }
+        $beforeRecord = $beforeByPid[$pid]
+        if ((Get-ExcelProcessFingerprint -ProcessRecord $beforeRecord) -ne (Get-ExcelProcessFingerprint -ProcessRecord $record)) {
+            $changed.Add([pscustomobject][ordered]@{ pid = $pid; before = $beforeRecord; after = $record }) | Out-Null
+        }
+    }
+
+    return [pscustomobject][ordered]@{
+        schema = 'ExcelProcessDelta.v1'
+        beforeLabel = [string]$Before.label
+        afterLabel = [string]$After.label
+        newProcesses = @($new.ToArray())
+        changedProcesses = @($changed.ToArray())
+    }
+}
+
+function Get-ExcelWindowCandidateScore {
+    param(
+        [Parameter(Mandatory = $true)]$ProcessRecord,
+        [Parameter(Mandatory = $true)]$Delta,
+        [string]$WorkbookStem = '',
+        [int]$PreferredProcessId = 0,
+        [Nullable[datetime]]$LaunchRequestedUtc = $null
+    )
+
+    $signals = New-Object System.Collections.Generic.List[string]
+    $missing = New-Object System.Collections.Generic.List[string]
+    $score = 0
+    $pid = [int]$ProcessRecord.pid
+    $isNew = @($Delta.newProcesses | Where-Object { [int]$_.pid -eq $pid }).Count -gt 0
+    $isChanged = @($Delta.changedProcesses | Where-Object { [int]$_.pid -eq $pid }).Count -gt 0
+
+    if ($PreferredProcessId -gt 0 -and $pid -eq $PreferredProcessId) { $score += 45; $signals.Add('preferred_start_process') | Out-Null }
+    if ($isNew) { $score += 30; $signals.Add('new_pid_after_baseline') | Out-Null }
+    elseif ($isChanged) { $score += 20; $signals.Add('existing_pid_window_changed') | Out-Null }
+    else { $missing.Add('not_new_or_changed') | Out-Null }
+
+    $visibleWindows = @($ProcessRecord.windows | Where-Object { [bool]$_.visible -and [Int64]$_.hwnd -ne 0 })
+    if ($visibleWindows.Count -gt 0) { $score += 15; $signals.Add('visible_excel_window') | Out-Null }
+    else { $missing.Add('no_visible_excel_window') | Out-Null }
+
+    $allTitles = @($ProcessRecord.mainWindowTitle) + @($ProcessRecord.windows | ForEach-Object { [string]$_.title })
+    if (-not [string]::IsNullOrWhiteSpace($WorkbookStem) -and @($allTitles | Where-Object { [string]$_ -like "*$WorkbookStem*" }).Count -gt 0) {
+        $score += 20; $signals.Add('workbook_title_match') | Out-Null
+    }
+    if (@($allTitles | Where-Object { [string]$_ -match '(?i)repaired|repair|recover|problem with some content' }).Count -gt 0) {
+        $score += 15; $signals.Add('repair_surface_observed') | Out-Null
+    }
+
+    if ($LaunchRequestedUtc -and $ProcessRecord.startTimeUtc) {
+        try {
+            $started = [datetime]::Parse([string]$ProcessRecord.startTimeUtc, $null, [Globalization.DateTimeStyles]::RoundtripKind)
+            if ($started.ToUniversalTime() -ge $LaunchRequestedUtc.Value.ToUniversalTime().AddSeconds(-5)) {
+                $score += 10; $signals.Add('started_after_launch_request') | Out-Null
+            }
+        } catch { }
+    }
+
+    if ([string]$ProcessRecord.executablePath -match '(?i)\\EXCEL\.EXE$') { $score += 5; $signals.Add('excel_executable_path') | Out-Null }
+
+    $rankedWindows = @($ProcessRecord.windows | ForEach-Object {
+        $windowScore = 0
+        if ([bool]$_.visible) { $windowScore += 20 }
+        if ([Int64]$_.hwnd -ne 0) { $windowScore += 10 }
+        if (-not [string]::IsNullOrWhiteSpace($WorkbookStem) -and [string]$_.title -like "*$WorkbookStem*") { $windowScore += 30 }
+        if ([string]$_.title -match '(?i)repaired|repair|recover|problem with some content') { $windowScore += 25 }
+        [pscustomobject][ordered]@{
+            pid = $pid
+            hwnd = [Int64]$_.hwnd
+            title = [string]$_.title
+            className = [string]$_.className
+            visible = [bool]$_.visible
+            enabled = [bool]$_.enabled
+            score = $windowScore
+        }
+    } | Sort-Object score -Descending, hwnd)
+
+    return [pscustomobject][ordered]@{
+        pid = $pid
+        processName = [string]$ProcessRecord.processName
+        executablePath = [string]$ProcessRecord.executablePath
+        startTimeUtc = [string]$ProcessRecord.startTimeUtc
+        score = [Math]::Min(100, $score)
+        isNewAfterBaseline = $isNew
+        isChangedAfterBaseline = $isChanged
+        evidenceSignals = @($signals.ToArray())
+        missingSignals = @($missing.ToArray())
+        selectedWindow = if ($rankedWindows.Count -gt 0) { $rankedWindows[0] } else { $null }
+    }
+}
+
+function Resolve-ExcelWindowSelection {
+    param(
+        [Parameter(Mandatory = $true)]$Before,
+        [Parameter(Mandatory = $true)]$After,
+        [string]$WorkbookStem = '',
+        [int]$PreferredProcessId = 0,
+        [Nullable[datetime]]$LaunchRequestedUtc = $null
+    )
+
+    $delta = Compare-ExcelProcessSnapshots -Before $Before -After $After
+    $candidateRecords = New-Object System.Collections.Generic.List[object]
+    $seen = @{}
+    foreach ($record in @($delta.newProcesses) + @($delta.changedProcesses | ForEach-Object { $_.after })) {
+        $pid = [int]$record.pid
+        if (-not $seen.ContainsKey($pid)) { $seen[$pid] = $true; $candidateRecords.Add($record) | Out-Null }
+    }
+    if ($PreferredProcessId -gt 0) {
+        foreach ($record in @($After.processes | Where-Object { [int]$_.pid -eq $PreferredProcessId })) {
+            if (-not $seen.ContainsKey([int]$record.pid)) { $seen[[int]$record.pid] = $true; $candidateRecords.Add($record) | Out-Null }
+        }
+    }
+
+    $candidates = @($candidateRecords.ToArray() | ForEach-Object {
+        Get-ExcelWindowCandidateScore -ProcessRecord $_ -Delta $delta -WorkbookStem $WorkbookStem `
+            -PreferredProcessId $PreferredProcessId -LaunchRequestedUtc $LaunchRequestedUtc
+    } | Sort-Object score -Descending, pid)
+
+    $eligible = @($candidates | Where-Object {
+        [int]$_.score -ge $script:ExcelWindowSelectionThreshold -and $null -ne $_.selectedWindow -and [Int64]$_.selectedWindow.hwnd -ne 0
+    })
+    if ($eligible.Count -eq 0) {
+        return [pscustomobject][ordered]@{ allowed = $false; reason = 'no_candidate_above_threshold'; winner = $null; tied = @(); candidates = $candidates; delta = $delta }
+    }
+    $maxScore = ($eligible | Measure-Object -Property score -Maximum).Maximum
+    $winners = @($eligible | Where-Object { [int]$_.score -eq [int]$maxScore })
+    if ($winners.Count -ne 1) {
+        return [pscustomobject][ordered]@{ allowed = $false; reason = 'multiple_tied_candidates'; winner = $null; tied = $winners; candidates = $candidates; delta = $delta }
+    }
+    return [pscustomobject][ordered]@{ allowed = $true; reason = 'confidence_ok'; winner = $winners[0]; tied = @(); candidates = $candidates; delta = $delta }
+}
+
+function Close-ExcelProbeProcess {
+    param(
+        [Parameter(Mandatory = $true)][int]$ProcessId,
+        [switch]$AllowTerminate
+    )
+
+    if (-not (Test-ExcelWindowsHost)) { return [pscustomobject]@{ closed = $false; reason = 'windows_host_required' } }
+    Initialize-ExcelWindowNative
+    foreach ($window in @(Get-ExcelWindowRecords -ProcessId $ProcessId)) {
+        if ([Int64]$window.hwnd -ne 0 -and [ExcelWindowNative]::IsWindow([IntPtr]([Int64]$window.hwnd))) {
+            [void][ExcelWindowNative]::PostMessage([IntPtr]([Int64]$window.hwnd), 0x0010, [IntPtr]::Zero, [IntPtr]::Zero)
+        }
+    }
+    Start-Sleep -Milliseconds 500
+    $remaining = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    if ($remaining -and $AllowTerminate) {
+        Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+        Start-Sleep -Milliseconds 200
+        $remaining = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    }
+    return [pscustomobject][ordered]@{
+        closed = ($null -eq $remaining)
+        reason = if ($null -eq $remaining) { 'exact_probe_process_closed' } elseif ($AllowTerminate) { 'probe_process_survived_terminate' } else { 'termination_not_authorized' }
+    }
+}

--- a/scripts/Invoke-ExcelDesktopRepairProbe.ps1
+++ b/scripts/Invoke-ExcelDesktopRepairProbe.ps1
@@ -1,0 +1,112 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Workbook,
+
+    [string]$OutDir = "Outputs/excel_desktop_repair_probe",
+
+    [string]$Python = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($env:OS -ne "Windows_NT") {
+    throw "Excel desktop COM probing requires Windows. Use python -m triage.excel_recovery_triage for static/log-only triage."
+}
+
+$resolvedWorkbook = (Resolve-Path -LiteralPath $Workbook).Path
+$outPath = [System.IO.Path]::GetFullPath($OutDir)
+New-Item -ItemType Directory -Force -Path $outPath | Out-Null
+
+$scanRoots = @($env:TEMP, (Split-Path -Parent $resolvedWorkbook)) | Where-Object { $_ -and (Test-Path $_) }
+$before = @{}
+foreach ($root in $scanRoots) {
+    Get-ChildItem -LiteralPath $root -Filter "error*.xml" -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $before[$_.FullName] = $_.LastWriteTimeUtc
+    }
+}
+
+$startedUtc = [DateTime]::UtcNow
+$excel = $null
+$openedWorkbook = $null
+$openSucceeded = $false
+$openError = ""
+
+try {
+    $excel = New-Object -ComObject Excel.Application
+    $excel.Visible = $false
+    $excel.DisplayAlerts = $false
+    $excel.AskToUpdateLinks = $false
+    try { $excel.AutomationSecurity = 3 } catch { }
+
+    # UpdateLinks=0, ReadOnly=$true. No save is performed.
+    $openedWorkbook = $excel.Workbooks.Open($resolvedWorkbook, 0, $true)
+    $openSucceeded = $true
+}
+catch {
+    $openError = $_.Exception.Message
+}
+finally {
+    if ($null -ne $openedWorkbook) {
+        try { $openedWorkbook.Close($false) } catch { }
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($openedWorkbook)
+    }
+    if ($null -ne $excel) {
+        try { $excel.Quit() } catch { }
+        [void][System.Runtime.InteropServices.Marshal]::FinalReleaseComObject($excel)
+    }
+    [GC]::Collect()
+    [GC]::WaitForPendingFinalizers()
+}
+
+Start-Sleep -Milliseconds 750
+$newLogs = @()
+foreach ($root in $scanRoots) {
+    Get-ChildItem -LiteralPath $root -Filter "error*.xml" -File -ErrorAction SilentlyContinue | ForEach-Object {
+        $isNew = -not $before.ContainsKey($_.FullName) -or $_.LastWriteTimeUtc -gt $startedUtc
+        if ($isNew) {
+            $destination = Join-Path $outPath $_.Name
+            Copy-Item -LiteralPath $_.FullName -Destination $destination -Force
+            $newLogs += $destination
+        }
+    }
+}
+$newLogs = @($newLogs | Sort-Object -Unique)
+
+if (-not $Python) {
+    $venvPython = Join-Path (Get-Location) ".venv\Scripts\python.exe"
+    $Python = if (Test-Path $venvPython) { $venvPython } else { "python" }
+}
+
+$jsonOut = Join-Path $outPath "excel_recovery_triage.json"
+$markdownOut = Join-Path $outPath "excel_recovery_triage.md"
+$arguments = @(
+    "-m", "triage.excel_recovery_triage",
+    $resolvedWorkbook,
+    "--json-out", $jsonOut,
+    "--markdown-out", $markdownOut
+)
+foreach ($log in $newLogs) {
+    $arguments += @("--recovery-log", $log)
+}
+
+& $Python @arguments
+$triageExitCode = $LASTEXITCODE
+
+$probe = [ordered]@{
+    generated_at_utc = [DateTime]::UtcNow.ToString("o")
+    workbook = $resolvedWorkbook
+    workbook_open_succeeded = $openSucceeded
+    workbook_open_error = $openError
+    recovery_logs = $newLogs
+    triage_json = $jsonOut
+    triage_markdown = $markdownOut
+    triage_exit_code = $triageExitCode
+    proof_ceiling = "Automated Excel desktop open attempt plus captured recovery logs and read-only OOXML triage. No operator acceptance is implied."
+}
+$probe | ConvertTo-Json -Depth 6 | Set-Content -LiteralPath (Join-Path $outPath "desktop_probe.json") -Encoding UTF8
+
+if (-not $openSucceeded -or $triageExitCode -ne 0) {
+    exit 1
+}
+exit 0

--- a/scripts/Test-ExcelWindowContext.ps1
+++ b/scripts/Test-ExcelWindowContext.ps1
@@ -1,0 +1,120 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+. (Join-Path $PSScriptRoot 'ExcelWindowContext.ps1')
+
+function Assert-True {
+    param([bool]$Condition, [Parameter(Mandatory = $true)][string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+function Assert-Equal {
+    param($Actual, $Expected, [Parameter(Mandatory = $true)][string]$Message)
+    if ([string]$Actual -ne [string]$Expected) {
+        throw "$Message Expected '$Expected' but received '$Actual'."
+    }
+}
+
+function New-TestWindow {
+    param(
+        [int]$Pid,
+        [Int64]$Hwnd,
+        [string]$Title,
+        [bool]$Visible = $true
+    )
+    return [pscustomobject][ordered]@{
+        pid = $Pid
+        hwnd = $Hwnd
+        title = $Title
+        className = 'XLMAIN'
+        visible = $Visible
+        enabled = $true
+        rect = [pscustomobject]@{ left = 0; top = 0; right = 1000; bottom = 700; width = 1000; height = 700 }
+    }
+}
+
+function New-TestProcess {
+    param(
+        [int]$Pid,
+        [object[]]$Windows = @(),
+        [string]$Started = '2026-07-14T20:00:00Z'
+    )
+    $main = if ($Windows.Count -gt 0) { $Windows[0] } else { $null }
+    return [pscustomobject][ordered]@{
+        pid = $Pid
+        processName = 'EXCEL'
+        executablePath = 'C:\Program Files\Microsoft Office\root\Office16\EXCEL.EXE'
+        startTimeUtc = $Started
+        mainWindowHandle = if ($main) { [Int64]$main.hwnd } else { 0 }
+        mainWindowTitle = if ($main) { [string]$main.title } else { '' }
+        windows = @($Windows)
+    }
+}
+
+function New-TestSnapshot {
+    param([string]$Label, [object[]]$Processes = @())
+    return [pscustomobject][ordered]@{
+        schema = 'ExcelProcessSnapshot.v1'
+        label = $Label
+        capturedAtUtc = '2026-07-14T20:00:00Z'
+        processes = @($Processes)
+    }
+}
+
+$launchUtc = [datetime]'2026-07-14T20:00:00Z'
+
+# T1: exact Start-Process PID with the workbook title wins.
+$before = New-TestSnapshot -Label 'S1'
+$window = New-TestWindow -Pid 200 -Hwnd 20001 -Title 'roster_review_blank.xlsx - Excel'
+$after = New-TestSnapshot -Label 'S2' -Processes @((New-TestProcess -Pid 200 -Windows @($window)))
+$result = Resolve-ExcelWindowSelection -Before $before -After $after -WorkbookStem 'roster_review_blank' -PreferredProcessId 200 -LaunchRequestedUtc $launchUtc
+Assert-True ([bool]$result.allowed) 'T1 expected the exact started Excel process to be selected.'
+Assert-Equal $result.winner.pid 200 'T1 selected the wrong PID.'
+Assert-Equal $result.winner.selectedWindow.hwnd 20001 'T1 selected the wrong HWND.'
+
+# T2: Excel process reuse is discoverable from an S1/S2 window delta.
+$beforeProcess = New-TestProcess -Pid 300 -Windows @()
+$before = New-TestSnapshot -Label 'S1' -Processes @($beforeProcess)
+$reusedWindow = New-TestWindow -Pid 300 -Hwnd 30001 -Title 'roster_review_blank.xlsx - Excel'
+$afterProcess = New-TestProcess -Pid 300 -Windows @($reusedWindow) -Started '2026-07-14T19:30:00Z'
+$after = New-TestSnapshot -Label 'S2' -Processes @($afterProcess)
+$result = Resolve-ExcelWindowSelection -Before $before -After $after -WorkbookStem 'roster_review_blank' -LaunchRequestedUtc $launchUtc
+Assert-True ([bool]$result.allowed) 'T2 expected a changed existing Excel process to be selected.'
+Assert-True ([bool]$result.winner.isChangedAfterBaseline) 'T2 did not retain process-reuse evidence.'
+
+# T3: equal candidates fail closed instead of choosing the foreground window.
+$w1 = New-TestWindow -Pid 401 -Hwnd 40101 -Title 'roster_review_blank.xlsx - Excel'
+$w2 = New-TestWindow -Pid 402 -Hwnd 40201 -Title 'roster_review_blank.xlsx - Excel'
+$after = New-TestSnapshot -Label 'S2' -Processes @(
+    (New-TestProcess -Pid 401 -Windows @($w1)),
+    (New-TestProcess -Pid 402 -Windows @($w2))
+)
+$result = Resolve-ExcelWindowSelection -Before (New-TestSnapshot -Label 'S1') -After $after -WorkbookStem 'roster_review_blank' -LaunchRequestedUtc $launchUtc
+Assert-True (-not [bool]$result.allowed) 'T3 must reject tied Excel candidates.'
+Assert-Equal $result.reason 'multiple_tied_candidates' 'T3 returned the wrong blocked reason.'
+
+# T4: an unrelated Excel window cannot win without a session-binding signal.
+$unrelated = New-TestWindow -Pid 500 -Hwnd 50001 -Title 'Budget.xlsx - Excel'
+$after = New-TestSnapshot -Label 'S2' -Processes @((New-TestProcess -Pid 500 -Windows @($unrelated)))
+$result = Resolve-ExcelWindowSelection -Before (New-TestSnapshot -Label 'S1') -After $after -WorkbookStem 'roster_review_blank' -LaunchRequestedUtc $launchUtc
+Assert-True (-not [bool]$result.allowed) 'T4 must reject an unrelated Excel window.'
+Assert-Equal $result.reason 'no_candidate_above_threshold' 'T4 returned the wrong blocked reason.'
+
+# T5: a stale or missing HWND cannot be selected even when the PID is preferred.
+$noWindowProcess = New-TestProcess -Pid 600 -Windows @()
+$after = New-TestSnapshot -Label 'S2' -Processes @($noWindowProcess)
+$result = Resolve-ExcelWindowSelection -Before (New-TestSnapshot -Label 'S1') -After $after -WorkbookStem 'roster_review_blank' -PreferredProcessId 600 -LaunchRequestedUtc $launchUtc
+Assert-True (-not [bool]$result.allowed) 'T5 must reject a process without a live HWND.'
+
+# T6: a repair modal under the frozen PID is retained as exact evidence.
+$main = New-TestWindow -Pid 700 -Hwnd 70001 -Title 'roster_review_blank.xlsx - Excel'
+$repair = New-TestWindow -Pid 700 -Hwnd 70002 -Title 'Repaired Records'
+$after = New-TestSnapshot -Label 'S2' -Processes @((New-TestProcess -Pid 700 -Windows @($main, $repair)))
+$result = Resolve-ExcelWindowSelection -Before (New-TestSnapshot -Label 'S1') -After $after -WorkbookStem 'roster_review_blank' -PreferredProcessId 700 -LaunchRequestedUtc $launchUtc
+Assert-True ([bool]$result.allowed) 'T6 expected the frozen repair-session PID to be selected.'
+Assert-True (@($result.winner.evidenceSignals) -contains 'repair_surface_observed') 'T6 did not retain repair-surface evidence.'
+
+Write-Host 'Excel window context tests: 6 passed'

--- a/tests/test_excel_recovery_triage.py
+++ b/tests/test_excel_recovery_triage.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import json
+import zipfile
+
+from triage.excel_recovery_triage import (
+    build_report,
+    main,
+    parse_recovery_log_text,
+    render_markdown,
+)
+
+RECOVERY_LOG = '''<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<recoveryLog xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <logFileName>error588520_01.xml</logFileName>
+  <summary>Errors were detected in file 'roster_review_blank.xlsx'</summary>
+  <removedParts>
+    <removedPart>Removed Part: /xl/styles.xml part with XML error. (Styles) Load error. Line 1, column 0.</removedPart>
+  </removedParts>
+  <removedRecords>
+    <removedRecord>Removed Records: Cell information from /xl/worksheets/sheet1.xml part</removedRecord>
+    <removedRecord>Removed Records: Cell information from /xl/worksheets/sheet2.xml part</removedRecord>
+  </removedRecords>
+  <repairedRecords>
+    <repairedRecord>Repaired Records: Conditional formatting from /xl/worksheets/sheet2.xml part</repairedRecord>
+  </repairedRecords>
+</recoveryLog>'''
+
+
+def _write_xlsx(path, parts):
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name, content in parts.items():
+            zf.writestr(name, content)
+
+
+def _valid_parts():
+    return {
+        "[Content_Types].xml": '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"/>',
+        "xl/workbook.xml": '<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"/>',
+        "xl/styles.xml": '<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><dxfs count="1"><dxf/></dxfs></styleSheet>',
+        "xl/worksheets/sheet1.xml": '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/></worksheet>',
+        "xl/worksheets/sheet2.xml": '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><sheetData/><conditionalFormatting sqref="A1"><cfRule type="expression" dxfId="0" priority="1"><formula>1=1</formula></cfRule></conditionalFormatting></worksheet>',
+    }
+
+
+def test_parses_recovery_log_and_normalizes_parts():
+    parsed = parse_recovery_log_text(RECOVERY_LOG)
+
+    assert parsed["parsed"] is True
+    assert parsed["log_file_name"] == "error588520_01.xml"
+    assert [entry["action"] for entry in parsed["entries"]] == [
+        "removed_part",
+        "removed_record",
+        "removed_record",
+        "repaired_record",
+    ]
+    assert parsed["entries"][0]["part"] == "xl/styles.xml"
+    assert parsed["entries"][-1]["part"] == "xl/worksheets/sheet2.xml"
+
+
+def test_exact_failure_class_is_stop_ship_and_correlated(tmp_path):
+    workbook = tmp_path / "broken.xlsx"
+    parts = _valid_parts()
+    parts["xl/styles.xml"] = b""
+    _write_xlsx(workbook, parts)
+    log = tmp_path / "error.xml"
+    log.write_text(RECOVERY_LOG, encoding="utf-8")
+
+    report = build_report(workbook, [log])
+
+    assert report["verdict"] == "STOP_SHIP"
+    assert "excel_recovery_actions_observed" in report["stop_ship_reasons"]
+    assert "xml_part_parse_failure" in report["stop_ship_reasons"]
+    assert {item["part"] for item in report["workbook"]["xml_parse_failures"]} == {"xl/styles.xml"}
+    assert {item["code"] for item in report["root_cause_candidates"]} >= {
+        "STYLES_XML_UNREADABLE",
+        "STYLE_TABLE_FAILURE_CASCADES_TO_CELLS",
+        "CONDITIONAL_FORMATTING_REPAIRED",
+    }
+
+
+def test_out_of_range_conditional_format_reference_is_stop_ship(tmp_path):
+    workbook = tmp_path / "bad_dxf.xlsx"
+    parts = _valid_parts()
+    parts["xl/worksheets/sheet2.xml"] = parts["xl/worksheets/sheet2.xml"].replace('dxfId="0"', 'dxfId="5"')
+    _write_xlsx(workbook, parts)
+
+    report = build_report(workbook)
+
+    assert report["verdict"] == "STOP_SHIP"
+    assert "conditional_formatting_dxf_reference_invalid" in report["stop_ship_reasons"]
+    assert report["workbook"]["styles_and_cf"]["out_of_range_dxf_references"][0]["dxf_id"] == 5
+
+
+def test_valid_static_package_passes_without_claiming_desktop_proof(tmp_path):
+    workbook = tmp_path / "ok.xlsx"
+    _write_xlsx(workbook, _valid_parts())
+
+    report = build_report(workbook)
+
+    assert report["verdict"] == "STATIC_PACKAGE_PASS"
+    assert report["achieved_proof"] == "static_package_inspection"
+    assert "no Desktop Excel" in report["proof_ceiling"]
+    assert report["workbook"]["xml_parse_failures"] == []
+
+
+def test_cli_writes_json_and_markdown(tmp_path):
+    workbook = tmp_path / "broken.xlsx"
+    parts = _valid_parts()
+    parts["xl/styles.xml"] = b""
+    _write_xlsx(workbook, parts)
+    log = tmp_path / "error.xml"
+    log.write_text(RECOVERY_LOG, encoding="utf-8")
+    json_out = tmp_path / "report.json"
+    markdown_out = tmp_path / "report.md"
+
+    rc = main([
+        str(workbook),
+        "--recovery-log",
+        str(log),
+        "--json-out",
+        str(json_out),
+        "--markdown-out",
+        str(markdown_out),
+    ])
+
+    assert rc == 1
+    assert json.loads(json_out.read_text(encoding="utf-8"))["verdict"] == "STOP_SHIP"
+    rendered = markdown_out.read_text(encoding="utf-8")
+    assert "STYLES_XML_UNREADABLE" in rendered
+    assert "xl/styles.xml" in rendered
+    assert render_markdown(build_report(workbook, [log])).startswith("# Excel Recovery Triage")

--- a/triage/excel_recovery_triage.py
+++ b/triage/excel_recovery_triage.py
@@ -354,7 +354,8 @@ def render_markdown(report: dict) -> str:
         lines.append("| Part | Error |")
         lines.append("|---|---|")
         for failure in failures:
-            lines.append(f"| `{failure['part']}` | {failure['error'].replace('|', '\\|')} |")
+            escaped_error = failure["error"].replace("|", "\\|")
+            lines.append(f"| `{failure['part']}` | {escaped_error} |")
     else:
         lines.append("- No XML parse failures detected by this static inspection.")
     lines.extend(["", "## Root-cause candidates", ""])

--- a/triage/excel_recovery_triage.py
+++ b/triage/excel_recovery_triage.py
@@ -1,0 +1,408 @@
+"""Automate Excel recovery-log parsing and targeted OOXML package triage.
+
+The command is read-only. It correlates a desktop Excel recovery log with the
+referenced workbook parts, parses all XML and relationship parts, and emits
+machine-readable JSON plus an operator-facing Markdown report.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import zipfile
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+from xml.etree import ElementTree as ET
+
+RECOVERY_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+_PART_RE = re.compile(r"/(?:[^\s<'\"]+/)*[^\s<'\"]+?\.xml(?:\.rels)?", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class RecoveryEntry:
+    action: str
+    message: str
+    part: str = ""
+
+
+@dataclass(frozen=True)
+class PartFinding:
+    part: str
+    present: bool
+    size_bytes: int = 0
+    sha256: str = ""
+    parse_status: str = "NOT_APPLICABLE"
+    parse_error: str = ""
+    referenced_by_recovery_log: bool = False
+
+
+def _sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _normalize_part(part: str) -> str:
+    return part.strip().lstrip("/")
+
+
+def _extract_part(message: str) -> str:
+    match = _PART_RE.search(message)
+    return _normalize_part(match.group(0)) if match else ""
+
+
+def parse_recovery_log_text(text: str) -> dict:
+    """Parse an Excel ``recoveryLog`` XML document into normalized entries."""
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as exc:
+        return {
+            "parsed": False,
+            "parse_error": f"{type(exc).__name__}: {exc}",
+            "log_file_name": "",
+            "summary": "",
+            "entries": [],
+        }
+
+    def _text(path: str) -> str:
+        node = root.find(path)
+        return (node.text or "").strip() if node is not None else ""
+
+    entries: list[RecoveryEntry] = []
+    containers = (
+        ("removed_part", f"{{{RECOVERY_NS}}}removedParts", f"{{{RECOVERY_NS}}}removedPart"),
+        ("removed_record", f"{{{RECOVERY_NS}}}removedRecords", f"{{{RECOVERY_NS}}}removedRecord"),
+        ("repaired_record", f"{{{RECOVERY_NS}}}repairedRecords", f"{{{RECOVERY_NS}}}repairedRecord"),
+    )
+    for action, container_tag, item_tag in containers:
+        container = root.find(container_tag)
+        if container is None:
+            continue
+        for item in container.findall(item_tag):
+            message = (item.text or "").strip()
+            entries.append(RecoveryEntry(action=action, message=message, part=_extract_part(message)))
+
+    return {
+        "parsed": True,
+        "parse_error": "",
+        "log_file_name": _text(f"{{{RECOVERY_NS}}}logFileName"),
+        "summary": _text(f"{{{RECOVERY_NS}}}summary"),
+        "entries": [asdict(entry) for entry in entries],
+    }
+
+
+def parse_recovery_log(path: str | Path) -> dict:
+    source = Path(path)
+    payload = parse_recovery_log_text(source.read_text(encoding="utf-8-sig", errors="replace"))
+    payload["source_path"] = str(source)
+    return payload
+
+
+def _parse_xml_part(raw: bytes) -> tuple[str, str]:
+    if not raw:
+        return "FAIL", "empty XML part"
+    try:
+        ET.fromstring(raw)
+    except ET.ParseError as exc:
+        return "FAIL", f"{type(exc).__name__}: {exc}"
+    return "PASS", ""
+
+
+def _part_finding(name: str, raw: bytes, *, referenced: bool) -> PartFinding:
+    if name.lower().endswith((".xml", ".rels")):
+        parse_status, parse_error = _parse_xml_part(raw)
+    else:
+        parse_status, parse_error = "NOT_APPLICABLE", ""
+    return PartFinding(
+        part=name,
+        present=True,
+        size_bytes=len(raw),
+        sha256=_sha256(raw),
+        parse_status=parse_status,
+        parse_error=parse_error,
+        referenced_by_recovery_log=referenced,
+    )
+
+
+def _styles_dxf_diagnostics(zf: zipfile.ZipFile, names: set[str]) -> dict:
+    result = {
+        "styles_present": "xl/styles.xml" in names,
+        "styles_parse_status": "NOT_RUN",
+        "styles_parse_error": "",
+        "declared_dxf_count": None,
+        "actual_dxf_count": None,
+        "cf_dxf_references": [],
+        "out_of_range_dxf_references": [],
+    }
+    if "xl/styles.xml" not in names:
+        return result
+
+    styles_raw = zf.read("xl/styles.xml")
+    status, error = _parse_xml_part(styles_raw)
+    result["styles_parse_status"] = status
+    result["styles_parse_error"] = error
+    if status != "PASS":
+        return result
+
+    styles_root = ET.fromstring(styles_raw)
+    ns = {"m": RECOVERY_NS}
+    dxfs = styles_root.find("m:dxfs", ns)
+    actual = len(list(dxfs)) if dxfs is not None else 0
+    declared_raw = dxfs.attrib.get("count") if dxfs is not None else None
+    declared = int(declared_raw) if declared_raw and declared_raw.isdigit() else None
+    result["declared_dxf_count"] = declared
+    result["actual_dxf_count"] = actual
+
+    references: list[dict] = []
+    invalid: list[dict] = []
+    for part in sorted(name for name in names if name.startswith("xl/worksheets/") and name.endswith(".xml")):
+        raw = zf.read(part)
+        status, _ = _parse_xml_part(raw)
+        if status != "PASS":
+            continue
+        root = ET.fromstring(raw)
+        for rule in root.findall(".//m:cfRule", ns):
+            raw_id = rule.attrib.get("dxfId")
+            if raw_id is None:
+                continue
+            try:
+                dxf_id = int(raw_id)
+            except ValueError:
+                record = {"part": part, "dxf_id": raw_id, "reason": "not_integer"}
+                references.append(record)
+                invalid.append(record)
+                continue
+            record = {"part": part, "dxf_id": dxf_id}
+            references.append(record)
+            if dxf_id < 0 or dxf_id >= actual:
+                invalid.append({**record, "reason": "out_of_range", "dxf_count": actual})
+    result["cf_dxf_references"] = references
+    result["out_of_range_dxf_references"] = invalid
+    return result
+
+
+def inspect_workbook(path: str | Path, referenced_parts: Iterable[str] = ()) -> dict:
+    """Read-only inspection of every XML/rels part plus recovery-referenced parts."""
+    workbook = Path(path)
+    referenced = {_normalize_part(part) for part in referenced_parts if part}
+    result = {
+        "path": str(workbook),
+        "exists": workbook.exists(),
+        "size_bytes": workbook.stat().st_size if workbook.exists() else 0,
+        "sha256": "",
+        "zip_status": "NOT_RUN",
+        "zip_error": "",
+        "parts": [],
+        "referenced_parts_missing": [],
+        "xml_parse_failures": [],
+        "styles_and_cf": {},
+    }
+    if not workbook.exists():
+        result["zip_status"] = "FAIL"
+        result["zip_error"] = "workbook does not exist"
+        return result
+
+    workbook_bytes = workbook.read_bytes()
+    result["sha256"] = _sha256(workbook_bytes)
+    try:
+        zf = zipfile.ZipFile(workbook)
+    except zipfile.BadZipFile as exc:
+        result["zip_status"] = "FAIL"
+        result["zip_error"] = f"{type(exc).__name__}: {exc}"
+        return result
+
+    with zf:
+        result["zip_status"] = "PASS"
+        names = set(zf.namelist())
+        findings: list[PartFinding] = []
+        for name in sorted(names):
+            if not name.lower().endswith((".xml", ".rels")) and name not in referenced:
+                continue
+            findings.append(_part_finding(name, zf.read(name), referenced=name in referenced))
+        for part in sorted(referenced - names):
+            findings.append(PartFinding(part=part, present=False, referenced_by_recovery_log=True))
+            result["referenced_parts_missing"].append(part)
+        result["parts"] = [asdict(finding) for finding in findings]
+        result["xml_parse_failures"] = [
+            {"part": finding.part, "error": finding.parse_error}
+            for finding in findings
+            if finding.parse_status == "FAIL"
+        ]
+        result["styles_and_cf"] = _styles_dxf_diagnostics(zf, names)
+    return result
+
+
+def _root_cause_candidates(recovery_logs: Sequence[dict], workbook: dict) -> list[dict]:
+    candidates: list[dict] = []
+    entries = [entry for log in recovery_logs for entry in log.get("entries", [])]
+    actions_by_part: dict[str, set[str]] = {}
+    for entry in entries:
+        part = entry.get("part", "")
+        if part:
+            actions_by_part.setdefault(part, set()).add(entry.get("action", ""))
+
+    parse_failures = {item["part"]: item["error"] for item in workbook.get("xml_parse_failures", [])}
+    styles = workbook.get("styles_and_cf", {})
+    if "xl/styles.xml" in parse_failures or styles.get("styles_parse_status") == "FAIL":
+        candidates.append({
+            "code": "STYLES_XML_UNREADABLE",
+            "confidence": "HIGH",
+            "evidence": parse_failures.get("xl/styles.xml") or styles.get("styles_parse_error"),
+            "impact": "Excel cannot resolve style indexes; cell records across many sheets may be removed.",
+        })
+    if actions_by_part.get("xl/styles.xml") and any(
+        part.startswith("xl/worksheets/") and "removed_record" in actions
+        for part, actions in actions_by_part.items()
+    ):
+        candidates.append({
+            "code": "STYLE_TABLE_FAILURE_CASCADES_TO_CELLS",
+            "confidence": "HIGH",
+            "evidence": "Recovery log removed styles.xml and cell records from worksheets.",
+            "impact": "Worksheet cells referencing the unreadable style table are discarded during repair.",
+        })
+    if any("repaired_record" in actions for part, actions in actions_by_part.items() if part.startswith("xl/worksheets/")):
+        candidates.append({
+            "code": "CONDITIONAL_FORMATTING_REPAIRED",
+            "confidence": "HIGH",
+            "evidence": "Recovery log reports repaired worksheet conditional formatting.",
+            "impact": "The workbook is failed for delivery even if Excel can display a repaired copy.",
+        })
+    invalid_dxf = styles.get("out_of_range_dxf_references") or []
+    if invalid_dxf:
+        candidates.append({
+            "code": "CF_DXF_REFERENCE_OUT_OF_RANGE",
+            "confidence": "HIGH",
+            "evidence": invalid_dxf,
+            "impact": "Conditional-formatting rules reference differential styles that do not exist.",
+        })
+    return candidates
+
+
+def build_report(workbook_path: str | Path, recovery_log_paths: Sequence[str | Path] = ()) -> dict:
+    logs = [parse_recovery_log(path) for path in recovery_log_paths]
+    referenced_parts = [
+        entry.get("part", "")
+        for log in logs
+        for entry in log.get("entries", [])
+        if entry.get("part")
+    ]
+    workbook = inspect_workbook(workbook_path, referenced_parts)
+    entries = [entry for log in logs for entry in log.get("entries", [])]
+    stop_ship_reasons: list[str] = []
+    if any(not log.get("parsed") for log in logs):
+        stop_ship_reasons.append("recovery_log_parse_failed")
+    if entries:
+        stop_ship_reasons.append("excel_recovery_actions_observed")
+    if workbook.get("zip_status") != "PASS":
+        stop_ship_reasons.append("invalid_or_missing_xlsx_package")
+    if workbook.get("xml_parse_failures"):
+        stop_ship_reasons.append("xml_part_parse_failure")
+    if workbook.get("referenced_parts_missing"):
+        stop_ship_reasons.append("recovery_referenced_part_missing")
+    if (workbook.get("styles_and_cf") or {}).get("out_of_range_dxf_references"):
+        stop_ship_reasons.append("conditional_formatting_dxf_reference_invalid")
+
+    verdict = "STOP_SHIP" if stop_ship_reasons else "STATIC_PACKAGE_PASS"
+    achieved_proof = "desktop_excel_repair_observed" if entries else "static_package_inspection"
+    return {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "verdict": verdict,
+        "stop_ship_reasons": stop_ship_reasons,
+        "achieved_proof": achieved_proof,
+        "proof_ceiling": (
+            "Desktop Excel recovery evidence plus read-only package triage. "
+            "Does not prove a repaired or replacement workbook is acceptable."
+            if entries
+            else "Read-only static package triage only; no Desktop Excel or Excel for Web acceptance proof."
+        ),
+        "workbook": workbook,
+        "recovery_logs": logs,
+        "root_cause_candidates": _root_cause_candidates(logs, workbook),
+    }
+
+
+def render_markdown(report: dict) -> str:
+    workbook = report["workbook"]
+    lines = [
+        "# Excel Recovery Triage",
+        "",
+        f"- **Verdict:** `{report['verdict']}`",
+        f"- **Workbook:** `{workbook['path']}`",
+        f"- **SHA-256:** `{workbook.get('sha256', '')}`",
+        f"- **Proof reached:** `{report['achieved_proof']}`",
+        f"- **Proof ceiling:** {report['proof_ceiling']}",
+        "",
+        "## Stop-ship reasons",
+        "",
+    ]
+    reasons = report.get("stop_ship_reasons") or []
+    lines.extend([f"- `{reason}`" for reason in reasons] or ["- None from the supplied evidence."])
+    lines.extend(["", "## Recovery actions", ""])
+    entries = [entry for log in report.get("recovery_logs", []) for entry in log.get("entries", [])]
+    if entries:
+        lines.append("| Action | Part | Message |")
+        lines.append("|---|---|---|")
+        for entry in entries:
+            message = entry.get("message", "").replace("|", "\\|")
+            lines.append(f"| {entry.get('action', '')} | `{entry.get('part', '')}` | {message} |")
+    else:
+        lines.append("- No recovery log actions supplied.")
+    lines.extend(["", "## XML failures", ""])
+    failures = workbook.get("xml_parse_failures") or []
+    if failures:
+        lines.append("| Part | Error |")
+        lines.append("|---|---|")
+        for failure in failures:
+            lines.append(f"| `{failure['part']}` | {failure['error'].replace('|', '\\|')} |")
+    else:
+        lines.append("- No XML parse failures detected by this static inspection.")
+    lines.extend(["", "## Root-cause candidates", ""])
+    candidates = report.get("root_cause_candidates") or []
+    if candidates:
+        for candidate in candidates:
+            lines.append(f"### {candidate['code']} ({candidate['confidence']})")
+            lines.append("")
+            lines.append(f"- Evidence: `{candidate['evidence']}`")
+            lines.append(f"- Impact: {candidate['impact']}")
+            lines.append("")
+    else:
+        lines.append("- No root-cause candidate reached the configured evidence threshold.")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("workbook", help="Path to the original workbook that Excel opened or repaired.")
+    parser.add_argument(
+        "--recovery-log",
+        action="append",
+        default=[],
+        help="Excel recoveryLog XML path. Repeat for multiple logs.",
+    )
+    parser.add_argument("--json-out", help="Write the full machine-readable report to this path.")
+    parser.add_argument("--markdown-out", help="Write the operator-facing report to this path.")
+    parser.add_argument("--print-json", action="store_true", help="Print the full JSON report to stdout.")
+    args = parser.parse_args(argv)
+
+    report = build_report(args.workbook, args.recovery_log)
+    if args.json_out:
+        target = Path(args.json_out)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    if args.markdown_out:
+        target = Path(args.markdown_out)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(render_markdown(report), encoding="utf-8")
+
+    if args.print_json:
+        print(json.dumps(report, indent=2))
+    else:
+        print(f"{report['verdict']}: {args.workbook}")
+        for reason in report["stop_ship_reasons"]:
+            print(f"- {reason}")
+    return 0 if report["verdict"] == "STATIC_PACKAGE_PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Sprint

Automated Excel Desktop recovery-log and OOXML triage harness.

## Why

A runtime blank-roster workbook opened in Desktop Excel with a repair prompt reporting:

- removed `xl/styles.xml` after an XML load error;
- removed cell records from worksheet parts;
- repaired conditional formatting on two worksheets.

The current roster blank-shell preflight checks sheet order, CF markers, fragile objects, and external links, but does not parse every XML part or inspect style/CF references. That allows a package with an unreadable styles part to reach Desktop Excel before the failure is classified.

This PR removes the manual operator burden of reading the recovery prompt, locating the recovery XML, and inspecting referenced OOXML parts by hand.

## Owned scope

- read-only recoveryLog parser;
- read-only workbook XML/rels parsing and part fingerprints;
- `xl/styles.xml` plus worksheet `dxfId` correlation;
- machine JSON and operator Markdown reports;
- Windows Excel COM probe that opens read-only, captures new recovery logs, closes without saving, and runs triage;
- focused synthetic regression coverage;
- dedicated CI lane.

## Forbidden scope preserved

- no workbook generator changes;
- no workbook repair or mutation;
- no private workbook or generated output commits;
- no Excel for Web or operator-acceptance claim;
- no changes to the contested relationship validator files in PRs #53/#57;
- no changes to mixed PR #56.

## Commands

Supplied recovery log:

```powershell
python -m triage.excel_recovery_triage `
  "Outputs/roster_blank_runtime/roster_review_blank.xlsx" `
  --recovery-log "C:\path\to\error588520_01.xml" `
  --json-out "Outputs/roster_blank_runtime/excel_recovery_triage.json" `
  --markdown-out "Outputs/roster_blank_runtime/excel_recovery_triage.md"
```

Automated Desktop Excel probe:

```powershell
.\scripts\Invoke-ExcelDesktopRepairProbe.ps1 `
  -Workbook "Outputs\roster_blank_runtime\roster_review_blank.xlsx" `
  -OutDir "Outputs\roster_blank_runtime\desktop_probe"
```

## Automated findings

The harness classifies the reported failure pattern as stop-ship and can produce high-confidence candidates including:

- `STYLES_XML_UNREADABLE`;
- `STYLE_TABLE_FAILURE_CASCADES_TO_CELLS`;
- `CONDITIONAL_FORMATTING_REPAIRED`;
- `CF_DXF_REFERENCE_OUT_OF_RANGE` when present in the package.

## Validation performed before push

```text
python -m py_compile triage/excel_recovery_triage.py tests/test_excel_recovery_triage.py
python -m pytest tests/test_excel_recovery_triage.py -q
5 passed
```

PowerShell syntax is checked in GitHub Actions. Native Excel COM execution remains a Windows runtime gate because this environment has no Desktop Excel installation.

## Proof ceiling

The Python suite proves recovery-log parsing, static package inspection, correlation, report generation, and fail-closed verdict behavior. A captured recovery log proves Desktop Excel performed repair actions on that exact workbook. The Windows launcher still requires execution on a machine with Desktop Excel, and neither static nor Desktop proof establishes Excel for Web acceptance.