### PR TITLE
chore(prompt-kit): trigger one-shot V39 convergence

### DIFF
--- a/docs/V39_CONVERGENCE_TRIGGER.md
+++ b/docs/V39_CONVERGENCE_TRIGGER.md
@@ -1,0 +1,3 @@
+# V39 Convergence Trigger
+
+This bounded marker exists only to create a GitHub-authored merge event on `feat/prompt-kit-v39-segmented`, allowing the one-shot base-convergence workflow to merge the current V38 base and delete itself.


### PR DESCRIPTION
Bounded trigger PR. Merging this into `feat/prompt-kit-v39-segmented` emits the push event required to run `.github/workflows/v39-base-converge.yml`. That workflow merges the current V38 base, refuses unexpected conflicts, preserves the unioned prompt-kit workflow, deletes itself, and pushes the convergence commit.