### PR TITLE
chore(prompt-kit): merge current V38 base into V39

### DIFF
--- a/.github/workflows/prompt-kit-v21.yml
+++ b/.github/workflows/prompt-kit-v21.yml
@@ -17,6 +17,8 @@ jobs:
           python-version: "3.11"
       - name: Install test dependency
         run: python -m pip install pytest
+      - name: Validate V38 prompt registry
+        run: python -m json.tool configs/prompt_kit/v38_prompt_assets.json
       - name: Import validators and generators
         run: |
           python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; import triage.prompt_kit_contract; import triage.prompt_kit_operability_contract; import triage.prompt_kit_copy_range_links; import triage.prompt_kit_v38_prompt_assets; import triage.prompt_kit_v38_generator; import triage.prompt_kit_v33_generator; import triage.prompt_kit_v33_ooxml; import triage.worksheet_cell_integrity; import triage.web_excel_compatibility_rules; print('prompt kit validators and generators import ok')"

--- a/.github/workflows/prompt-kit-v21.yml
+++ b/.github/workflows/prompt-kit-v21.yml
@@ -22,6 +22,8 @@ jobs:
       - name: Import validators and generators
         run: |
           python -c "import triage.workbook_package_hygiene; import triage.copy_surface_bounds; import triage.prompt_kit_contract; import triage.prompt_kit_operability_contract; import triage.prompt_kit_copy_range_links; import triage.prompt_kit_v38_prompt_assets; import triage.prompt_kit_v38_generator; import triage.prompt_kit_v33_generator; import triage.prompt_kit_v33_ooxml; import triage.worksheet_cell_integrity; import triage.web_excel_compatibility_rules; print('prompt kit validators and generators import ok')"
+      - name: Run V38 CMD launcher contracts
+        run: python -m pytest tests/test_prompt_kit_v38_cmd_launchers.py -q
       - name: Run copy-range link contract
         run: python -m pytest tests/test_prompt_kit_copy_range_links.py -q
       - name: Run V38 local runtime prompt contract

--- a/Run-AIPromptKitV38.cmd
+++ b/Run-AIPromptKitV38.cmd
@@ -1,0 +1,60 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+set "REPO_ROOT=%~dp0"
+for %%I in ("%REPO_ROOT%.") do set "REPO_ROOT=%%~fI"
+cd /d "%REPO_ROOT%" || (
+  echo ERROR: Could not enter repository directory: %REPO_ROOT%
+  set "EXIT_CODE=1"
+  goto :finish
+)
+
+set "SOURCE=%~1"
+set "OUT_DIR=%~2"
+set "EXPECTED_PROMPTS=%~3"
+
+if not defined OUT_DIR set "OUT_DIR=Outputs\prompt_kit_v38"
+if not defined EXPECTED_PROMPTS set "EXPECTED_PROMPTS=45"
+
+if not defined SOURCE (
+  echo.
+  echo AI Harness Prompt Kit V38 Asset Generator
+  echo ------------------------------------------
+  echo Drag a V37 .xlsx workbook or single-workbook .zip bundle onto this file,
+  echo or paste its full path below.
+  echo.
+  set /p "SOURCE=V37 workbook or bundle path: "
+)
+
+set "SOURCE=%SOURCE:"=%"
+if not defined SOURCE (
+  echo ERROR: No V37 source was provided.
+  set "EXIT_CODE=2"
+  goto :finish
+)
+
+for %%I in ("%SOURCE%") do set "SOURCE=%%~fI"
+if not exist "%SOURCE%" (
+  echo ERROR: Source file not found: %SOURCE%
+  set "EXIT_CODE=2"
+  goto :finish
+)
+
+for %%I in ("%OUT_DIR%") do set "OUTPUT_ROOT=%%~fI"
+
+call "%REPO_ROOT%\scripts\Generate-AIPromptKitV38.cmd" "%SOURCE%" "%OUT_DIR%" "%EXPECTED_PROMPTS%"
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" goto :finish
+
+echo.
+echo V38 assets are ready:
+echo   %OUTPUT_ROOT%\AI_Harness_Prompt_Kit_v38.xlsx
+echo   %OUTPUT_ROOT%\AI_Harness_Prompt_Kit_v38_local_runtime_build.md
+echo   %OUTPUT_ROOT%\AI_Harness_Prompt_Kit_v38_manifest.json
+echo   %OUTPUT_ROOT%\AI_Harness_Prompt_Kit_v38_bundle.zip
+
+:finish
+if not defined EXIT_CODE set "EXIT_CODE=0"
+echo.
+if not defined WEB_EXCEL_NO_PAUSE pause
+endlocal & exit /b %EXIT_CODE%

