### PR TITLE
docs(skill): adopt SysAdminSuite package analysis evidence

### DIFF
--- a/.claude/skills/package-static-analysis/SKILL.md
+++ b/.claude/skills/package-static-analysis/SKILL.md
@@ -1,0 +1,39 @@
+# Package Static Analysis Skill
+
+Use this skill when Web-Excel Repair Triage needs to interpret, compare, or preserve sanitized evidence produced by SysAdminSuite for an EXE, MSI, MST, MSP, archive, installer wrapper, script, shortcut, or configuration package.
+
+## Canonical authority
+
+SysAdminSuite owns package inspection and evidence generation:
+
+- `EndeavorEverlasting/SysAdminSuite`
+- `.claude/skills/package-static-analysis/SKILL.md`
+- `harness/api/package-static-analysis-skill.json`
+- `schemas/harness/package-static-analysis-result.schema.json`
+- `tools/package-analysis/analyze_package.py`
+- `scripts/Invoke-SasPackageStaticAnalysis.ps1`
+
+This repository may consume sanitized `package_analysis.json` evidence. It must not fork the analyzer or become a second authority for executable behavior.
+
+## Workflow
+
+1. Run the canonical SysAdminSuite analyzer against an operator-local package outside this repository.
+2. Keep the package, virtual environment, raw output, and private evidence outside Git.
+3. Copy into this repository only a deliberately sanitized evidence fixture when a regression test requires one.
+4. Validate the evidence schema version and all static-only proof flags before interpretation.
+5. Compare hashes, file classes, indicator counts, parser availability, skipped files, and errors without reconstructing redacted values.
+6. Use triage tooling only for sanitized report composition, evidence comparison, issue classification, and durable lessons.
+7. Route new analyzer capabilities, parser changes, and package-intake behavior back to SysAdminSuite.
+8. Route real installation, rollback, service, reboot, application, or device behavior to a separate authorized VM/runtime lane.
+
+## Data handling
+
+- Never commit private installers, extracted payloads, wheelhouses, raw strings, endpoints, UNC paths, credentials, activation data, or real client configuration.
+- Never reverse endpoint fingerprints or enrich them with external lookup.
+- Never follow shortcuts or contact package sources from this repository.
+- Never mark a package safe, installable, or accepted from static evidence alone.
+- Sanitized fixtures must preserve proof flags and structural facts while using fictional names and values.
+
+## Proof ceiling
+
+This skill supports interpretation and triage of static-only evidence. It does not prove Authenticode trust, supported silent arguments, installation success, application launch, service health, reboot behavior, rollback, clinical integration, SSO, or physical-device compatibility.

--- a/.github/workflows/package-static-analysis-skill.yml
+++ b/.github/workflows/package-static-analysis-skill.yml
@@ -1,0 +1,32 @@
+name: Package static analysis skill contracts
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - '.claude/skills/package-static-analysis/**'
+      - 'docs/PACKAGE_STATIC_ANALYSIS_ADOPTION.md'
+      - 'tests/test_package_static_analysis_skill_contract.py'
+      - '.github/workflows/package-static-analysis-skill.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/skills/package-static-analysis/**'
+      - 'docs/PACKAGE_STATIC_ANALYSIS_ADOPTION.md'
+      - 'tests/test_package_static_analysis_skill_contract.py'
+      - '.github/workflows/package-static-analysis-skill.yml'
+
+jobs:
+  contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: python -m pip install pytest
+      - run: python -m pytest tests/test_package_static_analysis_skill_contract.py -q

