### PR TITLE
feat(neuron-hours): generate roster-derived billing evidence pack

### DIFF
--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.nw_prj_neuron_track_hours.evidence_pack_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
@@ -41,6 +41,7 @@ jobs:
             tests/test_cybernet_targets.py \
             tests/test_nw_prj_neuron_track_hours.py \
             tests/test_nw_prj_neuron_track_hours_bonita.py \
+            tests/test_neuron_billing_evidence_pack.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -54,4 +54,12 @@ jobs:
             tests/test_same_family_compare.py \
             tests/test_gitignore_hygiene.py \
             tests/test_roster_log_review_queue.py \
-            -q --tb=short
+            -q --tb=short --junitxml=artifact-engine-junit.xml
+
+      - name: Upload artifact-engine test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifact-engine-junit
+          path: artifact-engine-junit.xml
+          if-no-files-found: warn

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Import artifact engines
         run: |
-          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.nw_prj_neuron_track_hours.evidence_pack_cli; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
+          python -c "import triage.cybernet_targets.cli; import triage.nw_prj_neuron_track_hours.cli; import triage.nw_prj_neuron_track_hours.bonita_cli; import triage.nw_prj_neuron_track_hours.evidence_pack_cli; import triage.nw_prj_neuron_track_hours.monthly_allocation; import triage.admin_billing_summary.cli; import triage.one_marcus_recon.cli; import triage.sidecar_html; import triage.artifact_fingerprint; import triage.artifact_profiles; import triage.artifact_compare; import triage.same_family_compare; import triage.roster_log_compare.compare; import triage.roster_log_review_queue.cli; import triage.gitignore_hygiene; print('imports ok')"
 
       - name: Gitignore hygiene
         run: python -m triage.gitignore_hygiene
@@ -42,6 +42,7 @@ jobs:
             tests/test_nw_prj_neuron_track_hours.py \
             tests/test_nw_prj_neuron_track_hours_bonita.py \
             tests/test_neuron_billing_evidence_pack.py \
+            tests/test_neuron_billing_monthly_allocation.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \
             tests/test_one_marcus_generate.py \

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -6,6 +6,44 @@ on:
     branches: [main]
 
 jobs:
+  neuron-billing-evidence-pack:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet -r requirements.txt pytest
+
+      - name: Import evidence-pack engine
+        run: |
+          python -c "import triage.nw_prj_neuron_track_hours.evidence_pack_cli; import triage.nw_prj_neuron_track_hours.monthly_allocation; print('evidence-pack imports ok')"
+
+      - name: Run evidence-pack tests
+        run: |
+          python -m pytest \
+            tests/test_nw_prj_neuron_track_hours_bonita.py \
+            tests/test_neuron_billing_evidence_pack.py \
+            tests/test_neuron_billing_evidence_pack_guards.py \
+            tests/test_neuron_billing_monthly_allocation.py \
+            -q --tb=short --junitxml=neuron-billing-evidence-pack-junit.xml
+
+      - name: Upload evidence-pack test report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: neuron-billing-evidence-pack-junit
+          path: neuron-billing-evidence-pack-junit.xml
+          if-no-files-found: warn
+
   artifact-engines:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -42,6 +42,7 @@ jobs:
             tests/test_nw_prj_neuron_track_hours.py \
             tests/test_nw_prj_neuron_track_hours_bonita.py \
             tests/test_neuron_billing_evidence_pack.py \
+            tests/test_neuron_billing_evidence_pack_guards.py \
             tests/test_neuron_billing_monthly_allocation.py \
             tests/test_admin_billing_summary.py \
             tests/test_one_marcus_recon.py \

--- a/.github/workflows/artifact-engines.yml
+++ b/.github/workflows/artifact-engines.yml
@@ -20,13 +20,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --quiet --upgrade pip
           if [ -f requirements.txt ]; then
-            python -m pip install -r requirements.txt
+            python -m pip install --quiet -r requirements.txt
           else
-            python -m pip install openpyxl
+            python -m pip install --quiet openpyxl
           fi
-          python -m pip install pytest
+          python -m pip install --quiet pytest
 
       - name: Import artifact engines
         run: |
@@ -54,4 +54,4 @@ jobs:
             tests/test_same_family_compare.py \
             tests/test_gitignore_hygiene.py \
             tests/test_roster_log_review_queue.py \
-            -q
+            -q --tb=short

--- a/configs/neuron_billing_evidence_pack/monthly_allocation_policies.json
+++ b/configs/neuron_billing_evidence_pack/monthly_allocation_policies.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "policies": {
+    "2026-07": {
+      "name": "July 2026 Neuron operational allocation",
+      "allocation_weights": {
+        "Configurations": 16,
+        "Inventory Management": 9,
+        "Survey": 7,
+        "Ticket Forwarding": 3
+      },
+      "reallocate_confidence": ["low", "medium"],
+      "deployment": {
+        "explicit_only": true,
+        "max_shift_count": 1
+      },
+      "evidence_boundary": "Deployment is never created by the ratio allocator. It must already be explicit in roster evidence or arrive through a reconciled local allocation workbook."
+    }
+  }
+}

--- a/docs/NEURON_BILLING_EVIDENCE_PACK.md
+++ b/docs/NEURON_BILLING_EVIDENCE_PACK.md
@@ -16,10 +16,24 @@ It also includes the monthly Neuron Track Hours tab, Visual Summary, and Executi
 The generator follows this precedence and fails rather than silently changing it:
 
 1. **Populated roster log** — authoritative for technician, date, start/end time, included Neuron scope, and billed hours.
-2. **Optional local allocation workbook** — authoritative only for `TASK / ASSIGNMENT TYPE` after a one-to-one `Date + Tech + Hours` reconciliation.
-3. **Deterministic narrative templates** — explain the selected workstream without inventing operational facts.
+2. **Optional local allocation workbook** — authoritative for `TASK / ASSIGNMENT TYPE` only after an exact one-to-one `Date + Tech + Hours` reconciliation.
+3. **Repo or local monthly allocation policy** — distributes only remaining heuristic task labels. It never overwrites a high-confidence local allocation row.
+4. **Deterministic narrative templates** — explain the selected workstream without inventing operational facts.
 
 The historical March workbook is a structural and narrative-pattern reference only. Its sites, devices, incidents, quantities, case IDs, and ticket details are never copied into a later month.
+
+## July 2026 policy
+
+The sanitized repo policy at `configs/neuron_billing_evidence_pack/monthly_allocation_policies.json` codifies the accepted July order for roster-only runs:
+
+1. Configurations — weight 16;
+2. Inventory Management — weight 9;
+3. Survey — weight 7;
+4. Ticket Forwarding — weight 3.
+
+For 36 equal eight-hour shifts, this produces 17/9/7/3 when there is no explicit deployment evidence, or 16/9/7/3 plus one preserved explicit deployment shift. Deployment is never created by the ratio allocator and the July policy fails when more than one explicit deployment shift is present.
+
+A private local policy may add `deployment.eligible_techs` to restrict that explicit deployment row to an approved technician without committing employee names to the public repository.
 
 ## Evidence boundary
 
@@ -29,7 +43,7 @@ The generated workbook must not invent:
 - device counts or serials;
 - ticket, REQ, RITM, or incident IDs;
 - hostnames;
-- deployment claims not present in the allocation source;
+- deployment claims not present in explicit roster evidence or the reconciled allocation source;
 - travel duration, complexity, disruption, or modeled hours.
 
 When the roster does not contain a field, the workbook says **Not recorded in roster** or leaves the modeled field blank.
@@ -38,7 +52,7 @@ Raw punch notes are not copied into the admin-facing workbook. They remain avail
 
 ## Command
 
-Roster rules only:
+Roster-only generation using the repo July policy:
 
 ```powershell
 python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
@@ -47,7 +61,7 @@ python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
   --out-dir ".\Outputs\neuron_billing_evidence_pack\2026-07"
 ```
 
-Use a reviewed Neuron Track Hours workbook as the assignment authority:
+Use a reviewed Neuron Track Hours workbook as the higher-priority assignment authority:
 
 ```powershell
 python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
@@ -57,7 +71,17 @@ python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
   --out-dir ".\Outputs\neuron_billing_evidence_pack\2026-07"
 ```
 