--- a/Sync-Validate-AIPromptKitV38.cmd
+++ b/Sync-Validate-AIPromptKitV38.cmd
@@ -11,9 +11,9 @@ cd /d "%REPO_ROOT%" || (
 )
 
 git rev-parse --show-toplevel >nul 2>&1
-if errorlevel 1 (
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" (
   echo ERROR: This launcher is not inside a Git repository.
-  set "EXIT_CODE=1"
   goto :finish
 )
 
@@ -28,24 +28,18 @@ if defined DIRTY_STATE (
 
 echo Fetching origin...
 git fetch origin
-if errorlevel 1 (
-  set "EXIT_CODE=%ERRORLEVEL%"
-  goto :finish
-)
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" goto :finish
 
 echo Switching to %TARGET_BRANCH%...
 git switch "%TARGET_BRANCH%"
-if errorlevel 1 (
-  set "EXIT_CODE=%ERRORLEVEL%"
-  goto :finish
-)
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" goto :finish
 
 echo Fast-forwarding from origin...
 git pull --ff-only origin "%TARGET_BRANCH%"
-if errorlevel 1 (
-  set "EXIT_CODE=%ERRORLEVEL%"
-  goto :finish
-)
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" goto :finish
 
 echo Running focused V38 validation...
 python -m pytest tests/test_prompt_kit_v38_prompt_assets.py tests/test_prompt_kit_v38_generator.py tests/test_prompt_kit_v38_cmd_launchers.py -q

--- a/Sync-Validate-AIPromptKitV38.cmd
+++ b/Sync-Validate-AIPromptKitV38.cmd
@@ -1,0 +1,62 @@
+@echo off
+setlocal EnableExtensions DisableDelayedExpansion
+
+set "TARGET_BRANCH=feat/prompt-kit-v33-self-service-generator"
+set "REPO_ROOT=%~dp0"
+for %%I in ("%REPO_ROOT%.") do set "REPO_ROOT=%%~fI"
+cd /d "%REPO_ROOT%" || (
+  echo ERROR: Could not enter repository directory: %REPO_ROOT%
+  set "EXIT_CODE=1"
+  goto :finish
+)
+
+git rev-parse --show-toplevel >nul 2>&1
+if errorlevel 1 (
+  echo ERROR: This launcher is not inside a Git repository.
+  set "EXIT_CODE=1"
+  goto :finish
+)
+
+set "DIRTY_STATE="
+for /f "delims=" %%I in ('git status --porcelain') do set "DIRTY_STATE=1"
+if defined DIRTY_STATE (
+  echo ERROR: The worktree has local changes. Commit, stash, or use an isolated worktree before syncing.
+  git status --short
+  set "EXIT_CODE=2"
+  goto :finish
+)
+
+echo Fetching origin...
+git fetch origin
+if errorlevel 1 (
+  set "EXIT_CODE=%ERRORLEVEL%"
+  goto :finish
+)
+
+echo Switching to %TARGET_BRANCH%...
+git switch "%TARGET_BRANCH%"
+if errorlevel 1 (
+  set "EXIT_CODE=%ERRORLEVEL%"
+  goto :finish
+)
+
+echo Fast-forwarding from origin...
+git pull --ff-only origin "%TARGET_BRANCH%"
+if errorlevel 1 (
+  set "EXIT_CODE=%ERRORLEVEL%"
+  goto :finish
+)
+
+echo Running focused V38 validation...
+python -m pytest tests/test_prompt_kit_v38_prompt_assets.py tests/test_prompt_kit_v38_generator.py tests/test_prompt_kit_v38_cmd_launchers.py -q
+set "EXIT_CODE=%ERRORLEVEL%"
+if not "%EXIT_CODE%"=="0" goto :finish
+
+echo.
+echo V38 branch sync and focused validation completed successfully.
+
+:finish
+if not defined EXIT_CODE set "EXIT_CODE=0"
+echo.
+if not defined WEB_EXCEL_NO_PAUSE pause
+endlocal & exit /b %EXIT_CODE%

--- a/configs/prompt_kit/v38_prompt_assets.json
+++ b/configs/prompt_kit/v38_prompt_assets.json
@@ -1,0 +1,25 @@
+{
+  "schema_version": 1,
+  "prompt_assets": [
+    {
+      "id": "LOCAL_RUNTIME_BUILD",
+      "title": "Local Runtime Build Converter",
+      "class": "local_coding_agent_runtime",
+      "execution_mode": "local_runtime_build",
+      "source": "prompts/v38/local-runtime-build.md",
+      "output": "AI_Harness_Prompt_Kit_v38_local_runtime_build.md",
+      "supported_agents": [
+        "Cosmos by Augment",
+        "Cursor",
+        "Codex",
+        "other local coding agents"
+      ],
+      "distinct_from": [
+        "harness_factoring",
+        "prompt_authoring"
+      ],
+      "requires_local_access": true,
+      "requires_runtime_execution": true
+    }
+  ]
+}

--- a/docs/AI_PROMPT_KIT_V38_SELF_SERVICE_GENERATION.md
+++ b/docs/AI_PROMPT_KIT_V38_SELF_SERVICE_GENERATION.md
@@ -8,38 +8,46 @@ V38 owns one bounded workbook repair: every `P##_COPY_SAFE` tab receives clickab
 
 V38 also generates a separately validated local-agent prompt support file for converting a sprint into an executable local runtime build. The prompt is geared toward Cosmos by Augment, Cursor, Codex, and comparable coding agents with local filesystem and terminal access.
 
-## Canonical commands
+## Operator launchers
 
-PowerShell:
+Users should not need to request commandlets or terminal snippets from an AI to generate or validate V38 assets.
 
-```powershell
-.\scripts\Generate-AIPromptKitV38.ps1 `
-  -Source "C:\Artifacts\AI_Harness_Prompt_Kit_v37.xlsx"
-```
+### Generate the V38 assets
 
-Double-click-compatible CMD:
+Double-click the repository-root launcher:
 
 ```text
-scripts\Generate-AIPromptKitV38.cmd "C:\Artifacts\AI_Harness_Prompt_Kit_v37.xlsx"
+Run-AIPromptKitV38.cmd
 ```
 
-Direct Python:
+The launcher:
 
-```powershell
-python -m triage.prompt_kit_v38_generator `
-  --source "C:\Artifacts\AI_Harness_Prompt_Kit_v37.xlsx" `
-  --out-dir "Outputs\prompt_kit_v38" `
-  --expected-prompt-count 45 `
-  --json
+- resolves the repository from its own `%~dp0` location;
+- accepts a V37 workbook or bundle by drag-and-drop, command-line argument, or interactive path prompt;
+- invokes the committed V38 generator;
+- preserves the generator exit code;
+- prints the exact workbook, prompt, manifest, and bundle paths;
+- pauses for Explorer users unless `WEB_EXCEL_NO_PAUSE` is set.
+
+### Sync and validate the V38 implementation
+
+Double-click:
+
+```text
+Sync-Validate-AIPromptKitV38.cmd
 ```
 
-Prompt asset only:
+The launcher refuses a dirty worktree, fetches origin, switches to the canonical V38 branch, fast-forwards only, and runs the focused V38 contract suite. This replaces the former multi-command PowerShell handoff.
 
-```powershell
-python -m triage.prompt_kit_v38_prompt_assets `
-  --out-dir "Outputs\prompt_kit_v38" `
-  --json
+### Automation and advanced use
+
+The root asset launcher also accepts optional arguments:
+
+```text
+Run-AIPromptKitV38.cmd <V37-workbook-or-bundle> [output-directory] [expected-prompt-count]
 ```
+
+The implementation-level entrypoints remain available under `scripts/` and `triage/`, but they are not the normal operator path.
 
 ## Source contract
 
@@ -50,13 +58,14 @@ The workbook source may be:
 
 The workbook source is never overwritten. The default output root is `Outputs/prompt_kit_v38/`.
 
-The local-runtime prompt source is tracked at:
+The local-runtime prompt source and declarative registry are tracked at:
 
 ```text
 prompts/v38/local-runtime-build.md
+configs/prompt_kit/v38_prompt_assets.json
 ```
 
-The source prompt is validated before it is copied into the generated delivery artifacts.
+The registry and source prompt are validated before generated delivery artifacts are written.
 
 ## Generated artifacts
 
@@ -67,7 +76,7 @@ AI_Harness_Prompt_Kit_v38_manifest.json
 AI_Harness_Prompt_Kit_v38_bundle.zip
 ```
 
-Support files from an input bundle are preserved in the output bundle unless their names collide with canonical generated artifacts. Workbook binaries and operator-local reports remain generated outputs and must not be committed.
+Support files from an input bundle are preserved unless their names collide with canonical generated artifacts. Workbook binaries and operator-local reports remain generated outputs and must not be committed.
 
 ## Local runtime build prompt contract
 
@@ -101,7 +110,7 @@ Forbidden workbook changes include workbook metadata, relationships, content typ
 
 Excel automation, LibreOffice, `openpyxl`, and any other whole-workbook serializer are forbidden for this conversion.
 
-The new local-runtime prompt is a delivery-bundle support file. It does not add a worksheet, change workbook topology, or weaken the accepted V37-to-V38 package boundary.
+The local-runtime prompt is a delivery-bundle support file. It does not add a worksheet, change workbook topology, or weaken the accepted V37-to-V38 package boundary.
 
 ## Fail-closed gates
 
@@ -115,32 +124,24 @@ Generation fails when:
 - a non-prompt worksheet part changes;
 - calculation-chain identities are stale or incomplete;
 - a second workbook generation pass is not byte-identical;
+- the declarative prompt registry is malformed or inconsistent;
 - the local-runtime prompt omits correct-directory discipline;
 - the local-runtime prompt does not distinguish runtime construction from factoring;
 - the local-runtime prompt does not require local execution after script creation;
 - required commit, push, validation, safety, or proof-ceiling language is absent;
 - deferred-work language such as `sit tight` is introduced.
 
+The sync launcher also fails closed before fetching when the worktree contains local changes.
+
 ## Validation
 
-```powershell
-python -m py_compile `
-  triage/prompt_kit_v38_prompt_assets.py `
-  triage/prompt_kit_v38_generator.py `
-  tests/test_prompt_kit_v38_prompt_assets.py `
-  tests/test_prompt_kit_v38_generator.py
+The normal Windows validation surface is:
 
-python -m pytest `
-  tests/test_prompt_kit_copy_range_links.py `
-  tests/test_prompt_kit_v38_prompt_assets.py `
-  tests/test_prompt_kit_v38_generator.py `
-  -q
-
-python -m triage.prompt_kit_v38_prompt_assets --help
-python -m triage.prompt_kit_v38_generator --help
+```text
+Sync-Validate-AIPromptKitV38.cmd
 ```
 
-Then run the existing package, worksheet, copy-surface, operability, and Web Excel compatibility validators against the generated workbook.
+CI additionally runs the prompt registry, CMD launcher contracts, copy-range links, V38 prompt assets, V38 generator, V33 compatibility, remaining prompt-kit validators, and CLI smoke checks.
 
 ## Compatibility posture
 
@@ -150,4 +151,4 @@ The V38 runtime prompt is emitted outside the workbook because the field-open V3
 
 ## Proof ceiling
 
-Repository tests and the V38 manifest may prove exact formula generation, package boundaries, calculation-chain integrity, output naming, bundle construction, local-runtime prompt validation, and byte idempotence. They do not prove that Cosmos by Augment, Cursor, Codex, or another local agent successfully executed a real repository sprint. Local agent execution, Excel for Web opening, and click-selection behavior remain separate runtime and field gates.
+Repository tests and the V38 manifest may prove exact formula generation, package boundaries, calculation-chain integrity, output naming, bundle construction, prompt-registry validation, CMD launcher contracts, local-runtime prompt validation, and byte idempotence. They do not prove that Cosmos by Augment, Cursor, Codex, or another local agent successfully executed a real repository sprint. Local agent execution, Excel for Web opening, and click-selection behavior remain separate runtime and field gates.

--- a/tests/test_prompt_kit_v38_cmd_launchers.py
+++ b/tests/test_prompt_kit_v38_cmd_launchers.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_LAUNCHER = REPO_ROOT / "Run-AIPromptKitV38.cmd"
+SYNC_LAUNCHER = REPO_ROOT / "Sync-Validate-AIPromptKitV38.cmd"
+
+
+def _text(path: Path) -> str:
+    assert path.is_file(), path
+    return path.read_text(encoding="utf-8")
+
+
+def test_v38_asset_launcher_is_click_ready_and_prints_artifacts() -> None:
+    text = _text(RUN_LAUNCHER)
+
+    assert "%~dp0" in text
+    assert 'cd /d "%REPO_ROOT%"' in text
+    assert "set /p \"SOURCE=" in text
+    assert "scripts\\Generate-AIPromptKitV38.cmd" in text
+    assert "AI_Harness_Prompt_Kit_v38.xlsx" in text
+    assert "AI_Harness_Prompt_Kit_v38_local_runtime_build.md" in text
+    assert "AI_Harness_Prompt_Kit_v38_manifest.json" in text
+    assert "AI_Harness_Prompt_Kit_v38_bundle.zip" in text
+    assert "WEB_EXCEL_NO_PAUSE" in text
+    assert "endlocal & exit /b %EXIT_CODE%" in text
+    assert "C:\\Users\\" not in text
+
+
+def test_v38_sync_launcher_replaces_manual_next_command() -> None:
+    text = _text(SYNC_LAUNCHER)
+
+    assert "%~dp0" in text
+    assert 'cd /d "%REPO_ROOT%"' in text
+    assert "git status --porcelain" in text
+    assert "git fetch origin" in text
+    assert 'git switch "%TARGET_BRANCH%"' in text
+    assert 'git pull --ff-only origin "%TARGET_BRANCH%"' in text
+    assert "tests/test_prompt_kit_v38_prompt_assets.py" in text
+    assert "tests/test_prompt_kit_v38_generator.py" in text
+    assert "tests/test_prompt_kit_v38_cmd_launchers.py" in text
+    assert "WEB_EXCEL_NO_PAUSE" in text
+    assert "endlocal & exit /b %EXIT_CODE%" in text
+    assert "C:\\Users\\" not in text
+
+
+def test_sync_launcher_refuses_dirty_worktrees_before_fetch() -> None:
+    text = _text(SYNC_LAUNCHER)
+
+    dirty_check = text.index("git status --porcelain")
+    dirty_refusal = text.index("The worktree has local changes")
+    fetch = text.index("git fetch origin")
+    assert dirty_check < dirty_refusal < fetch

--- a/tests/test_prompt_kit_v38_prompt_assets.py
+++ b/tests/test_prompt_kit_v38_prompt_assets.py
@@ -1,27 +1,44 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from triage.prompt_kit_v38_prompt_assets import (
+    DEFAULT_REGISTRY,
     DEFAULT_SOURCE,
     OUTPUT_FILENAME,
     PROMPT_CLASS,
     PROMPT_ID,
+    load_prompt_registry,
     materialize_prompt_assets,
     validate_prompt_text,
 )
 
 
-def test_local_runtime_prompt_is_agent_neutral_executable_and_directory_safe(tmp_path: Path) -> None:
-    assets = materialize_prompt_assets(tmp_path)
+def test_local_runtime_prompt_is_registry_backed_executable_and_directory_safe(tmp_path: Path) -> None:
+    definitions = load_prompt_registry()
+    assert len(definitions) == 1
+    definition = definitions[0]
+    assert definition.prompt_id == PROMPT_ID
+    assert definition.prompt_class == PROMPT_CLASS
+    assert definition.execution_mode == "local_runtime_build"
+    assert definition.source == DEFAULT_SOURCE
+    assert definition.output_filename == OUTPUT_FILENAME
+    assert definition.distinct_from == ("harness_factoring", "prompt_authoring")
+    assert definition.requires_local_access is True
+    assert definition.requires_runtime_execution is True
 
+    assets = materialize_prompt_assets(tmp_path)
     assert len(assets) == 1
     asset = assets[0]
     assert asset.prompt_id == PROMPT_ID
     assert asset.prompt_class == PROMPT_CLASS
+    assert asset.execution_mode == "local_runtime_build"
     assert asset.validation_passed is True
+    assert asset.distinct_from == ("harness_factoring", "prompt_authoring")
+    assert asset.registry == str(DEFAULT_REGISTRY.resolve())
     assert asset.supported_agents == (
         "Cosmos by Augment",
         "Cursor",
@@ -38,7 +55,27 @@ def test_local_runtime_prompt_is_agent_neutral_executable_and_directory_safe(tmp
     assert "git rev-parse --show-toplevel" in text
     assert "Do not stop after creating scripts" in text
     assert "LOCAL RUNTIME PROOF" in text
-    assert output.read_text(encoding="utf-8") == DEFAULT_SOURCE.read_text(encoding="utf-8").rstrip() + "\n"
+    assert text == DEFAULT_SOURCE.read_text(encoding="utf-8").rstrip() + "\n"
+
+
+def test_registry_rejects_runtime_prompt_without_factoring_separation(tmp_path: Path) -> None:
+    payload = json.loads(DEFAULT_REGISTRY.read_text(encoding="utf-8"))
+    payload["prompt_assets"][0]["distinct_from"] = ["prompt_authoring"]
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="distinct from harness_factoring"):
+        load_prompt_registry(registry)
+
+
+def test_registry_rejects_nonlocal_execution_contract(tmp_path: Path) -> None:
+    payload = json.loads(DEFAULT_REGISTRY.read_text(encoding="utf-8"))
+    payload["prompt_assets"][0]["requires_runtime_execution"] = False
+    registry = tmp_path / "registry.json"
+    registry.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="require runtime execution"):
+        load_prompt_registry(registry)
 
 
 def test_local_runtime_prompt_rejects_factoring_only_payload() -> None:

--- a/triage/prompt_kit_v38_prompt_assets.py
+++ b/triage/prompt_kit_v38_prompt_assets.py
@@ -1,19 +1,17 @@
-"""Validate and materialize the V38 local-agent prompt support files."""
+"""Validate and materialize declarative V38 local-agent prompt assets."""
 from __future__ import annotations
 
 import argparse
 import hashlib
 import json
+import re
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Optional, Sequence
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_SOURCE = REPO_ROOT / "prompts" / "v38" / "local-runtime-build.md"
-OUTPUT_FILENAME = "AI_Harness_Prompt_Kit_v38_local_runtime_build.md"
-PROMPT_ID = "LOCAL_RUNTIME_BUILD"
-PROMPT_CLASS = "local_coding_agent_runtime"
-SUPPORTED_AGENTS = (
+DEFAULT_REGISTRY = REPO_ROOT / "configs" / "prompt_kit" / "v38_prompt_assets.json"
+REQUIRED_AGENT_NAMES = (
     "Cosmos by Augment",
     "Cursor",
     "Codex",
@@ -48,14 +46,31 @@ FORBIDDEN_MARKERS = (
 
 
 @dataclass(frozen=True)
+class PromptDefinition:
+    prompt_id: str
+    prompt_class: str
+    execution_mode: str
+    title: str
+    source: Path
+    output_filename: str
+    supported_agents: tuple[str, ...]
+    distinct_from: tuple[str, ...]
+    requires_local_access: bool
+    requires_runtime_execution: bool
+
+
+@dataclass(frozen=True)
 class PromptAsset:
     prompt_id: str
     prompt_class: str
+    execution_mode: str
     title: str
     source: str
     output: str
     sha256: str
     supported_agents: tuple[str, ...]
+    distinct_from: tuple[str, ...]
+    registry: str
     validation_passed: bool
 
     def to_dict(self) -> dict:
@@ -64,6 +79,125 @@ class PromptAsset:
 
 def _sha256_bytes(payload: bytes) -> str:
     return hashlib.sha256(payload).hexdigest()
+
+
+def _repo_relative_path(raw: object, field: str) -> Path:
+    if not isinstance(raw, str) or not raw.strip():
+        raise ValueError(f"prompt registry {field} must be a non-empty repository-relative path")
+    relative = Path(raw)
+    if relative.is_absolute():
+        raise ValueError(f"prompt registry {field} must be repository-relative: {raw}")
+    resolved = (REPO_ROOT / relative).resolve()
+    try:
+        resolved.relative_to(REPO_ROOT)
+    except ValueError as exc:
+        raise ValueError(f"prompt registry {field} escapes the repository: {raw}") from exc
+    return resolved
+
+
+def load_prompt_registry(registry: Path = DEFAULT_REGISTRY) -> tuple[PromptDefinition, ...]:
+    registry = registry.resolve()
+    if not registry.is_file():
+        raise FileNotFoundError(registry)
+    try:
+        payload = json.loads(registry.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid V38 prompt registry JSON: {exc}") from exc
+    if payload.get("schema_version") != 1:
+        raise ValueError("V38 prompt registry schema_version must equal 1")
+    raw_assets = payload.get("prompt_assets")
+    if not isinstance(raw_assets, list) or not raw_assets:
+        raise ValueError("V38 prompt registry must define at least one prompt asset")
+
+    definitions: list[PromptDefinition] = []
+    seen_ids: set[str] = set()
+    seen_outputs: set[str] = set()
+    for index, raw in enumerate(raw_assets):
+        if not isinstance(raw, dict):
+            raise ValueError(f"V38 prompt registry entry {index} must be an object")
+        prompt_id = raw.get("id")
+        if not isinstance(prompt_id, str) or not re.fullmatch(r"[A-Z][A-Z0-9_]+", prompt_id):
+            raise ValueError(f"invalid V38 prompt id: {prompt_id!r}")
+        if prompt_id in seen_ids:
+            raise ValueError(f"duplicate V38 prompt id: {prompt_id}")
+        seen_ids.add(prompt_id)
+
+        prompt_class = raw.get("class")
+        execution_mode = raw.get("execution_mode")
+        if prompt_class != "local_coding_agent_runtime":
+            raise ValueError(f"{prompt_id} must use class local_coding_agent_runtime")
+        if execution_mode != "local_runtime_build":
+            raise ValueError(f"{prompt_id} must use execution_mode local_runtime_build")
+
+        title = raw.get("title")
+        if not isinstance(title, str) or not title.strip():
+            raise ValueError(f"{prompt_id} title must be non-empty")
+        source = _repo_relative_path(raw.get("source"), f"{prompt_id}.source")
+        try:
+            source.relative_to(REPO_ROOT / "prompts" / "v38")
+        except ValueError as exc:
+            raise ValueError(f"{prompt_id} source must remain under prompts/v38") from exc
+
+        output_filename = raw.get("output")
+        if (
+            not isinstance(output_filename, str)
+            or not output_filename.endswith(".md")
+            or Path(output_filename).name != output_filename
+        ):
+            raise ValueError(f"{prompt_id} output must be one Markdown filename")
+        if output_filename in seen_outputs:
+            raise ValueError(f"duplicate V38 prompt output: {output_filename}")
+        seen_outputs.add(output_filename)
+
+        supported_agents_raw = raw.get("supported_agents")
+        if not isinstance(supported_agents_raw, list) or not all(
+            isinstance(item, str) and item.strip() for item in supported_agents_raw
+        ):
+            raise ValueError(f"{prompt_id} supported_agents must be a non-empty string list")
+        supported_agents = tuple(supported_agents_raw)
+        missing_agents = [item for item in REQUIRED_AGENT_NAMES if item not in supported_agents]
+        if missing_agents:
+            raise ValueError(f"{prompt_id} is missing required local-agent surfaces: {missing_agents}")
+
+        distinct_from_raw = raw.get("distinct_from")
+        if not isinstance(distinct_from_raw, list) or not all(
+            isinstance(item, str) and item.strip() for item in distinct_from_raw
+        ):
+            raise ValueError(f"{prompt_id} distinct_from must be a non-empty string list")
+        distinct_from = tuple(distinct_from_raw)
+        if "harness_factoring" not in distinct_from:
+            raise ValueError(f"{prompt_id} must be explicitly distinct from harness_factoring")
+
+        requires_local_access = raw.get("requires_local_access")
+        requires_runtime_execution = raw.get("requires_runtime_execution")
+        if requires_local_access is not True:
+            raise ValueError(f"{prompt_id} must require local access")
+        if requires_runtime_execution is not True:
+            raise ValueError(f"{prompt_id} must require runtime execution")
+
+        definitions.append(
+            PromptDefinition(
+                prompt_id=prompt_id,
+                prompt_class=prompt_class,
+                execution_mode=execution_mode,
+                title=title.strip(),
+                source=source,
+                output_filename=output_filename,
+                supported_agents=supported_agents,
+                distinct_from=distinct_from,
+                requires_local_access=requires_local_access,
+                requires_runtime_execution=requires_runtime_execution,
+            )
+        )
+    return tuple(definitions)
+
+
+_DEFAULT_DEFINITION = load_prompt_registry()[0]
+DEFAULT_SOURCE = _DEFAULT_DEFINITION.source
+OUTPUT_FILENAME = _DEFAULT_DEFINITION.output_filename
+PROMPT_ID = _DEFAULT_DEFINITION.prompt_id
+PROMPT_CLASS = _DEFAULT_DEFINITION.prompt_class
+SUPPORTED_AGENTS = _DEFAULT_DEFINITION.supported_agents
 
 
 def validate_prompt_text(text: str) -> None:
@@ -93,36 +227,51 @@ def load_prompt(source: Path = DEFAULT_SOURCE) -> str:
     return text
 
 
-def materialize_prompt_assets(output_dir: Path, source: Path = DEFAULT_SOURCE) -> tuple[PromptAsset, ...]:
+def materialize_prompt_assets(
+    output_dir: Path,
+    source: Path | None = None,
+    registry: Path = DEFAULT_REGISTRY,
+) -> tuple[PromptAsset, ...]:
     output_dir = output_dir.resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
-    source = source.resolve()
-    text = load_prompt(source)
-    output = output_dir / OUTPUT_FILENAME
-    output.write_text(text.rstrip() + "\n", encoding="utf-8")
-    payload = output.read_bytes()
-    return (
-        PromptAsset(
-            prompt_id=PROMPT_ID,
-            prompt_class=PROMPT_CLASS,
-            title="Local Runtime Build Converter",
-            source=str(source),
-            output=str(output),
-            sha256=_sha256_bytes(payload),
-            supported_agents=SUPPORTED_AGENTS,
-            validation_passed=True,
-        ),
-    )
+    registry = registry.resolve()
+    definitions = load_prompt_registry(registry)
+    if source is not None and len(definitions) != 1:
+        raise ValueError("--source override is valid only when the registry defines exactly one prompt asset")
+
+    assets: list[PromptAsset] = []
+    for definition in definitions:
+        actual_source = source.resolve() if source is not None else definition.source
+        text = load_prompt(actual_source)
+        output = output_dir / definition.output_filename
+        output.write_text(text.rstrip() + "\n", encoding="utf-8")
+        assets.append(
+            PromptAsset(
+                prompt_id=definition.prompt_id,
+                prompt_class=definition.prompt_class,
+                execution_mode=definition.execution_mode,
+                title=definition.title,
+                source=str(actual_source),
+                output=str(output),
+                sha256=_sha256_bytes(output.read_bytes()),
+                supported_agents=definition.supported_agents,
+                distinct_from=definition.distinct_from,
+                registry=str(registry),
+                validation_passed=True,
+            )
+        )
+    return tuple(assets)
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--registry", type=Path, default=DEFAULT_REGISTRY)
+    parser.add_argument("--source", type=Path)
     parser.add_argument("--out-dir", type=Path, default=Path("Outputs/prompt_kit_v38"))
     parser.add_argument("--json", action="store_true")
     args = parser.parse_args(argv)
     try:
-        assets = materialize_prompt_assets(args.out_dir, args.source)
+        assets = materialize_prompt_assets(args.out_dir, args.source, args.registry)
     except Exception as exc:
         print(f"V38 prompt asset generation failed: {exc}")
         return 1


### PR DESCRIPTION
Merge the current `feat/prompt-kit-v33-self-service-generator` branch into `feat/prompt-kit-v39-segmented` after manually preserving the union of V38 and V39 workflow gates. This is a base-convergence PR only; it must not change prompt semantics, sparse-navigation doctrine, generated artifacts, or release state.