--- a/docs/PACKAGE_STATIC_ANALYSIS_ADOPTION.md
+++ b/docs/PACKAGE_STATIC_ANALYSIS_ADOPTION.md
@@ -1,0 +1,80 @@
+# Package Static Analysis Adoption
+
+Web-Excel Repair Triage consumes sanitized package-analysis evidence. SysAdminSuite remains the canonical executable-analysis harness.
+
+## Cross-repository boundary
+
+| Responsibility | Owner |
+|---|---|
+| Hash local package files | SysAdminSuite |
+| Inspect PE, OLE/MSI, ZIP, scripts, and configurations | SysAdminSuite |
+| Create the isolated analysis virtual environment | SysAdminSuite |
+| Define the result schema and proof flags | SysAdminSuite |
+| Keep raw packages and evidence ignored | Operator and SysAdminSuite |
+| Compare sanitized evidence and preserve durable lessons | Web-Excel Repair Triage |
+| Execute an installer or validate application behavior | Separate authorized VM/runtime lane |
+
+The triage repository must not copy the analyzer implementation. That would create two drifting authorities for safety, redaction, and proof classification.
+
+## Canonical local command
+
+From a SysAdminSuite checkout on Windows:
+
+```powershell
+.\scripts\Invoke-SasPackageStaticAnalysis.ps1 `
+  -InputPath 'D:\PrivatePackages\Allscripts' `
+  -CreateVenv
+```
+
+Optional deeper PE/OLE inspection may use an approved offline wheelhouse:
+
+```powershell
+.\scripts\Invoke-SasPackageStaticAnalysis.ps1 `
+  -InputPath 'D:\PrivatePackages\Allscripts' `
+  -CreateVenv `
+  -OfflineWheelhouse 'D:\ApprovedWheelhouse'
+```
+
+The SysAdminSuite wrapper uses `pip --no-index --find-links`; it does not fall back to public package indexes.
+
+## Evidence intake
+
+Canonical outputs:
+
+```text
+package_analysis.json
+package_analysis.txt
+```
+
+Before a sanitized fixture enters this repository, verify:
+
+- `schema_version` is `sas-package-static-analysis/v1`;
+- every execution, extraction, network, mutation, trust, and runtime proof flag is false;
+- no absolute input path is emitted;
+- endpoint-like values are fingerprints only;
+- raw private strings are absent;
+- package and client names are replaced when the fixture is public;
+- the fixture remains useful for the exact regression under test.
+
+## Suitable triage work
+
+This repository may:
+
+- compare two sanitized analysis results;
+- classify changed hashes and package composition;
+- render a leadership-safe or developer-safe report;
+- preserve package-shape lessons;
+- identify missing preflight, logging, runtime-acceptance, reboot, and rollback requirements;
+- create sanitized regression fixtures.
+
+It must not:
+
+- execute, unpack, patch, or rewrite private installers;
+- infer approved arguments from common conventions;
+- contact discovered endpoints;
+- claim that static indicators ran;
+- claim that a package installs or works.
+
+## Promotion boundary
+
+Static evidence is the intake floor. A package enters VM testing only after its identity is complete and package-specific preflight, logging, runtime acceptance, reboot, and rollback requirements are defined. Physical-device acceptance remains a later gate.

--- a/tests/test_package_static_analysis_skill_contract.py
+++ b/tests/test_package_static_analysis_skill_contract.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / ".claude/skills/package-static-analysis/SKILL.md"
+DOC = ROOT / "docs/PACKAGE_STATIC_ANALYSIS_ADOPTION.md"
+WORKFLOW = ROOT / ".github/workflows/package-static-analysis-skill.yml"
+
+
+def read(path: Path) -> str:
+    assert path.is_file(), f"missing required file: {path.relative_to(ROOT)}"
+    return path.read_text(encoding="utf-8")
+
+
+def test_skill_uses_sysadminsuite_as_canonical_authority() -> None:
+    text = read(SKILL)
+    for fragment in (
+        "EndeavorEverlasting/SysAdminSuite",
+        "harness/api/package-static-analysis-skill.json",
+        "schemas/harness/package-static-analysis-result.schema.json",
+        "tools/package-analysis/analyze_package.py",
+        "scripts/Invoke-SasPackageStaticAnalysis.ps1",
+    ):
+        assert fragment in text
+    assert "must not fork the analyzer" in text.lower()
+
+
+def test_static_only_and_private_data_boundaries_are_explicit() -> None:
+    combined = read(SKILL) + "\n" + read(DOC)
+    required = (
+        "static-only",
+        "never commit private installers",
+        "never follow shortcuts",
+        "never mark a package safe",
+        "authorized VM/runtime lane",
+        "endpoint",
+        "proof ceiling",
+    )
+    lowered = combined.lower()
+    for fragment in required:
+        assert fragment.lower() in lowered
+    for forbidden in ("msiexec /i", "start-process", "subprocess.run", "invoke-webrequest", "pip install pefile"):
+        assert forbidden not in lowered
+
+
+def test_adoption_doc_names_offline_venv_and_evidence_contract() -> None:
+    text = read(DOC)
+    assert "-CreateVenv" in text
+    assert "-OfflineWheelhouse" in text
+    assert "--no-index --find-links" in text
+    assert "package_analysis.json" in text
+    assert "sas-package-static-analysis/v1" in text
+    assert "every execution, extraction, network, mutation, trust, and runtime proof flag is false" in text
+
+
+def test_workflow_runs_this_contract() -> None:
+    text = read(WORKFLOW)
+    assert "ubuntu-latest" in text
+    assert "python -m pytest tests/test_package_static_analysis_skill_contract.py" in text
+
+
+def test_documents_do_not_contain_client_package_values() -> None:
+    combined = read(SKILL) + "\n" + read(DOC)
+    forbidden = ("nt2kwb", "nslijhs", "northwell", "defaultpassword", "bearer ", "api_key")
+    lowered = combined.lower()
+    for value in forbidden:
+        assert value not in lowered


### PR DESCRIPTION
## Mission

Adopt the SysAdminSuite package-static-analysis skill in the triage repository while preserving one canonical executable-analysis authority.

## Delivered

- `.claude/skills/package-static-analysis/SKILL.md` for interpreting and comparing sanitized evidence;
- cross-repository ownership guide;
- exact local SysAdminSuite invocation with isolated virtual environment and optional offline wheelhouse;
- explicit prohibition on analyzer forks, private binaries, raw strings, endpoint lookup, installer execution, and inflated runtime claims;
- dependency-free contract test and focused CI workflow.

## Authority boundary

SysAdminSuite owns hashing, PE/OLE/ZIP inspection, static indicators, redaction, result schema, virtual-environment setup, and evidence generation. Web-Excel Repair Triage may consume deliberately sanitized `package_analysis.json` evidence for comparison, reporting, issue classification, and durable lessons.

## Final-head validation

Head: `bf47b9fd42207bf7d997280e41547365e745fc70`

- Package static analysis skill contracts #1 — PASS;
- `python -m pytest tests/test_package_static_analysis_skill_contract.py -q` — PASS, 5 tests;
- local Python compile and text hygiene — PASS;
- import and Git-ignore hygiene steps in Artifact engine tests #189 — PASS;
- the existing explicitly enumerated artifact-engine regression batch — FAIL outside this PR's four changed documentation/contract files;
- inline review threads — 0.

This PR remains draft until the existing artifact-engine failures are independently triaged or a clean baseline is established.

## Proof ceiling

Documentation and contract proof for sanitized static-evidence consumption only. No executable analysis, package execution, network activity, VM behavior, installation, rollback, or application acceptance is claimed in this repository.