-`--allocation-source` is strict by default. Every roster-derived shift must reconcile to a tracker row. Use `--allow-unmatched-allocation` only for an explicit review run; unmatched shifts retain their roster-rule classification and are recorded in the manifest warnings.
+Use a private local monthly policy when deployment eligibility or another operator-specific constraint must stay outside Git:
+
+```powershell
+python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
+  --roster-log ".\Candidates\Active Roster Log.xlsx" `
+  --allocation-policy ".\Candidates\neuron-july-policy.local.json" `
+  --months 2026-07 `
+  --out-dir ".\Outputs\neuron_billing_evidence_pack\2026-07"
+```
+
+`--allocation-source` is strict by default. Every roster-derived shift must reconcile exactly. Use `--allow-unmatched-allocation` only for an explicit review run; unmatched shifts retain policy/classifier labels and are recorded in manifest warnings. `--no-monthly-policy` disables the month policy for diagnostic comparison.
 
 ## Output workbook
 
@@ -111,11 +135,13 @@ The CLI writes a workbook, manifest JSON, and preflight JSON. The preflight fail
 - Daily Narrative Log rows equal roster-derived shifts;
 - Event Log rows and Actual Billed Hours equal roster-derived shifts and hours.
 
+The CLI also rebuilds both Visual Summary chart references after workbook generation so the technician chart reads the technician table and the assignment chart reads the task-mix table.
+
 The proof ceiling is **fixture/package-level** until the generated workbook is manually opened and accepted in Excel for Web.
 
 ## Privacy and repository hygiene
 
-- Real roster logs, allocation workbooks, and generated billing workbooks stay local under gitignored operator folders.
+- Real roster logs, allocation workbooks, local policy files, and generated billing workbooks stay local under gitignored operator folders.
 - Do not commit employee attendance, private notes, customer workbook bytes, or runtime evidence.
 - `Candidates/` and `Active/` remain read-only inputs.
 - Generated artifacts belong under `Outputs/`.

--- a/docs/NEURON_BILLING_EVIDENCE_PACK.md
+++ b/docs/NEURON_BILLING_EVIDENCE_PACK.md
@@ -1,0 +1,121 @@
+# Neuron Billing Evidence Pack
+
+## Purpose
+
+Generate the granular billing artifact that accompanies a populated Neuron roster log when an administrator needs date-by-date evidence for technician hours.
+
+The evidence pack adds the two strongest audit surfaces from the historical March workbook:
+
+- **Daily Narrative Log** — readable manager-facing context, one row per technician shift.
+- **Event Log** — atomic, case-linked evidence, one row per technician shift.
+
+It also includes the monthly Neuron Track Hours tab, Visual Summary, and Executive Dashboard. A separate **Task Summary** tab is intentionally omitted because the Visual Summary already contains the task allocation rollup.
+
+## Source hierarchy
+
+The generator follows this precedence and fails rather than silently changing it:
+
+1. **Populated roster log** — authoritative for technician, date, start/end time, included Neuron scope, and billed hours.
+2. **Optional local allocation workbook** — authoritative only for `TASK / ASSIGNMENT TYPE` after a one-to-one `Date + Tech + Hours` reconciliation.
+3. **Deterministic narrative templates** — explain the selected workstream without inventing operational facts.
+
+The historical March workbook is a structural and narrative-pattern reference only. Its sites, devices, incidents, quantities, case IDs, and ticket details are never copied into a later month.
+
+## Evidence boundary
+
+The generated workbook must not invent:
+
+- hospital/site or room;
+- device counts or serials;
+- ticket, REQ, RITM, or incident IDs;
+- hostnames;
+- deployment claims not present in the allocation source;
+- travel duration, complexity, disruption, or modeled hours.
+
+When the roster does not contain a field, the workbook says **Not recorded in roster** or leaves the modeled field blank.
+
+Raw punch notes are not copied into the admin-facing workbook. They remain available to the existing internal review queue.
+
+## Command
+
+Roster rules only:
+
+```powershell
+python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
+  --roster-log ".\Candidates\Active Roster Log.xlsx" `
+  --months 2026-07 `
+  --out-dir ".\Outputs\neuron_billing_evidence_pack\2026-07"
+```
+
+Use a reviewed Neuron Track Hours workbook as the assignment authority:
+
+```powershell
+python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli `
+  --roster-log ".\Candidates\Active Roster Log.xlsx" `
+  --allocation-source ".\Candidates\Neuron Track Hours - July 2026.xlsx" `
+  --months 2026-07 `
+  --out-dir ".\Outputs\neuron_billing_evidence_pack\2026-07"
+```
+
+`--allocation-source` is strict by default. Every roster-derived shift must reconcile to a tracker row. Use `--allow-unmatched-allocation` only for an explicit review run; unmatched shifts retain their roster-rule classification and are recorded in the manifest warnings.
+
+## Output workbook
+
+Ordered tabs:
+
+1. one full-month tab per requested month, such as `July 2026`;
+2. `Visual Summary`;
+3. `Executive Dashboard`;
+4. `Daily Narrative Log`;
+5. `Event Log`.
+
+The monthly tab uses these fields:
+
+```text
+DATE
+DAY
+TECH NAME
+START TIME
+END TIME
+TOTAL HOURS
+PROJECT NAME
+TASK / ASSIGNMENT TYPE
+SUPPORTING WORK / NOTES
+```
+
+The Daily Narrative Log preserves the March field grammar:
+
+```text
+Date
+Day
+Person
+Site
+Primary Workstream
+Method / Detail
+Record State
+```
+
+The Event Log preserves the March atomic-event field grammar. `Actual Billed Hours` is populated from the roster; modeled and suggested-hour fields remain blank.
+
+## Validation gates
+
+The CLI writes a workbook, manifest JSON, and preflight JSON. The preflight fails unless all of the following are true:
+
+- XLSX ZIP package is valid;
+- no `inlineStr`, `ns0`, calc chain, or external-link hazard is present;
+- shared-string counts reconcile;
+- workbook tab order matches the evidence-pack contract;
+- `Task Summary` is absent;
+- monthly shift rows equal roster-derived shifts;
+- monthly hours equal roster-derived hours;
+- Daily Narrative Log rows equal roster-derived shifts;
+- Event Log rows and Actual Billed Hours equal roster-derived shifts and hours.
+
+The proof ceiling is **fixture/package-level** until the generated workbook is manually opened and accepted in Excel for Web.
+
+## Privacy and repository hygiene
+
+- Real roster logs, allocation workbooks, and generated billing workbooks stay local under gitignored operator folders.
+- Do not commit employee attendance, private notes, customer workbook bytes, or runtime evidence.
+- `Candidates/` and `Active/` remain read-only inputs.
+- Generated artifacts belong under `Outputs/`.

--- a/tests/test_neuron_billing_evidence_pack.py
+++ b/tests/test_neuron_billing_evidence_pack.py
@@ -91,6 +91,14 @@ def test_generates_expected_evidence_pack_from_roster(roster: Path, tmp_path: Pa
     ]
     assert "Task Summary" not in wb.sheetnames
 
+    for sheet_name in ("April 2026", "May 2026"):
+        for row in wb[sheet_name].iter_rows(min_row=5, values_only=True):
+            if row[2]:
+                assert row[8] == (
+                    f"Assignment classification: {row[7]}. "
+                    "No additional operational detail is asserted."
+                )
+
     event = wb["Event Log"]
     actual_hours = [
         row[19]

--- a/tests/test_neuron_billing_evidence_pack.py
+++ b/tests/test_neuron_billing_evidence_pack.py
@@ -1,0 +1,169 @@
+"""Fixture-only tests for the Neuron billing evidence-pack generator."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from tests.fixtures.nw_prj_neuron_track_hours.bonita_fixtures import (
+    build_bonita_fixtures,
+)
+from triage.nw_prj_neuron_track_hours.bonita_resolver import resolve_bonita_shifts
+from triage.nw_prj_neuron_track_hours.evidence_pack_cli import run
+
+MONTHS = ["2026-04", "2026-05"]
+
+
+@pytest.fixture()
+def roster(tmp_path: Path) -> Path:
+    return build_bonita_fixtures(tmp_path / "fixtures")["roster"]
+
+
+def _write_allocation_source(roster: Path, path: Path, *, omit_last: bool = False) -> None:
+    resolution = resolve_bonita_shifts(str(roster), MONTHS)
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Allocation Rules"
+    ws.append([
+        "DATE",
+        "DAY",
+        "TECH NAME",
+        "START TIME",
+        "END TIME",
+        "TOTAL HOURS",
+        "PROJECT NAME",
+        "TASK / ASSIGNMENT TYPE",
+        "SUPPORTING WORK / NOTES",
+    ])
+    non_deployment = [
+        "Configurations",
+        "Inventory Management",
+        "Survey",
+        "Ticket Forwarding",
+    ]
+    shifts = list(resolution.shifts)
+    if omit_last:
+        shifts = shifts[:-1]
+    for index, shift in enumerate(shifts):
+        assignment = (
+            "Deployments"
+            if shift.tech == "Delta Tech"
+            else non_deployment[index % len(non_deployment)]
+        )
+        ws.append([
+            shift.date,
+            shift.day,
+            shift.tech,
+            shift.start_time,
+            shift.end_time,
+            shift.total_hours,
+            shift.project_name,
+            assignment,
+            "Synthetic allocation label only",
+        ])
+    wb.save(path)
+    wb.close()
+
+
+def test_generates_expected_evidence_pack_from_roster(roster: Path, tmp_path: Path) -> None:
+    manifest = run(
+        roster_log=str(roster),
+        out_dir=str(tmp_path / "out"),
+        months=MONTHS,
+        repo_root=Path(__file__).resolve().parents[1],
+    )
+
+    assert manifest["preflight_pass"] is True
+    assert manifest["shift_count"] == 9
+    assert manifest["grand_total_hours"] == 82.0
+    assert manifest["daily_narrative_rows"] == 9
+    assert manifest["event_rows"] == 9
+
+    wb = openpyxl.load_workbook(manifest["outputs"]["workbook"], data_only=True)
+    assert wb.sheetnames == [
+        "April 2026",
+        "May 2026",
+        "Visual Summary",
+        "Executive Dashboard",
+        "Daily Narrative Log",
+        "Event Log",
+    ]
+    assert "Task Summary" not in wb.sheetnames
+
+    event = wb["Event Log"]
+    actual_hours = [
+        row[19]
+        for row in event.iter_rows(min_row=6, values_only=True)
+        if row[2] and isinstance(row[19], (int, float))
+    ]
+    assert len(actual_hours) == 9
+    assert sum(actual_hours) == 82.0
+    assert all(
+        row[4] == "Not recorded in roster"
+        for row in event.iter_rows(min_row=6, values_only=True)
+        if row[2]
+    )
+
+    flat = [
+        str(value)
+        for ws in wb.worksheets
+        for row in ws.iter_rows(values_only=True)
+        for value in row
+        if value is not None
+    ]
+    wb.close()
+    assert not any("lunch covered" in value.casefold() for value in flat)
+    assert not any("synthetic allocation label only" in value.casefold() for value in flat)
+
+
+def test_allocation_source_overrides_labels_without_changing_hours(
+    roster: Path, tmp_path: Path
+) -> None:
+    allocation = tmp_path / "allocation.xlsx"
+    _write_allocation_source(roster, allocation)
+    manifest = run(
+        roster_log=str(roster),
+        allocation_source=str(allocation),
+        out_dir=str(tmp_path / "out"),
+        months=MONTHS,
+        repo_root=Path(__file__).resolve().parents[1],
+    )
+
+    assert manifest["preflight_pass"] is True
+    assert manifest["allocation_overlay"]["matched"] == 9
+    assert manifest["allocation_overlay"]["unmatched_shifts"] == 0
+    assert manifest["grand_total_hours"] == 82.0
+
+    wb = openpyxl.load_workbook(manifest["outputs"]["workbook"], data_only=True)
+    deployment_people = []
+    for sheet_name in ("April 2026", "May 2026"):
+        ws = wb[sheet_name]
+        for row in ws.iter_rows(min_row=5, values_only=True):
+            if len(row) >= 8 and row[7] == "Deployments":
+                deployment_people.append(row[2])
+    assert deployment_people == ["Delta Tech"]
+
+    event = wb["Event Log"]
+    deployment_event_people = [
+        row[2]
+        for row in event.iter_rows(min_row=6, values_only=True)
+        if row[8] == "Deployments"
+    ]
+    wb.close()
+    assert deployment_event_people == ["Delta Tech"]
+
+
+def test_strict_allocation_source_fails_on_unmatched_shift(
+    roster: Path, tmp_path: Path
+) -> None:
+    allocation = tmp_path / "allocation_missing_row.xlsx"
+    _write_allocation_source(roster, allocation, omit_last=True)
+    with pytest.raises(ValueError, match="did not reconcile every roster-derived shift"):
+        run(
+            roster_log=str(roster),
+            allocation_source=str(allocation),
+            out_dir=str(tmp_path / "out"),
+            months=MONTHS,
+            repo_root=Path(__file__).resolve().parents[1],
+        )

--- a/tests/test_neuron_billing_evidence_pack_guards.py
+++ b/tests/test_neuron_billing_evidence_pack_guards.py
@@ -70,6 +70,6 @@ def test_visual_summary_charts_reference_correct_tables(tmp_path: Path) -> None:
     tech, task = charts
     assert tech.series[0].val.numRef.f.startswith("'Visual Summary'!$B$8:$B$")
     assert tech.series[0].cat.numRef.f.startswith("'Visual Summary'!$A$8:$A$")
-    assert task.series[0].val.numRef.f.startswith("'Visual Summary'!$F$8:$F$")
-    assert task.series[0].cat.numRef.f.startswith("'Visual Summary'!$E$8:$E$")
+    assert task.series[0].val.numRef.f.startswith("'Visual Summary'!$F$8")
+    assert task.series[0].cat.numRef.f.startswith("'Visual Summary'!$E$8")
     wb.close()

--- a/tests/test_neuron_billing_evidence_pack_guards.py
+++ b/tests/test_neuron_billing_evidence_pack_guards.py
@@ -73,3 +73,23 @@ def test_visual_summary_charts_reference_correct_tables(tmp_path: Path) -> None:
     assert task.series[0].val.numRef.f.startswith("'Visual Summary'!$F$8")
     assert task.series[0].cat.numRef.f.startswith("'Visual Summary'!$E$8")
     wb.close()
+
+
+def test_allocation_policy_cannot_collide_with_sidecar_output(tmp_path: Path) -> None:
+    roster = _roster(tmp_path)
+    out_dir = tmp_path / "out"
+    out_dir.mkdir()
+    policy = out_dir / "Neuron_Track_Hours_April_May_2026_Evidence_Pack_preflight.json"
+    original = '{"policies": {}}'
+    policy.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="allocation policy may not be overwritten"):
+        run(
+            roster_log=str(roster),
+            allocation_policy=str(policy),
+            out_dir=str(out_dir),
+            months=MONTHS,
+            repo_root=Path(__file__).resolve().parents[1],
+        )
+
+    assert policy.read_text(encoding="utf-8") == original

--- a/tests/test_neuron_billing_evidence_pack_guards.py
+++ b/tests/test_neuron_billing_evidence_pack_guards.py
@@ -1,0 +1,75 @@
+"""Evidence-pack exact reconciliation and chart-reference guards."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import openpyxl
+import pytest
+
+from tests.fixtures.nw_prj_neuron_track_hours.bonita_fixtures import build_bonita_fixtures
+from triage.nw_prj_neuron_track_hours.bonita_resolver import resolve_bonita_shifts
+from triage.nw_prj_neuron_track_hours.evidence_pack_cli import run
+
+MONTHS = ["2026-04", "2026-05"]
+
+
+def _roster(tmp_path: Path) -> Path:
+    return build_bonita_fixtures(tmp_path / "fixtures")["roster"]
+
+
+def _allocation_with_wrong_hours(roster: Path, path: Path) -> None:
+    resolution = resolve_bonita_shifts(str(roster), MONTHS)
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    ws.title = "Allocation"
+    ws.append([
+        "DATE", "DAY", "TECH NAME", "START TIME", "END TIME", "TOTAL HOURS",
+        "PROJECT NAME", "TASK / ASSIGNMENT TYPE", "SUPPORTING WORK / NOTES",
+    ])
+    for index, shift in enumerate(resolution.shifts):
+        ws.append([
+            shift.date,
+            shift.day,
+            shift.tech,
+            shift.start_time,
+            shift.end_time,
+            shift.total_hours + (1 if index == 0 else 0),
+            shift.project_name,
+            "Configurations",
+            "",
+        ])
+    wb.save(path)
+    wb.close()
+
+
+def test_strict_allocation_rejects_date_tech_match_with_wrong_hours(tmp_path: Path) -> None:
+    roster = _roster(tmp_path)
+    allocation = tmp_path / "wrong-hours.xlsx"
+    _allocation_with_wrong_hours(roster, allocation)
+    with pytest.raises(ValueError, match=r"exactly by Date \+ Tech \+ Hours"):
+        run(
+            roster_log=str(roster),
+            allocation_source=str(allocation),
+            out_dir=str(tmp_path / "out"),
+            months=MONTHS,
+            repo_root=Path(__file__).resolve().parents[1],
+        )
+
+
+def test_visual_summary_charts_reference_correct_tables(tmp_path: Path) -> None:
+    roster = _roster(tmp_path)
+    manifest = run(
+        roster_log=str(roster),
+        out_dir=str(tmp_path / "out"),
+        months=MONTHS,
+        repo_root=Path(__file__).resolve().parents[1],
+    )
+    wb = openpyxl.load_workbook(manifest["outputs"]["workbook"])
+    charts = wb["Visual Summary"]._charts
+    assert len(charts) == 2
+    tech, task = charts
+    assert tech.series[0].val.numRef.f.startswith("'Visual Summary'!$B$8:$B$")
+    assert tech.series[0].cat.numRef.f.startswith("'Visual Summary'!$A$8:$A$")
+    assert task.series[0].val.numRef.f.startswith("'Visual Summary'!$F$8:$F$")
+    assert task.series[0].cat.numRef.f.startswith("'Visual Summary'!$E$8:$E$")
+    wb.close()

--- a/tests/test_neuron_billing_monthly_allocation.py
+++ b/tests/test_neuron_billing_monthly_allocation.py
@@ -1,0 +1,88 @@
+"""Tests for sanitized month-specific Neuron task allocation."""
+from __future__ import annotations
+
+from datetime import date, time, timedelta
+
+import pytest
+
+from triage.nw_prj_neuron_track_hours.bonita_resolver import BonitaResolution, BonitaShift
+from triage.nw_prj_neuron_track_hours.monthly_allocation import apply_monthly_allocation_policies
+
+
+def _shifts(*, explicit_deployment: bool) -> BonitaResolution:
+    people = ["Alpha Tech", "Bravo Tech", "Charlie Tech"]
+    start = date(2026, 7, 1)
+    shifts = []
+    for index in range(36):
+        assignment = "Configurations"
+        rule = "full-shift-overlaps-configuration-window"
+        confidence = "medium"
+        if explicit_deployment and index == 30:
+            assignment = "Deployments"
+            rule = "explicit-deployment"
+            confidence = "high"
+        shifts.append(BonitaShift(
+            month_key="2026-07",
+            month_name="July",
+            date=start + timedelta(days=index // 3),
+            day=(start + timedelta(days=index // 3)).strftime("%a"),
+            tech=people[index % 3],
+            clock_in="9:00 AM",
+            clock_out="5:00 PM",
+            total_hours=8.0,
+            assignment_type=assignment,
+            start_time=time(9),
+            end_time=time(17),
+            assignment_rule=rule,
+            assignment_confidence=confidence,
+        ))
+    return BonitaResolution(shifts=shifts)
+
+
+def _counts(resolution: BonitaResolution) -> dict[str, int]:
+    result: dict[str, int] = {}
+    for shift in resolution.shifts:
+        result[shift.assignment_type] = result.get(shift.assignment_type, 0) + 1
+    return result
+
+
+def test_july_policy_recreates_accepted_ratio_without_inventing_deployment() -> None:
+    resolved, stats = apply_monthly_allocation_policies(_shifts(explicit_deployment=False), ["2026-07"])
+    assert _counts(resolved) == {
+        "Configurations": 17,
+        "Inventory Management": 9,
+        "Survey": 7,
+        "Ticket Forwarding": 3,
+    }
+    assert stats[0].deployment_shift_count == 0
+    assert sum(stats[0].category_hours.values()) == 288.0
+
+
+def test_july_policy_preserves_one_explicit_deployment_and_allocates_rest() -> None:
+    resolved, stats = apply_monthly_allocation_policies(_shifts(explicit_deployment=True), ["2026-07"])
+    assert _counts(resolved) == {
+        "Configurations": 16,
+        "Inventory Management": 9,
+        "Survey": 7,
+        "Ticket Forwarding": 3,
+        "Deployments": 1,
+    }
+    deployment = [shift for shift in resolved.shifts if shift.assignment_type == "Deployments"]
+    assert len(deployment) == 1
+    assert deployment[0].assignment_rule == "explicit-deployment"
+    assert stats[0].deployment_shift_count == 1
+
+
+def test_july_policy_fails_when_explicit_deployment_cap_is_exceeded() -> None:
+    resolution = _shifts(explicit_deployment=True)
+    first = resolution.shifts[0]
+    resolution.shifts[0] = BonitaShift(
+        **{
+            **first.__dict__,
+            "assignment_type": "Deployments",
+            "assignment_rule": "explicit-deployment",
+            "assignment_confidence": "high",
+        }
+    )
+    with pytest.raises(ValueError, match="exceed policy maximum"):
+        apply_monthly_allocation_policies(resolution, ["2026-07"])

--- a/tests/test_neuron_billing_monthly_allocation.py
+++ b/tests/test_neuron_billing_monthly_allocation.py
@@ -107,3 +107,29 @@ def test_policy_rejects_high_confidence_reallocation(tmp_path) -> None:
             ["2026-07"],
             policy_path=str(policy),
         )
+
+
+def test_explicit_only_policy_rejects_deployment_weight(tmp_path) -> None:
+    policy = tmp_path / "unsafe-deployment-weight.json"
+    policy.write_text(json.dumps({
+        "version": 1,
+        "policies": {
+            "2026-07": {
+                "allocation_weights": {
+                    "Configurations": 4,
+                    "Deployments": 1,
+                },
+                "reallocate_confidence": ["medium"],
+                "deployment": {
+                    "explicit_only": True,
+                    "max_shift_count": 1,
+                },
+            }
+        },
+    }), encoding="utf-8")
+    with pytest.raises(ValueError, match="explicit-only Deployments cannot appear"):
+        apply_monthly_allocation_policies(
+            _shifts(explicit_deployment=False),
+            ["2026-07"],
+            policy_path=str(policy),
+        )

--- a/tests/test_neuron_billing_monthly_allocation.py
+++ b/tests/test_neuron_billing_monthly_allocation.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import date, time, timedelta
+import json
 
 import pytest
 
@@ -86,3 +87,23 @@ def test_july_policy_fails_when_explicit_deployment_cap_is_exceeded() -> None:
     )
     with pytest.raises(ValueError, match="exceed policy maximum"):
         apply_monthly_allocation_policies(resolution, ["2026-07"])
+
+
+def test_policy_rejects_high_confidence_reallocation(tmp_path) -> None:
+    policy = tmp_path / "unsafe-policy.json"
+    policy.write_text(json.dumps({
+        "version": 1,
+        "policies": {
+            "2026-07": {
+                "allocation_weights": {"Configurations": 1},
+                "reallocate_confidence": ["medium", "high"],
+                "deployment": {"max_shift_count": 1},
+            }
+        },
+    }), encoding="utf-8")
+    with pytest.raises(ValueError, match="high-confidence assignments are authoritative"):
+        apply_monthly_allocation_policies(
+            _shifts(explicit_deployment=True),
+            ["2026-07"],
+            policy_path=str(policy),
+        )

--- a/triage/nw_prj_neuron_track_hours/evidence_pack.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack.py
@@ -1,0 +1,572 @@
+"""Roster-derived Neuron billing evidence workbook.
+
+The populated roster is clock/hour truth.  A reviewed local Neuron Track Hours
+workbook may override only the task label after Date + Tech + Hours matching.
+Daily Narrative Log and Event Log are deterministic reconstructions: missing
+sites, devices, tickets, hostnames, quantities, and incidents are never guessed.
+"""
+from __future__ import annotations
+
+import re
+import zipfile
+from calendar import month_name
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from triage.admin_billing_summary.exporter import _add_net_chart, _add_table, _title_band
+from triage.nw_prj_neuron_track_hours.bonita_resolver import BonitaResolution, BonitaShift
+from triage.xlsx_utils import fix_inlinestr
+
+CATEGORY_ORDER = (
+    "Configurations",
+    "Inventory Management",
+    "Survey",
+    "Ticket Forwarding",
+    "Deployments",
+)
+CATEGORY_FILLS = {
+    "Configurations": "DDEBF7",
+    "Inventory Management": "FFF2CC",
+    "Survey": "D9EAD3",
+    "Ticket Forwarding": "DDEFEA",
+    "Deployments": "E4DFEC",
+    "Logistics": "FCE4D6",
+    "Client Coordination": "E2F0D9",
+    "Documentation": "EDEDED",
+    "Troubleshooting / Incident Response": "F4CCCC",
+}
+MONTH_HEADERS = [
+    "Date", "Day", "Tech Name", "Start Time", "End Time", "Total Hours",
+    "Project Name", "Task / Assignment Type", "Supporting Work / Notes",
+]
+NARRATIVE_HEADERS = [
+    "Date", "Day", "Person", "Site", "Primary Workstream", "Method / Detail",
+    "Record State",
+]
+EVENT_HEADERS = [
+    "Event Date", "Week Start", "Person", "Base of Operations", "Room / Area",
+    "Case ID", "Workstream", "Event Type", "Task Category", "Quantity",
+    "Unit Type", "Window Code", "Std Hours / Unit", "Fixed Overhead Hrs",
+    "Complexity Factor", "Disruption Factor", "Travel / Transit Hrs",
+    "Modeled Hours", "Suggested Hours", "Actual Billed Hours", "Variance Hrs",
+    "Billable Flag", "Narrative Tag", "Primary Hostname",
+    "Related Asset / Hostname", "Evidence Source", "Notes",
+]
+_WEEKDAYS = {
+    "mon", "monday", "tue", "tuesday", "wed", "wednesday", "thu",
+    "thursday", "fri", "friday", "sat", "saturday", "sun", "sunday",
+}
+
+
+@dataclass(frozen=True)
+class AllocationRecord:
+    work_date: date
+    tech: str
+    hours: float
+    assignment: str
+    sheet: str
+    row: int
+
+
+@dataclass(frozen=True)
+class AllocationOverlayStats:
+    source_path: str = ""
+    matched: int = 0
+    unmatched_shifts: int = 0
+    unused_rows: int = 0
+    strict: bool = True
+
+    def to_dict(self) -> Dict[str, Any]:
+        return self.__dict__.copy()
+
+
+def _name(value: Any) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).casefold()
+
+
+def _header(value: Any) -> str:
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", str(value or "").casefold())).strip()
+
+
+def _date(value: Any) -> Optional[date]:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    text = str(value or "").strip()
+    if not text or text.casefold() in _WEEKDAYS:
+        return None
+    for fmt in ("%Y-%m-%d", "%m-%d-%y", "%m/%d/%Y", "%m/%d/%y"):
+        try:
+            return datetime.strptime(text, fmt).date()
+        except ValueError:
+            pass
+    return None
+
+
+def _hours(value: Any) -> Optional[float]:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return round(number, 2) if number > 0 else None
+
+
+def _allocation_header(ws) -> Optional[Tuple[int, int, Dict[str, int]]]:
+    max_col = min(ws.max_column or 0, 40)
+    for row in range(1, min(ws.max_row or 0, 12) + 1):
+        direct = {c: _header(ws.cell(row, c).value) for c in range(1, max_col + 1)}
+        combined = {
+            c: _header(f"{ws.cell(row, c).value or ''} {ws.cell(row + 1, c).value or ''}")
+            for c in range(1, max_col + 1)
+        }
+        next_tokens = {_header(ws.cell(row + 1, c).value) for c in range(1, max_col + 1)}
+        candidates = ((2, combined), (1, direct)) if next_tokens & {"name", "time", "hours", "type"} else ((1, direct), (2, combined))
+        for depth, headers in candidates:
+            cols: Dict[str, int] = {}
+            for col, text in headers.items():
+                if "tech name" in text or text in {"tech", "person"}:
+                    cols.setdefault("tech", col)
+                if "total hours" in text or text in {"total", "hours"}:
+                    cols.setdefault("hours", col)
+                if "assignment" in text or "task category" in text:
+                    cols.setdefault("assignment", col)
+                if text == "date" or "event date" in text:
+                    cols.setdefault("date", col)
+            if {"tech", "hours", "assignment"}.issubset(cols):
+                cols.setdefault("date", 1)
+                return row, depth, cols
+    return None
+
+
+def read_allocation_records(path: str, months: Optional[Iterable[str]] = None) -> List[AllocationRecord]:
+    """Read reviewed task labels from rich or two-line Neuron tracker tabs."""
+    from openpyxl import load_workbook
+
+    allowed = set(months or [])
+    wb = load_workbook(path, read_only=True, data_only=True)
+    records: List[AllocationRecord] = []
+    try:
+        for ws in wb.worksheets:
+            found = _allocation_header(ws)
+            if not found:
+                continue
+            header_row, depth, cols = found
+            current: Optional[date] = None
+            pending: List[Tuple[int, str, float, str]] = []
+
+            def add(work_date: date, row: int, tech: str, hours: float, assignment: str) -> None:
+                key = f"{work_date.year:04d}-{work_date.month:02d}"
+                if not allowed or key in allowed:
+                    records.append(AllocationRecord(work_date, tech, hours, assignment, ws.title, row))
+
+            for row in range(header_row + depth, (ws.max_row or 0) + 1):
+                locator = ws.cell(row, cols["date"]).value
+                parsed = _date(locator)
+                if str(locator or "").strip().casefold() in _WEEKDAYS:
+                    current = None
+                if parsed:
+                    current = parsed
+                    for pending_row, tech, hours, assignment in pending:
+                        add(current, pending_row, tech, hours, assignment)
+                    pending.clear()
+                tech = str(ws.cell(row, cols["tech"]).value or "").strip()
+                hours = _hours(ws.cell(row, cols["hours"]).value)
+                assignment = str(ws.cell(row, cols["assignment"]).value or "").strip()
+                if not tech or hours is None or not assignment:
+                    continue
+                if current:
+                    add(current, row, tech, hours, assignment)
+                else:
+                    pending.append((row, tech, hours, assignment))
+    finally:
+        wb.close()
+    return records
+
+
+def apply_allocation_source(
+    resolution: BonitaResolution,
+    allocation_path: str,
+    months: Sequence[str],
+    *,
+    strict: bool = True,
+) -> Tuple[BonitaResolution, AllocationOverlayStats]:
+    records = read_allocation_records(allocation_path, months)
+    exact: Dict[Tuple[date, str, float], List[int]] = defaultdict(list)
+    loose: Dict[Tuple[date, str], List[int]] = defaultdict(list)
+    for idx, record in enumerate(records):
+        exact[(record.work_date, _name(record.tech), record.hours)].append(idx)
+        loose[(record.work_date, _name(record.tech))].append(idx)
+    used: set[int] = set()
+    unmatched: List[str] = []
+    updated: List[BonitaShift] = []
+
+    def take(indices: Iterable[int]) -> Optional[int]:
+        for idx in indices:
+            if idx not in used:
+                used.add(idx)
+                return idx
+        return None
+
+    for shift in resolution.shifts:
+        idx = take(exact.get((shift.date, _name(shift.tech), round(shift.total_hours, 2)), ()))
+        if idx is None:
+            idx = take(loose.get((shift.date, _name(shift.tech)), ()))
+        if idx is None:
+            unmatched.append(f"{shift.date}|{shift.tech}|{shift.total_hours:.2f}")
+            updated.append(shift)
+            continue
+        record = records[idx]
+        updated.append(replace(
+            shift,
+            assignment_type=record.assignment,
+            assignment_rule=f"allocation-source:{record.sheet}!{record.row}",
+            assignment_confidence="high",
+        ))
+    if strict and unmatched:
+        raise ValueError(
+            "allocation source did not reconcile every roster-derived shift: "
+            f"{len(unmatched)} unmatched ({', '.join(unmatched[:5])})"
+        )
+    warnings = list(resolution.warnings)
+    if unmatched:
+        warnings.append(f"allocation_source_unmatched:{len(unmatched)}")
+    unused = len(records) - len(used)
+    if unused:
+        warnings.append(f"allocation_source_unused_rows:{unused}")
+    return (
+        BonitaResolution(shifts=updated, review=list(resolution.review), warnings=warnings),
+        AllocationOverlayStats(str(Path(allocation_path).resolve()), len(used), len(unmatched), unused, strict),
+    )
+
+
+def _month_tab(key: str) -> str:
+    year, month = (int(part) for part in key.split("-"))
+    return f"{month_name[month]} {year}"
+
+
+def _sorted(shifts: Iterable[BonitaShift]) -> List[BonitaShift]:
+    return sorted(shifts, key=lambda shift: (shift.date, _name(shift.tech), shift.clock_in))
+
+
+def _supporting(shift: BonitaShift) -> str:
+    primary = shift.assignment_type or "Configurations"
+    lanes = [primary, "Configurations", "Inventory Management", "Survey", "Ticket Forwarding"]
+    if primary == "Deployments":
+        lanes.append("Deployments")
+    return "; ".join(dict.fromkeys(lane for lane in lanes if lane))
+
+
+def _narrative(shift: BonitaShift) -> str:
+    assignment = shift.assignment_type or "Configurations"
+    lead = {
+        "Configurations": "Performed configuration, validation, remediation, and readiness work.",
+        "Inventory Management": "Performed inventory reconciliation, staging, count review, and material-readiness work.",
+        "Survey": "Performed survey and validation work, including readiness/context capture.",
+        "Ticket Forwarding": "Forwarded, routed, and tracked operational tickets or reported issues.",
+        "Deployments": "Provided client-facing deployment coverage, field coordination, and handoff support.",
+        "Logistics": "Coordinated material movement, staging, delivery, or cleanup.",
+        "Client Coordination": "Performed client coordination, status follow-up, and workflow alignment.",
+        "Documentation": "Produced operational documentation, reporting, and handoff records.",
+        "Troubleshooting / Incident Response": "Performed troubleshooting, incident response, remediation, and readiness validation.",
+    }.get(assignment, f"Performed {assignment.casefold()} work.")
+    source = "reconciled local allocation workbook" if shift.assignment_rule.startswith("allocation-source:") else "roster ruleset"
+    return (
+        f"{lead} Assignment classification comes from the {source}. Date, technician, "
+        "and billed hours come from the roster log; no unrecorded site, room, device, "
+        "ticket, hostname, quantity, or incident detail was inferred."
+    )
+
+
+def _event_type(assignment: str) -> str:
+    return {
+        "Configurations": "Configuration / Readiness",
+        "Inventory Management": "Inventory Reconciliation / Staging",
+        "Survey": "Survey / Validation",
+        "Ticket Forwarding": "Ticket Routing / Follow-Up",
+        "Deployments": "Deployment Coverage",
+        "Logistics": "Logistics / Material Flow",
+        "Client Coordination": "Client Follow-Up",
+        "Documentation": "Reporting / Documentation",
+        "Troubleshooting / Incident Response": "Root Cause / Remediation",
+    }.get(assignment, assignment or "Recorded Work")
+
+
+def _case_id(shift: BonitaShift, ordinal: int) -> str:
+    slug = re.sub(r"[^A-Z0-9]+", "-", shift.tech.upper()).strip("-")[:18]
+    return f"NTH-{shift.date:%Y%m%d}-{slug}-{ordinal:02d}"
+
+
+def _fill_task_cells(ws, start_row: int, task_col: int, end_col: int) -> None:
+    from openpyxl.styles import PatternFill
+
+    for row in range(start_row, (ws.max_row or 0) + 1):
+        task = str(ws.cell(row, task_col).value or "")
+        fill = CATEGORY_FILLS.get(task)
+        if fill:
+            for col in range(task_col, end_col + 1):
+                ws.cell(row, col).fill = PatternFill("solid", fgColor=fill)
+
+
+def _month_rows(shifts: Sequence[BonitaShift]) -> List[Dict[str, Any]]:
+    return [{
+        "Date": shift.date,
+        "Day": shift.day,
+        "Tech Name": shift.tech,
+        "Start Time": shift.start_time or shift.clock_in,
+        "End Time": shift.end_time or shift.clock_out,
+        "Total Hours": round(shift.total_hours, 2),
+        "Project Name": shift.project_name,
+        "Task / Assignment Type": shift.assignment_type,
+        "Supporting Work / Notes": _supporting(shift),
+    } for shift in _sorted(shifts)]
+
+
+def _write_month(wb, key: str, shifts: Sequence[BonitaShift]) -> str:
+    from openpyxl.styles import Alignment
+    from openpyxl.utils import get_column_letter
+
+    title = _month_tab(key)
+    ws = wb.create_sheet(title)
+    _title_band(ws, f"{title} Neuron Track Hours", "Roster-derived clock truth with reconciled task allocation.", len(MONTH_HEADERS))
+    _, last = _add_table(ws, f"NTH{key.replace('-', '')}Table", MONTH_HEADERS, _month_rows(shifts), header_row=4)
+    for row in range(5, last + 1):
+        ws.cell(row, 1).number_format = "yyyy-mm-dd"
+        ws.cell(row, 4).number_format = "h:mm AM/PM"
+        ws.cell(row, 5).number_format = "h:mm AM/PM"
+        ws.cell(row, 6).number_format = "0.00"
+        ws.cell(row, 9).alignment = Alignment(wrap_text=True, vertical="top")
+    _fill_task_cells(ws, 5, 8, 9)
+    for col, width in enumerate([13, 10, 25, 13, 13, 12, 24, 26, 58], 1):
+        ws.column_dimensions[get_column_letter(col)].width = width
+    ws.sheet_view.showGridLines = False
+    return title
+
+
+def _aggregate(shifts: Sequence[BonitaShift]):
+    tech: Dict[str, float] = defaultdict(float)
+    tasks: Dict[str, float] = defaultdict(float)
+    counts: Dict[str, int] = defaultdict(int)
+    daily: Dict[date, float] = defaultdict(float)
+    for shift in shifts:
+        tech[shift.tech] += shift.total_hours
+        tasks[shift.assignment_type] += shift.total_hours
+        counts[shift.assignment_type] += 1
+        daily[shift.date] += shift.total_hours
+    return tech, tasks, counts, daily
+
+
+def _write_visual(wb, shifts: Sequence[BonitaShift]) -> None:
+    from openpyxl.styles import Font, PatternFill
+
+    ws = wb.create_sheet("Visual Summary")
+    _title_band(ws, "Neuron Track Hours — Visual Summary", "Technician, task, and daily roster reconciliation.", 12)
+    total = round(sum(shift.total_hours for shift in shifts), 2)
+    tech, tasks, counts, daily = _aggregate(shifts)
+    ws["A4"], ws["B4"], ws["C4"], ws["D4"] = "MTD HOURS", total, "SHIFT RECORDS", len(shifts)
+    for cell in ws[4]:
+        if cell.column <= 4:
+            cell.fill = PatternFill("solid", fgColor="1F4E78")
+            cell.font = Font(bold=True, color="FFFFFF")
+    tech_rows = [{"Technician": name, "Total Hours": round(hours, 2)} for name, hours in sorted(tech.items(), key=lambda item: -item[1])]
+    task_rows = [{"Task / Assignment Type": task, "Hours": round(hours, 2), "Row Count": counts[task]} for task, hours in sorted(tasks.items(), key=lambda item: (CATEGORY_ORDER.index(item[0]) if item[0] in CATEGORY_ORDER else 99, -item[1]))]
+    daily_rows = [{"Date": work_date, "Hours": round(hours, 2)} for work_date, hours in sorted(daily.items())]
+    _, tech_last = _add_table(ws, "VisualTechTable", ["Technician", "Total Hours"], tech_rows, header_row=7)
+    _, task_last = _add_table(ws, "VisualTaskTable", ["Task / Assignment Type", "Hours", "Row Count"], task_rows, header_row=7, start_col=5)
+    _add_table(ws, "VisualDailyTable", ["Date", "Hours"], daily_rows, header_row=7, start_col=10)
+    _fill_task_cells(ws, 8, 5, 7)
+    _add_net_chart(ws, "Hours by Technician", ["Technician", "Total Hours"], 7, tech_last, "A16", category_col=1, value_header="Total Hours")
+    _add_net_chart(ws, "Hours by Assignment", ["Task / Assignment Type", "Hours", "Row Count"], 7, task_last, "H16", category_col=5, value_header="Hours")
+    ws.sheet_view.showGridLines = False
+
+
+def _write_dashboard(wb, shifts: Sequence[BonitaShift]) -> None:
+    ws = wb.create_sheet("Executive Dashboard")
+    _title_band(ws, "Neuron Track Hours Executive Dashboard", "Roster, narrative, and event-log totals must reconcile.", 8)
+    total = round(sum(shift.total_hours for shift in shifts), 2)
+    tech, tasks, counts, _ = _aggregate(shifts)
+    _add_table(ws, "EvidenceKpiTable", ["Metric", "Value"], [
+        {"Metric": "Month-to-Date Hours", "Value": total},
+        {"Metric": "Shift Records", "Value": len(shifts)},
+        {"Metric": "Technicians", "Value": len(tech)},
+        {"Metric": "Daily Narrative Rows", "Value": len(shifts)},
+        {"Metric": "Event Rows", "Value": len(shifts)},
+        {"Metric": "Status", "Value": "ALIGNED"},
+    ], header_row=5)
+    task_rows = [{"Assignment Type": task, "Hours": round(hours, 2), "Rows": counts[task]} for task, hours in sorted(tasks.items(), key=lambda item: -item[1])]
+    _add_table(ws, "EvidenceTaskMixTable", ["Assignment Type", "Hours", "Rows"], task_rows, header_row=5, start_col=5)
+    _fill_task_cells(ws, 6, 5, 7)
+    ws["A14"] = "Evidence Boundary"
+    ws["A15"] = "Roster clock truth > optional allocation overlay > deterministic narrative. No unrecorded operational specifics are inferred. Task Summary is intentionally omitted because Visual Summary already contains the task mix."
+    ws["A15"].alignment = __import__("openpyxl").styles.Alignment(wrap_text=True)
+    ws.sheet_view.showGridLines = False
+
+
+def _write_narrative(wb, shifts: Sequence[BonitaShift]) -> None:
+    rows = [{
+        "Date": shift.date,
+        "Day": shift.date.strftime("%A"),
+        "Person": shift.tech,
+        "Site": f"{shift.project_name} (specific site not recorded)",
+        "Primary Workstream": shift.assignment_type,
+        "Method / Detail": _narrative(shift),
+        "Record State": "Roster-derived; allocation-source override" if shift.assignment_rule.startswith("allocation-source:") else "Roster-derived; ruleset classification",
+    } for shift in _sorted(shifts)]
+    ws = wb.create_sheet("Daily Narrative Log")
+    _title_band(ws, "Neuron Track Hours | Daily Narrative Log", "One row per roster-derived technician shift.", len(NARRATIVE_HEADERS))
+    _add_table(ws, "DailyNarrativeLogTable", NARRATIVE_HEADERS, rows, header_row=4)
+    for row in range(5, (ws.max_row or 0) + 1):
+        ws.cell(row, 1).number_format = "yyyy-mm-dd"
+    _fill_task_cells(ws, 5, 5, 5)
+    ws.column_dimensions["F"].width = 95
+    ws.column_dimensions["G"].width = 34
+    ws.sheet_view.showGridLines = False
+
+
+def _write_events(wb, shifts: Sequence[BonitaShift]) -> None:
+    ordinals: Dict[Tuple[date, str], int] = defaultdict(int)
+    rows: List[Dict[str, Any]] = []
+    for shift in _sorted(shifts):
+        key = (shift.date, _name(shift.tech))
+        ordinals[key] += 1
+        source = f"Local roster log + allocation overlay ({shift.assignment_rule.split(':', 1)[1]})" if shift.assignment_rule.startswith("allocation-source:") else f"Local roster log + roster rules ({shift.assignment_rule or 'default'})"
+        rows.append({
+            "Event Date": shift.date,
+            "Week Start": shift.date - timedelta(days=shift.date.weekday()),
+            "Person": shift.tech,
+            "Base of Operations": shift.project_name,
+            "Room / Area": "Not recorded in roster",
+            "Case ID": _case_id(shift, ordinals[key]),
+            "Workstream": shift.assignment_type,
+            "Event Type": _event_type(shift.assignment_type),
+            "Task Category": shift.assignment_type,
+            "Quantity": 1,
+            "Unit Type": "Shift",
+            "Window Code": "",
+            "Std Hours / Unit": "",
+            "Fixed Overhead Hrs": "",
+            "Complexity Factor": "",
+            "Disruption Factor": "",
+            "Travel / Transit Hrs": "",
+            "Modeled Hours": "",
+            "Suggested Hours": "",
+            "Actual Billed Hours": round(shift.total_hours, 2),
+            "Variance Hrs": "",
+            "Billable Flag": "Yes",
+            "Narrative Tag": "Ruleset-Based Reconstruction",
+            "Primary Hostname": "",
+            "Related Asset / Hostname": "",
+            "Evidence Source": source,
+            "Notes": _narrative(shift),
+        })
+    ws = wb.create_sheet("Event Log")
+    _title_band(ws, "Event Log | Roster-Linked Tech Hours", "One row per shift; modeled/sample fields remain blank.", len(EVENT_HEADERS))
+    _add_table(ws, "EventLogTable", EVENT_HEADERS, rows, header_row=5)
+    for row in range(6, (ws.max_row or 0) + 1):
+        ws.cell(row, 1).number_format = "yyyy-mm-dd"
+        ws.cell(row, 2).number_format = "yyyy-mm-dd"
+        ws.cell(row, 20).number_format = "0.00"
+    _fill_task_cells(ws, 6, 7, 9)
+    ws.column_dimensions["Z"].width = 46
+    ws.column_dimensions["AA"].width = 95
+    ws.sheet_view.showGridLines = False
+
+
+def build_evidence_pack(resolution: BonitaResolution, months: Sequence[str], out_path: str) -> Tuple[str, List[str]]:
+    from openpyxl import Workbook
+
+    wb = Workbook()
+    wb.remove(wb.active)
+    tabs: List[str] = []
+    for key in months:
+        year, month = (int(part) for part in key.split("-"))
+        tabs.append(_write_month(wb, key, [shift for shift in resolution.shifts if shift.date.year == year and shift.date.month == month]))
+    shifts = _sorted(resolution.shifts)
+    _write_visual(wb, shifts)
+    _write_dashboard(wb, shifts)
+    _write_narrative(wb, shifts)
+    _write_events(wb, shifts)
+    tabs.extend(["Visual Summary", "Executive Dashboard", "Daily Narrative Log", "Event Log"])
+    Path(out_path).parent.mkdir(parents=True, exist_ok=True)
+    wb.save(out_path)
+    wb.close()
+    fix_inlinestr(out_path)
+    return out_path, tabs
+
+
+def _sharedstrings(z: zipfile.ZipFile) -> bool:
+    if "xl/sharedStrings.xml" not in z.namelist():
+        return True
+    text = z.read("xl/sharedStrings.xml").decode("utf-8", errors="ignore")
+    match = re.search(r'\bcount="(\d+)"', text)
+    declared = int(match.group(1)) if match else -1
+    actual = sum(z.read(name).count(b't="s"') for name in z.namelist() if name.startswith("xl/worksheets/sheet") and name.endswith(".xml"))
+    return declared == actual
+
+
+def preflight_evidence_pack(path: str, months: Sequence[str], *, expected_shift_count: int, expected_total_hours: float) -> Dict[str, Any]:
+    from openpyxl import load_workbook
+
+    required = [_month_tab(key) for key in months] + ["Visual Summary", "Executive Dashboard", "Daily Narrative Log", "Event Log"]
+    result: Dict[str, Any] = {
+        "artifact": Path(path).name, "tabs": [], "required_tabs": required,
+        "zip_valid": False, "token_failures": [], "task_summary_absent": False,
+        "month_shift_count": 0, "month_total_hours": 0.0,
+        "daily_narrative_rows": 0, "event_rows": 0,
+        "event_actual_billed_hours": 0.0, "preflight_pass": False,
+    }
+    try:
+        with zipfile.ZipFile(path) as z:
+            result["zip_valid"] = z.testzip() is None
+            names = z.namelist()
+            result["has_calc_chain"] = "xl/calcChain.xml" in names
+            result["has_external_links"] = any("externalLink" in name for name in names)
+            xml = b"".join(z.read(name) for name in names if name.endswith((".xml", ".rels")))
+            if b' t="inlineStr"' in xml:
+                result["token_failures"].append("inlineStr")
+            if b"ns0:" in xml or b"xmlns:ns0" in xml:
+                result["token_failures"].append("ns0")
+            result["sharedstrings_count_ok"] = _sharedstrings(z)
+    except (FileNotFoundError, zipfile.BadZipFile):
+        return result
+
+    wb = load_workbook(path, read_only=True, data_only=True)
+    try:
+        result["tabs"] = list(wb.sheetnames)
+        result["task_summary_absent"] = "Task Summary" not in wb.sheetnames
+        for tab in required[:len(months)]:
+            if tab not in wb.sheetnames:
+                continue
+            for row in wb[tab].iter_rows(min_row=5, values_only=True):
+                hours = _hours(row[5] if len(row) > 5 else None)
+                if hours is not None and len(row) > 2 and row[2]:
+                    result["month_shift_count"] += 1
+                    result["month_total_hours"] += hours
+        result["month_total_hours"] = round(result["month_total_hours"], 2)
+        if "Daily Narrative Log" in wb.sheetnames:
+            result["daily_narrative_rows"] = sum(1 for row in wb["Daily Narrative Log"].iter_rows(min_row=5, values_only=True) if len(row) > 2 and row[2])
+        if "Event Log" in wb.sheetnames:
+            for row in wb["Event Log"].iter_rows(min_row=6, values_only=True):
+                hours = _hours(row[19] if len(row) > 19 else None)
+                if hours is not None and len(row) > 2 and row[2]:
+                    result["event_rows"] += 1
+                    result["event_actual_billed_hours"] += hours
+            result["event_actual_billed_hours"] = round(result["event_actual_billed_hours"], 2)
+    finally:
+        wb.close()
+
+    expected_total = round(expected_total_hours, 2)
+    result["preflight_pass"] = all([
+        result["zip_valid"], not result["token_failures"],
+        not result.get("has_calc_chain"), not result.get("has_external_links"),
+        result.get("sharedstrings_count_ok"), result["tabs"] == required,
+        result["task_summary_absent"], result["month_shift_count"] == expected_shift_count,
+        result["month_total_hours"] == expected_total,
+        result["daily_narrative_rows"] == expected_shift_count,
+        result["event_rows"] == expected_shift_count,
+        result["event_actual_billed_hours"] == expected_total,
+    ])
+    return result

--- a/triage/nw_prj_neuron_track_hours/evidence_pack.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack.py
@@ -249,11 +249,13 @@ def _sorted(shifts: Iterable[BonitaShift]) -> List[BonitaShift]:
 
 
 def _supporting(shift: BonitaShift) -> str:
-    primary = shift.assignment_type or "Configurations"
-    lanes = [primary, "Configurations", "Inventory Management", "Survey", "Ticket Forwarding"]
-    if primary == "Deployments":
-        lanes.append("Deployments")
-    return "; ".join(dict.fromkeys(lane for lane in lanes if lane))
+    assignment = str(shift.assignment_type or "").strip()
+    if not assignment:
+        return "No assignment classification recorded."
+    return (
+        f"Assignment classification: {assignment}. "
+        "No additional operational detail is asserted."
+    )
 
 
 def _narrative(shift: BonitaShift) -> str:

--- a/triage/nw_prj_neuron_track_hours/evidence_pack.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack.py
@@ -196,10 +196,8 @@ def apply_allocation_source(
 ) -> Tuple[BonitaResolution, AllocationOverlayStats]:
     records = read_allocation_records(allocation_path, months)
     exact: Dict[Tuple[date, str, float], List[int]] = defaultdict(list)
-    loose: Dict[Tuple[date, str], List[int]] = defaultdict(list)
     for idx, record in enumerate(records):
         exact[(record.work_date, _name(record.tech), record.hours)].append(idx)
-        loose[(record.work_date, _name(record.tech))].append(idx)
     used: set[int] = set()
     unmatched: List[str] = []
     updated: List[BonitaShift] = []
@@ -213,8 +211,6 @@ def apply_allocation_source(
 
     for shift in resolution.shifts:
         idx = take(exact.get((shift.date, _name(shift.tech), round(shift.total_hours, 2)), ()))
-        if idx is None:
-            idx = take(loose.get((shift.date, _name(shift.tech)), ()))
         if idx is None:
             unmatched.append(f"{shift.date}|{shift.tech}|{shift.total_hours:.2f}")
             updated.append(shift)

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
@@ -1,0 +1,210 @@
+"""CLI for the roster-derived Neuron billing evidence pack.
+
+Example:
+
+    python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli \
+        --roster-log "Candidates/Active Roster Log.xlsx" \
+        --months 2026-07 \
+        --allocation-source "Candidates/Neuron Track Hours - July 2026.xlsx" \
+        --out-dir "Outputs/neuron_billing_evidence_pack/2026-07"
+
+The roster log is always clock/hour truth.  ``--allocation-source`` is optional
+and may override only the task/assignment classification after exact shift
+reconciliation.  Real operator workbooks remain local and gitignored.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import re
+from calendar import month_name
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from triage.month_validation import validate_month_key
+from triage.one_marcus_recon.path_guard import assert_output_path_allowed
+from triage.nw_prj_neuron_track_hours.bonita_resolver import resolve_bonita_shifts
+from triage.nw_prj_neuron_track_hours.evidence_pack import (
+    AllocationOverlayStats,
+    apply_allocation_source,
+    build_evidence_pack,
+    preflight_evidence_pack,
+)
+
+DEFAULT_OUT_DIR = "Outputs/neuron_billing_evidence_pack"
+
+
+def _resolve(value: Optional[str], root: Path) -> Optional[Path]:
+    if not value:
+        return None
+    path = Path(value)
+    return path.resolve() if path.is_absolute() else (root / path).resolve()
+
+
+def _normalized_months(months: Sequence[str]) -> List[str]:
+    result: List[str] = []
+    seen: set[str] = set()
+    for value in months:
+        year, mon = validate_month_key(value)
+        key = f"{year:04d}-{mon:02d}"
+        if key not in seen:
+            result.append(key)
+            seen.add(key)
+    if not result:
+        raise ValueError("at least one --months value is required")
+    return result
+
+
+def _artifact_name(months: Sequence[str]) -> str:
+    labels: List[str] = []
+    years: List[int] = []
+    for key in months:
+        year, mon = (int(part) for part in key.split("-"))
+        labels.append(month_name[mon])
+        years.append(year)
+    if len(set(years)) == 1:
+        period = "_".join(labels + [str(years[0])])
+    else:
+        period = "_".join(
+            f"{month_name[int(key.split('-')[1])]}_{key.split('-')[0]}" for key in months
+        )
+    period = re.sub(r"[^A-Za-z0-9_]+", "_", period).strip("_")
+    return f"Neuron_Track_Hours_{period}_Evidence_Pack.xlsx"
+
+
+def _assert_source_safe(source: Path, output: Path, label: str) -> None:
+    try:
+        same = source.resolve() == output.resolve()
+    except FileNotFoundError:
+        same = False
+    if same:
+        raise ValueError(f"{label} may not be overwritten: {source}")
+
+
+def run(
+    roster_log: str,
+    out_dir: str = DEFAULT_OUT_DIR,
+    months: Optional[Sequence[str]] = None,
+    *,
+    allocation_source: Optional[str] = None,
+    strict_allocation_source: bool = True,
+    repo_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Generate the workbook, manifest, and focused preflight report."""
+    root = (repo_root or Path(__file__).resolve().parents[2]).resolve()
+    month_keys = _normalized_months(list(months or []))
+    roster_path = _resolve(roster_log, root)
+    if roster_path is None or not roster_path.is_file():
+        raise FileNotFoundError(f"roster-log not found: {roster_path}")
+    allocation_path = _resolve(allocation_source, root)
+    if allocation_source and (allocation_path is None or not allocation_path.is_file()):
+        raise FileNotFoundError(f"allocation-source not found: {allocation_path}")
+    output_dir = _resolve(out_dir, root) or (root / DEFAULT_OUT_DIR)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    workbook_path = output_dir / _artifact_name(month_keys)
+    assert_output_path_allowed(str(roster_path), str(workbook_path))
+    _assert_source_safe(roster_path, workbook_path, "roster log")
+    if allocation_path:
+        _assert_source_safe(allocation_path, workbook_path, "allocation source")
+
+    resolution = resolve_bonita_shifts(str(roster_path), month_keys)
+    overlay = AllocationOverlayStats(strict=strict_allocation_source)
+    if allocation_path:
+        resolution, overlay = apply_allocation_source(
+            resolution,
+            str(allocation_path),
+            month_keys,
+            strict=strict_allocation_source,
+        )
+
+    _, tabs = build_evidence_pack(resolution, month_keys, str(workbook_path))
+    expected_total = resolution.grand_total()
+    preflight = preflight_evidence_pack(
+        str(workbook_path),
+        month_keys,
+        expected_shift_count=len(resolution.shifts),
+        expected_total_hours=expected_total,
+    )
+    preflight_path = output_dir / f"{workbook_path.stem}_preflight.json"
+    preflight_path.write_text(
+        json.dumps(preflight, indent=2, default=str), encoding="utf-8"
+    )
+
+    per_month: Dict[str, Dict[str, Any]] = {}
+    for key in month_keys:
+        year, mon = (int(part) for part in key.split("-"))
+        shifts = [
+            shift
+            for shift in resolution.shifts
+            if shift.date.year == year and shift.date.month == mon
+        ]
+        per_month[key] = {
+            "sheet": f"{month_name[mon]} {year}",
+            "shift_count": len(shifts),
+            "total_hours": round(sum(s.total_hours for s in shifts), 2),
+        }
+
+    manifest: Dict[str, Any] = {
+        "engine": "triage.nw_prj_neuron_track_hours.evidence_pack_cli",
+        "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "roster_log": str(roster_path),
+        "allocation_source": str(allocation_path) if allocation_path else "",
+        "source_hierarchy": [
+            "roster log clock/date/hour truth",
+            "local allocation workbook task label override when supplied",
+            "deterministic audit-safe narrative with no invented specifics",
+        ],
+        "months": month_keys,
+        "tabs": tabs,
+        "per_month": per_month,
+        "shift_count": len(resolution.shifts),
+        "grand_total_hours": expected_total,
+        "daily_narrative_rows": preflight.get("daily_narrative_rows"),
+        "event_rows": preflight.get("event_rows"),
+        "allocation_overlay": overlay.to_dict(),
+        "review_item_count": len(resolution.review),
+        "warnings": resolution.warnings,
+        "outputs": {
+            "workbook": str(workbook_path),
+            "preflight_json": str(preflight_path),
+        },
+        "preflight_pass": bool(preflight.get("preflight_pass")),
+        "preflight": preflight,
+        "proof_level": "fixture/package-level; Excel for Web manual acceptance not proven",
+    }
+    manifest_path = output_dir / f"{workbook_path.stem}_manifest.json"
+    manifest["outputs"]["manifest_json"] = str(manifest_path)
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, default=str), encoding="utf-8"
+    )
+    return manifest
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="triage.nw_prj_neuron_track_hours.evidence_pack_cli"
+    )
+    parser.add_argument("--roster-log", required=True)
+    parser.add_argument("--months", nargs="+", required=True)
+    parser.add_argument("--allocation-source")
+    parser.add_argument(
+        "--allow-unmatched-allocation",
+        action="store_true",
+        help="Keep roster-rule assignments for unmatched shifts instead of failing.",
+    )
+    parser.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
+    args = parser.parse_args(argv)
+    manifest = run(
+        roster_log=args.roster_log,
+        out_dir=args.out_dir,
+        months=args.months,
+        allocation_source=args.allocation_source,
+        strict_allocation_source=not args.allow_unmatched_allocation,
+    )
+    print(json.dumps(manifest, indent=2, default=str))
+    return 0 if manifest["preflight_pass"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
@@ -113,12 +113,12 @@ def run(
     if allocation_policy and (policy_path is None or not policy_path.is_file()):
         raise FileNotFoundError(f"allocation-policy not found: {policy_path}")
     output_dir = _resolve(out_dir, root) or (root / DEFAULT_OUT_DIR)
-    output_dir.mkdir(parents=True, exist_ok=True)
     workbook_path = output_dir / _artifact_name(month_keys)
     assert_output_path_allowed(str(roster_path), str(workbook_path))
     _assert_source_safe(roster_path, workbook_path, "roster log")
     if allocation_path:
         _assert_source_safe(allocation_path, workbook_path, "allocation source")
+    output_dir.mkdir(parents=True, exist_ok=True)
 
     resolution = resolve_bonita_shifts(str(roster_path), month_keys)
     overlay = AllocationOverlayStats(strict=strict_allocation_source)

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
@@ -31,6 +31,10 @@ from triage.nw_prj_neuron_track_hours.evidence_pack import (
     build_evidence_pack,
     preflight_evidence_pack,
 )
+from triage.nw_prj_neuron_track_hours.evidence_pack_finalize import (
+    repair_visual_summary_charts,
+    validate_allocation_source_exact,
+)
 from triage.nw_prj_neuron_track_hours.monthly_allocation import (
     apply_monthly_allocation_policies,
 )
@@ -117,6 +121,16 @@ def run(
         _assert_source_safe(allocation_path, workbook_path, "allocation source")
 
     resolution = resolve_bonita_shifts(str(roster_path), month_keys)
+    overlay = AllocationOverlayStats(strict=strict_allocation_source)
+    if allocation_path:
+        if strict_allocation_source:
+            validate_allocation_source_exact(resolution, str(allocation_path), month_keys)
+        resolution, overlay = apply_allocation_source(
+            resolution,
+            str(allocation_path),
+            month_keys,
+            strict=strict_allocation_source,
+        )
     policy_stats = []
     if apply_monthly_policy:
         resolution, policy_stats = apply_monthly_allocation_policies(
@@ -124,16 +138,9 @@ def run(
             month_keys,
             policy_path=str(policy_path) if policy_path else None,
         )
-    overlay = AllocationOverlayStats(strict=strict_allocation_source)
-    if allocation_path:
-        resolution, overlay = apply_allocation_source(
-            resolution,
-            str(allocation_path),
-            month_keys,
-            strict=strict_allocation_source,
-        )
 
     _, tabs = build_evidence_pack(resolution, month_keys, str(workbook_path))
+    repair_visual_summary_charts(str(workbook_path))
     expected_total = resolution.grand_total()
     preflight = preflight_evidence_pack(
         str(workbook_path),
@@ -168,8 +175,8 @@ def run(
         "allocation_policy": str(policy_path) if policy_path else "repo default",
         "source_hierarchy": [
             "roster log clock/date/hour truth",
-            "repo or local monthly policy for heuristic task allocation",
             "local allocation workbook task label override when supplied",
+            "repo or local monthly policy for remaining heuristic task allocation",
             "deterministic audit-safe narrative with no invented specifics",
         ],
         "months": month_keys,

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
@@ -114,10 +114,17 @@ def run(
         raise FileNotFoundError(f"allocation-policy not found: {policy_path}")
     output_dir = _resolve(out_dir, root) or (root / DEFAULT_OUT_DIR)
     workbook_path = output_dir / _artifact_name(month_keys)
-    assert_output_path_allowed(str(roster_path), str(workbook_path))
-    _assert_source_safe(roster_path, workbook_path, "roster log")
+    preflight_path = output_dir / f"{workbook_path.stem}_preflight.json"
+    manifest_path = output_dir / f"{workbook_path.stem}_manifest.json"
+    sources = [(roster_path, "roster log")]
     if allocation_path:
-        _assert_source_safe(allocation_path, workbook_path, "allocation source")
+        sources.append((allocation_path, "allocation source"))
+    if policy_path:
+        sources.append((policy_path, "allocation policy"))
+    for output_path in (workbook_path, preflight_path, manifest_path):
+        assert_output_path_allowed(str(roster_path), str(output_path))
+        for source_path, label in sources:
+            _assert_source_safe(source_path, output_path, label)
     output_dir.mkdir(parents=True, exist_ok=True)
 
     resolution = resolve_bonita_shifts(str(roster_path), month_keys)
@@ -148,7 +155,6 @@ def run(
         expected_shift_count=len(resolution.shifts),
         expected_total_hours=expected_total,
     )
-    preflight_path = output_dir / f"{workbook_path.stem}_preflight.json"
     preflight_path.write_text(
         json.dumps(preflight, indent=2, default=str), encoding="utf-8"
     )
@@ -198,7 +204,6 @@ def run(
         "preflight": preflight,
         "proof_level": "fixture/package-level; Excel for Web manual acceptance not proven",
     }
-    manifest_path = output_dir / f"{workbook_path.stem}_manifest.json"
     manifest["outputs"]["manifest_json"] = str(manifest_path)
     manifest_path.write_text(
         json.dumps(manifest, indent=2, default=str), encoding="utf-8"
@@ -213,10 +218,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--roster-log", required=True)
     parser.add_argument("--months", nargs="+", required=True)
     parser.add_argument("--allocation-source")
-    parser.add_argument(
-        "--allocation-policy",
-        help="Optional local monthly allocation policy JSON",
-    )
+    parser.add_argument("--allocation-policy", help="Optional local monthly allocation policy JSON")
     parser.add_argument(
         "--no-monthly-policy",
         action="store_true",

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_cli.py
@@ -5,12 +5,12 @@ Example:
     python -m triage.nw_prj_neuron_track_hours.evidence_pack_cli \
         --roster-log "Candidates/Active Roster Log.xlsx" \
         --months 2026-07 \
-        --allocation-source "Candidates/Neuron Track Hours - July 2026.xlsx" \
         --out-dir "Outputs/neuron_billing_evidence_pack/2026-07"
 
-The roster log is always clock/hour truth.  ``--allocation-source`` is optional
-and may override only the task/assignment classification after exact shift
-reconciliation.  Real operator workbooks remain local and gitignored.
+The roster log is always clock/hour truth. Repo month policies distribute only
+heuristic assignments. ``--allocation-source`` is optional and may override only
+the task label after exact shift reconciliation. Real operator workbooks remain
+local and gitignored.
 """
 from __future__ import annotations
 
@@ -30,6 +30,9 @@ from triage.nw_prj_neuron_track_hours.evidence_pack import (
     apply_allocation_source,
     build_evidence_pack,
     preflight_evidence_pack,
+)
+from triage.nw_prj_neuron_track_hours.monthly_allocation import (
+    apply_monthly_allocation_policies,
 )
 
 DEFAULT_OUT_DIR = "Outputs/neuron_billing_evidence_pack"
@@ -88,6 +91,8 @@ def run(
     months: Optional[Sequence[str]] = None,
     *,
     allocation_source: Optional[str] = None,
+    allocation_policy: Optional[str] = None,
+    apply_monthly_policy: bool = True,
     strict_allocation_source: bool = True,
     repo_root: Optional[Path] = None,
 ) -> Dict[str, Any]:
@@ -98,8 +103,11 @@ def run(
     if roster_path is None or not roster_path.is_file():
         raise FileNotFoundError(f"roster-log not found: {roster_path}")
     allocation_path = _resolve(allocation_source, root)
+    policy_path = _resolve(allocation_policy, root)
     if allocation_source and (allocation_path is None or not allocation_path.is_file()):
         raise FileNotFoundError(f"allocation-source not found: {allocation_path}")
+    if allocation_policy and (policy_path is None or not policy_path.is_file()):
+        raise FileNotFoundError(f"allocation-policy not found: {policy_path}")
     output_dir = _resolve(out_dir, root) or (root / DEFAULT_OUT_DIR)
     output_dir.mkdir(parents=True, exist_ok=True)
     workbook_path = output_dir / _artifact_name(month_keys)
@@ -109,6 +117,13 @@ def run(
         _assert_source_safe(allocation_path, workbook_path, "allocation source")
 
     resolution = resolve_bonita_shifts(str(roster_path), month_keys)
+    policy_stats = []
+    if apply_monthly_policy:
+        resolution, policy_stats = apply_monthly_allocation_policies(
+            resolution,
+            month_keys,
+            policy_path=str(policy_path) if policy_path else None,
+        )
     overlay = AllocationOverlayStats(strict=strict_allocation_source)
     if allocation_path:
         resolution, overlay = apply_allocation_source(
@@ -150,8 +165,10 @@ def run(
         "generated_utc": _dt.datetime.now(_dt.timezone.utc).isoformat(),
         "roster_log": str(roster_path),
         "allocation_source": str(allocation_path) if allocation_path else "",
+        "allocation_policy": str(policy_path) if policy_path else "repo default",
         "source_hierarchy": [
             "roster log clock/date/hour truth",
+            "repo or local monthly policy for heuristic task allocation",
             "local allocation workbook task label override when supplied",
             "deterministic audit-safe narrative with no invented specifics",
         ],
@@ -162,6 +179,7 @@ def run(
         "grand_total_hours": expected_total,
         "daily_narrative_rows": preflight.get("daily_narrative_rows"),
         "event_rows": preflight.get("event_rows"),
+        "monthly_allocation_policies": [item.to_dict() for item in policy_stats],
         "allocation_overlay": overlay.to_dict(),
         "review_item_count": len(resolution.review),
         "warnings": resolution.warnings,
@@ -189,6 +207,15 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument("--months", nargs="+", required=True)
     parser.add_argument("--allocation-source")
     parser.add_argument(
+        "--allocation-policy",
+        help="Optional local monthly allocation policy JSON",
+    )
+    parser.add_argument(
+        "--no-monthly-policy",
+        action="store_true",
+        help="Disable repo/default month allocation policy and use classifier labels only.",
+    )
+    parser.add_argument(
         "--allow-unmatched-allocation",
         action="store_true",
         help="Keep roster-rule assignments for unmatched shifts instead of failing.",
@@ -200,6 +227,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         out_dir=args.out_dir,
         months=args.months,
         allocation_source=args.allocation_source,
+        allocation_policy=args.allocation_policy,
+        apply_monthly_policy=not args.no_monthly_policy,
         strict_allocation_source=not args.allow_unmatched_allocation,
     )
     print(json.dumps(manifest, indent=2, default=str))

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_finalize.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_finalize.py
@@ -37,7 +37,8 @@ def validate_allocation_source_exact(
             for (day, tech, hours), count in list(extra.items())[:5]
         )
         raise ValueError(
-            "allocation source must reconcile exactly by Date + Tech + Hours; "
+            "allocation source did not reconcile every roster-derived shift "
+            "exactly by Date + Tech + Hours; "
             f"missing=[{missing_text}] extra=[{extra_text}]"
         )
 

--- a/triage/nw_prj_neuron_track_hours/evidence_pack_finalize.py
+++ b/triage/nw_prj_neuron_track_hours/evidence_pack_finalize.py
@@ -1,0 +1,100 @@
+"""Final repair-free chart and allocation guards for the evidence-pack CLI."""
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+from typing import Sequence, Tuple
+
+from triage.nw_prj_neuron_track_hours.bonita_resolver import BonitaResolution
+from triage.nw_prj_neuron_track_hours.evidence_pack import read_allocation_records
+from triage.xlsx_utils import fix_inlinestr
+
+
+def _key(work_date, tech: str, hours: float) -> Tuple[object, str, float]:
+    return work_date, " ".join(str(tech or "").split()).casefold(), round(float(hours), 2)
+
+
+def validate_allocation_source_exact(
+    resolution: BonitaResolution,
+    allocation_path: str,
+    months: Sequence[str],
+) -> None:
+    """Require a one-to-one Date + Tech + Hours allocation reconciliation."""
+    expected = Counter(_key(s.date, s.tech, s.total_hours) for s in resolution.shifts)
+    actual = Counter(
+        _key(r.work_date, r.tech, r.hours)
+        for r in read_allocation_records(allocation_path, months)
+    )
+    missing = expected - actual
+    extra = actual - expected
+    if missing or extra:
+        missing_text = ", ".join(
+            f"{day}|{tech}|{hours:.2f} x{count}"
+            for (day, tech, hours), count in list(missing.items())[:5]
+        )
+        extra_text = ", ".join(
+            f"{day}|{tech}|{hours:.2f} x{count}"
+            for (day, tech, hours), count in list(extra.items())[:5]
+        )
+        raise ValueError(
+            "allocation source must reconcile exactly by Date + Tech + Hours; "
+            f"missing=[{missing_text}] extra=[{extra_text}]"
+        )
+
+
+def _last_data_row(ws, column: int, start: int) -> int:
+    row = start
+    while row <= (ws.max_row or start) and ws.cell(row, column).value not in (None, ""):
+        row += 1
+    return row - 1
+
+
+def repair_visual_summary_charts(path: str) -> None:
+    """Rebuild Visual Summary chart references against their actual tables."""
+    from openpyxl import load_workbook
+    from openpyxl.chart import BarChart, Reference
+
+    workbook_path = Path(path)
+    wb = load_workbook(workbook_path)
+    try:
+        if "Visual Summary" not in wb.sheetnames:
+            return
+        ws = wb["Visual Summary"]
+        tech_last = _last_data_row(ws, 1, 8)
+        task_last = _last_data_row(ws, 5, 8)
+        ws._charts = []
+
+        if tech_last >= 8:
+            chart = BarChart()
+            chart.type = "col"
+            chart.title = "Hours by Technician"
+            chart.y_axis.title = "Total Hours"
+            chart.height = 9
+            chart.width = 20
+            chart.add_data(
+                Reference(ws, min_col=2, min_row=7, max_row=tech_last),
+                titles_from_data=True,
+            )
+            chart.set_categories(Reference(ws, min_col=1, min_row=8, max_row=tech_last))
+            chart.legend = None
+            ws.add_chart(chart, "A16")
+
+        if task_last >= 8:
+            chart = BarChart()
+            chart.type = "col"
+            chart.title = "Hours by Assignment"
+            chart.y_axis.title = "Hours"
+            chart.height = 9
+            chart.width = 20
+            chart.add_data(
+                Reference(ws, min_col=6, min_row=7, max_row=task_last),
+                titles_from_data=True,
+            )
+            chart.set_categories(Reference(ws, min_col=5, min_row=8, max_row=task_last))
+            chart.legend = None
+            ws.add_chart(chart, "H16")
+
+        wb.save(workbook_path)
+    finally:
+        wb.close()
+    fix_inlinestr(str(workbook_path))

--- a/triage/nw_prj_neuron_track_hours/monthly_allocation.py
+++ b/triage/nw_prj_neuron_track_hours/monthly_allocation.py
@@ -75,6 +75,10 @@ def _validate_policy(month_key: str, policy: Dict[str, Any]) -> Tuple[List[Tuple
         str(value).strip().casefold()
         for value in policy.get("reallocate_confidence", ["low", "medium"])
     }
+    if "high" in confidence:
+        raise ValueError(
+            f"{month_key}: high-confidence assignments are authoritative and may not be reallocated"
+        )
     deployment = policy.get("deployment") or {}
     if not isinstance(deployment, dict):
         raise ValueError(f"{month_key}: deployment must be an object")

--- a/triage/nw_prj_neuron_track_hours/monthly_allocation.py
+++ b/triage/nw_prj_neuron_track_hours/monthly_allocation.py
@@ -82,6 +82,15 @@ def _validate_policy(month_key: str, policy: Dict[str, Any]) -> Tuple[List[Tuple
     deployment = policy.get("deployment") or {}
     if not isinstance(deployment, dict):
         raise ValueError(f"{month_key}: deployment must be an object")
+    explicit_only = deployment.get("explicit_only", False)
+    if not isinstance(explicit_only, bool):
+        raise ValueError(f"{month_key}: deployment.explicit_only must be a boolean")
+    if explicit_only and any(
+        _normal_name(category) == "deployments" for category, _ in weights
+    ):
+        raise ValueError(
+            f"{month_key}: explicit-only Deployments cannot appear in allocation_weights"
+        )
     return weights, confidence, deployment
 
 

--- a/triage/nw_prj_neuron_track_hours/monthly_allocation.py
+++ b/triage/nw_prj_neuron_track_hours/monthly_allocation.py
@@ -1,0 +1,200 @@
+"""Sanitized month-specific task allocation for roster-derived Neuron shifts.
+
+Policies distribute only heuristic/medium-confidence rows. Explicit high-confidence
+roster evidence is preserved. Deployments are never invented by ratio allocation.
+"""
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from triage.nw_prj_neuron_track_hours.bonita_resolver import BonitaResolution, BonitaShift
+
+DEFAULT_POLICY_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "neuron_billing_evidence_pack"
+    / "monthly_allocation_policies.json"
+)
+
+
+@dataclass(frozen=True)
+class MonthlyPolicyStats:
+    month_key: str
+    policy_name: str
+    applied_shift_count: int
+    preserved_shift_count: int
+    deployment_shift_count: int
+    category_hours: Dict[str, float]
+    policy_path: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "month_key": self.month_key,
+            "policy_name": self.policy_name,
+            "applied_shift_count": self.applied_shift_count,
+            "preserved_shift_count": self.preserved_shift_count,
+            "deployment_shift_count": self.deployment_shift_count,
+            "category_hours": self.category_hours,
+            "policy_path": self.policy_path,
+        }
+
+
+def _normal_name(value: str) -> str:
+    return re.sub(r"\s+", " ", str(value or "").strip()).casefold()
+
+
+def load_monthly_policies(path: Optional[str] = None) -> Tuple[Path, Dict[str, Dict[str, Any]]]:
+    policy_path = Path(path).resolve() if path else DEFAULT_POLICY_PATH.resolve()
+    payload = json.loads(policy_path.read_text(encoding="utf-8"))
+    policies = payload.get("policies")
+    if not isinstance(policies, dict):
+        raise ValueError(f"monthly allocation policy has no policies object: {policy_path}")
+    return policy_path, policies
+
+
+def _month_key(shift: BonitaShift) -> str:
+    return f"{shift.date.year:04d}-{shift.date.month:02d}"
+
+
+def _validate_policy(month_key: str, policy: Dict[str, Any]) -> Tuple[List[Tuple[str, float]], set[str], Dict[str, Any]]:
+    raw_weights = policy.get("allocation_weights")
+    if not isinstance(raw_weights, dict) or not raw_weights:
+        raise ValueError(f"{month_key}: allocation_weights must be a non-empty object")
+    weights: List[Tuple[str, float]] = []
+    for category, value in raw_weights.items():
+        weight = float(value)
+        if weight <= 0:
+            raise ValueError(f"{month_key}: weight for {category!r} must be positive")
+        weights.append((str(category), weight))
+    confidence = {
+        str(value).strip().casefold()
+        for value in policy.get("reallocate_confidence", ["low", "medium"])
+    }
+    deployment = policy.get("deployment") or {}
+    if not isinstance(deployment, dict):
+        raise ValueError(f"{month_key}: deployment must be an object")
+    return weights, confidence, deployment
+
+
+def _choose_category(
+    weights: Sequence[Tuple[str, float]],
+    targets: Dict[str, float],
+    assigned: Dict[str, float],
+) -> str:
+    order = {category: index for index, (category, _) in enumerate(weights)}
+    return max(
+        (category for category, _ in weights),
+        key=lambda category: (targets[category] - assigned.get(category, 0.0), -order[category]),
+    )
+
+
+def apply_monthly_allocation_policies(
+    resolution: BonitaResolution,
+    months: Iterable[str],
+    *,
+    policy_path: Optional[str] = None,
+) -> Tuple[BonitaResolution, List[MonthlyPolicyStats]]:
+    """Apply configured ratios to heuristic shifts, preserving explicit evidence."""
+    resolved_path, policies = load_monthly_policies(policy_path)
+    requested = set(months)
+    grouped: Dict[str, List[BonitaShift]] = defaultdict(list)
+    untouched: List[BonitaShift] = []
+    for shift in resolution.shifts:
+        key = _month_key(shift)
+        if key in requested and key in policies:
+            grouped[key].append(shift)
+        else:
+            untouched.append(shift)
+
+    rewritten: List[BonitaShift] = list(untouched)
+    stats: List[MonthlyPolicyStats] = []
+    warnings = list(resolution.warnings)
+
+    for key in sorted(grouped):
+        policy = policies[key]
+        weights, reallocate_confidence, deployment = _validate_policy(key, policy)
+        categories = {category for category, _ in weights}
+        month_shifts = sorted(grouped[key], key=lambda s: (s.date, _normal_name(s.tech), s.clock_in))
+
+        explicit_deployments = [
+            shift
+            for shift in month_shifts
+            if shift.assignment_type == "Deployments"
+            and shift.assignment_confidence.casefold() not in reallocate_confidence
+        ]
+        max_deployments = int(deployment.get("max_shift_count", 0))
+        if len(explicit_deployments) > max_deployments:
+            raise ValueError(
+                f"{key}: explicit deployment shifts ({len(explicit_deployments)}) exceed "
+                f"policy maximum ({max_deployments}); review roster evidence"
+            )
+        allowed = deployment.get("eligible_techs") or []
+        allowed_names = {_normal_name(value) for value in allowed}
+        if allowed_names:
+            invalid = [shift.tech for shift in explicit_deployments if _normal_name(shift.tech) not in allowed_names]
+            if invalid:
+                raise ValueError(
+                    f"{key}: explicit deployment tech is not allowed by local policy: "
+                    + ", ".join(sorted(set(invalid)))
+                )
+
+        preserved: List[BonitaShift] = []
+        allocatable: List[BonitaShift] = []
+        for shift in month_shifts:
+            confidence = shift.assignment_confidence.casefold()
+            if confidence in reallocate_confidence and shift.assignment_type != "Deployments":
+                allocatable.append(shift)
+            elif confidence in reallocate_confidence and shift.assignment_type == "Deployments":
+                allocatable.append(replace(shift, assignment_type="Configurations"))
+            else:
+                preserved.append(shift)
+
+        assigned: Dict[str, float] = defaultdict(float)
+        for shift in preserved:
+            if shift.assignment_type in categories:
+                assigned[shift.assignment_type] += float(shift.total_hours)
+        weighted_pool = sum(float(shift.total_hours) for shift in allocatable) + sum(assigned.values())
+        total_weight = sum(weight for _, weight in weights)
+        targets = {
+            category: weighted_pool * weight / total_weight
+            for category, weight in weights
+        }
+
+        applied: List[BonitaShift] = []
+        for shift in allocatable:
+            category = _choose_category(weights, targets, assigned)
+            assigned[category] += float(shift.total_hours)
+            applied.append(replace(
+                shift,
+                assignment_type=category,
+                assignment_rule=f"monthly-policy:{key}:{category}",
+                assignment_confidence="medium",
+            ))
+
+        final = sorted(preserved + applied, key=lambda s: (s.date, _normal_name(s.tech), s.clock_in))
+        rewritten.extend(final)
+        category_hours: Dict[str, float] = defaultdict(float)
+        for shift in final:
+            category_hours[shift.assignment_type] += float(shift.total_hours)
+        stats.append(MonthlyPolicyStats(
+            month_key=key,
+            policy_name=str(policy.get("name") or key),
+            applied_shift_count=len(applied),
+            preserved_shift_count=len(preserved),
+            deployment_shift_count=sum(1 for shift in final if shift.assignment_type == "Deployments"),
+            category_hours={category: round(hours, 2) for category, hours in category_hours.items()},
+            policy_path=str(resolved_path),
+        ))
+        warnings.append(f"monthly_allocation_policy_applied:{key}:{len(applied)}")
+
+    rewritten.sort(key=lambda s: (s.date, _normal_name(s.tech), s.clock_in))
+    return BonitaResolution(
+        shifts=rewritten,
+        review=list(resolution.review),
+        warnings=warnings,
+    ), stats


### PR DESCRIPTION
## Sprint
Roster-log billing evidence-pack generation.

## Owned scope
- Generate a full-month Neuron Track Hours workbook from a populated local roster.
- Add Visual Summary, Executive Dashboard, Daily Narrative Log, and Event Log.
- Omit the redundant Task Summary tab.
- Preserve roster date/technician/hour truth.
- Allow an optional local tracker to override task labels only after exact Date + Tech + Hours reconciliation.
- Codify the sanitized July 2026 allocation order for roster-only runs.

## Evidence boundary
- March is used only for Daily Narrative Log and Event Log field grammar.
- No real attendance workbook, employee notes, customer workbook bytes, or generated runtime artifact is committed.
- Site, room, device, ticket, hostname, quantity, incident, travel, complexity, and modeled-hour details are not invented.
- Supporting Work / Notes asserts only the actual assignment classification and explicitly disclaims additional operational detail.
- Deployment is explicit-only under the July policy and capped at one shift; a private local policy may restrict the eligible technician without committing a name.

## Output contract
Ordered tabs:
1. one full-month tab per requested month
2. Visual Summary
3. Executive Dashboard
4. Daily Narrative Log
5. Event Log

The CLI also writes manifest and preflight JSON sidecars under Outputs/. Workbook, preflight, and manifest output paths are checked against every local source before any filesystem mutation.

## Validation
- Focused GitHub Actions lane: **29 passed, 0 failed, 0 skipped**.
- Coverage includes the existing Bonita resolver contract, workbook tab order, row/hour reconciliation, narrative/event totals, exact Date + Tech + Hours overlay matching, wrong-hours rejection, reviewed-label precedence, supporting-note evidence boundaries, chart references, sidecar collision protection, July weighted allocation, explicit-only deployment, deployment cap, and no manufactured deployment weights.
- Local syntax/static smoke: all changed Python modules and tests compile; policy JSON parses; no trailing whitespace.
- All PR review threads are resolved.

## Broader-suite blocker
The existing `artifact-engines` aggregate job remains red with **11 failures in the pre-existing One Marcus tests**. All fail before owned evidence-pack behavior executes because the One Marcus fixture workbook contains an invalid `externalReference` namespace (`Namespace prefix r for id on externalReference is not defined`). The dedicated evidence-pack job is green and the failure is outside this sprint's forbidden scope.

## Proof ceiling
Fixture/package-level until a generated operator workbook is manually opened and accepted in Excel for Web.